### PR TITLE
ci: run lint, typecheck, and build on pull requests

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,41 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-checks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Lint, Typecheck, Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run type check
+        run: npm run typecheck
+
+      - name: Run build
+        run: npm run build


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow at `.github/workflows/pr-checks.yml`
- trigger checks on every PR targeting `master` (plus manual `workflow_dispatch`)
- run `npm ci`, `npm run lint`, `npm run typecheck`, and `npm run build`
- add workflow concurrency to cancel outdated runs for the same PR

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run build`

Closes #16
