### PR TITLE
Implement distribution sampler with various statistical distributions…

### DIFF
--- a/src/engine/distribution.ts
+++ b/src/engine/distribution.ts
@@ -1,0 +1,290 @@
+import { BaseDistributionConfig, DistributionConfig, RandomGenerator } from './types'
+
+type DistributionSampler = () => number
+
+export class Distributions {
+  private spareNormal: number | null = null
+
+  constructor(private readonly rng: RandomGenerator) {}
+
+  random(): number {
+    return this.rng.next()
+  }
+
+  constant(value: number): number {
+    return value
+  }
+
+  uniform(min: number, max: number): number {
+    if (!(max > min)) {
+      throw new Error(`uniform(min, max): max (${max}) must be > min (${min})`)
+    }
+
+    return min + this.rng.next() * (max - min)
+  }
+
+  exponential(lambda: number): number {
+    if (!(lambda > 0)) {
+      throw new Error(`exponential(lambda): lambda (${lambda}) must be > 0`)
+    }
+
+    return -Math.log(1 - this.rng.next()) / lambda
+  }
+
+  normal(mean = 0, stdDev = 1): number {
+    if (!(stdDev > 0)) {
+      throw new Error(`normal(mean, stdDev): stdDev (${stdDev}) must be > 0`)
+    }
+
+    if (this.spareNormal !== null) {
+      const z = this.spareNormal
+      this.spareNormal = null
+      return mean + stdDev * z
+    }
+
+    let u1 = this.rng.next()
+    while (u1 <= Number.EPSILON) {
+      u1 = this.rng.next()
+    }
+
+    const u2 = this.rng.next()
+    const radius = Math.sqrt(-2 * Math.log(u1))
+    const theta = 2 * Math.PI * u2
+    const z0 = radius * Math.cos(theta)
+    const z1 = radius * Math.sin(theta)
+    this.spareNormal = z1
+
+    return mean + stdDev * z0
+  }
+
+  logNormal(mu: number, sigma: number): number {
+    if (!(sigma > 0)) {
+      throw new Error(`logNormal(mu, sigma): sigma (${sigma}) must be > 0`)
+    }
+
+    return Math.exp(this.normal(mu, sigma))
+  }
+
+  poisson(lambda: number): number {
+    if (!(lambda > 0)) {
+      throw new Error(`poisson(lambda): lambda (${lambda}) must be > 0`)
+    }
+
+    const limit = Math.exp(-lambda)
+    let k = 0
+    let p = 1
+
+    do {
+      k++
+      p *= this.nextOpen01()
+    } while (p > limit)
+
+    return k - 1
+  }
+
+  weibull(shape: number, scale: number): number {
+    if (!(shape > 0) || !(scale > 0)) {
+      throw new Error(`weibull(shape, scale): shape (${shape}) and scale (${scale}) must be > 0`)
+    }
+
+    return scale * Math.pow(-Math.log(1 - this.rng.next()), 1 / shape)
+  }
+
+  gamma(shape: number, scale: number): number {
+    if (!(shape > 0) || !(scale > 0)) {
+      throw new Error(`gamma(shape, scale): shape (${shape}) and scale (${scale}) must be > 0`)
+    }
+
+    if (shape < 1) {
+      const u = this.nextOpen01()
+      return this.gamma(shape + 1, scale) * Math.pow(u, 1 / shape)
+    }
+
+    const d = shape - 1 / 3
+    const c = 1 / Math.sqrt(9 * d)
+
+    while (true) {
+      let x = 0
+      let v = 0
+
+      do {
+        x = this.normal()
+        v = 1 + c * x
+      } while (v <= 0)
+
+      v = v * v * v
+      const u = this.nextOpen01()
+
+      if (u < 1 - 0.0331 * x * x * x * x) {
+        return scale * d * v
+      }
+
+      if (Math.log(u) < 0.5 * x * x + d * (1 - v + Math.log(v))) {
+        return scale * d * v
+      }
+    }
+  }
+
+  beta(alpha: number, beta: number): number {
+    if (!(alpha > 0) || !(beta > 0)) {
+      throw new Error(`beta(alpha, beta): alpha (${alpha}) and beta (${beta}) must be > 0`)
+    }
+
+    const x = this.gamma(alpha, 1)
+    const y = this.gamma(beta, 1)
+    return x / (x + y)
+  }
+
+  pareto(alpha: number, xMin: number): number {
+    if (!(alpha > 0) || !(xMin > 0)) {
+      throw new Error(`pareto(alpha, xMin): alpha (${alpha}) and xMin (${xMin}) must be > 0`)
+    }
+
+    return xMin / Math.pow(1 - this.rng.next(), 1 / alpha)
+  }
+
+  empirical(values: number[], weights?: number[]): number {
+    if (values.length === 0) {
+      throw new Error(`empirical(values): values must contain at least one element`)
+    }
+
+    if (!weights) {
+      const index = this.rng.integer(0, values.length - 1)
+      return values[index]
+    }
+
+    if (weights.length !== values.length) {
+      throw new Error(
+        `empirical(values, weights): values length (${values.length}) must match weights length (${weights.length})`
+      )
+    }
+
+    const index = this.pickIndexByWeight(weights)
+    return values[index]
+  }
+
+  mixture(distributions: DistributionSampler[], weights: number[]): number {
+    if (distributions.length === 0) {
+      throw new Error(`mixture(distributions, weights): distributions must not be empty`)
+    }
+
+    if (distributions.length !== weights.length) {
+      throw new Error(
+        `mixture(distributions, weights): distributions length (${distributions.length}) must match weights length (${weights.length})`
+      )
+    }
+
+    const index = this.pickIndexByWeight(weights)
+    return distributions[index]()
+  }
+
+  binomial(n: number, p: number): number {
+    if (!Number.isInteger(n) || n < 0) {
+      throw new Error(`binomial(n, p): n (${n}) must be a non-negative integer`)
+    }
+
+    if (p < 0 || p > 1) {
+      throw new Error(`binomial(n, p): p (${p}) must be in [0, 1]`)
+    }
+
+    let successes = 0
+    for (let i = 0; i < n; i++) {
+      if (this.rng.next() < p) {
+        successes++
+      }
+    }
+    return successes
+  }
+
+  fromConfig(config: DistributionConfig): number {
+    if (config.type === 'mixture') {
+      const distributions = config.components.map(
+        (component) => () => this.fromBaseConfig(component.distribution)
+      )
+      const weights = config.components.map((component) => component.weight)
+      return this.mixture(distributions, weights)
+    }
+
+    return this.fromBaseConfig(config)
+  }
+
+  private fromBaseConfig(config: BaseDistributionConfig): number {
+    switch (config.type) {
+      case 'constant':
+      case 'deterministic':
+        return this.constant(config.value)
+      case 'uniform':
+        return this.uniform(config.min, config.max)
+      case 'exponential':
+        return this.exponential(config.lambda)
+      case 'normal':
+        return this.normal(config.mean, config.stdDev)
+      case 'log-normal':
+        return this.logNormal(config.mu, config.sigma)
+      case 'poisson':
+        return this.poisson(config.lambda)
+      case 'weibull':
+        return this.weibull(config.shape, config.scale)
+      case 'gamma':
+        return this.gamma(config.shape, config.scale)
+      case 'beta':
+        return this.beta(config.alpha, config.beta)
+      case 'pareto':
+        return this.pareto(config.shape, config.scale)
+      case 'empirical':
+        return config.interpolation === 'linear'
+          ? this.empiricalLinear(config.samples)
+          : this.empirical(config.samples)
+      case 'binomial':
+        return this.binomial(config.n, config.p)
+      default: {
+        const neverConfig: never = config
+        throw new Error(`Unknown distribution: ${JSON.stringify(neverConfig)}`)
+      }
+    }
+  }
+
+  private empiricalLinear(values: number[]): number {
+    if (values.length === 0) {
+      throw new Error(`empiricalLinear(values): values must contain at least one element`)
+    }
+
+    if (values.length === 1) {
+      return values[0]
+    }
+
+    const index = this.rng.integer(0, values.length - 2)
+    const t = this.rng.next()
+    return values[index] + t * (values[index + 1] - values[index])
+  }
+
+  private pickIndexByWeight(weights: number[]): number {
+    let total = 0
+    for (const weight of weights) {
+      if (!Number.isFinite(weight) || weight < 0) {
+        throw new Error(`pickIndexByWeight(weights): every weight must be finite and >= 0`)
+      }
+      total += weight
+    }
+
+    if (!(total > 0)) {
+      throw new Error(`pickIndexByWeight(weights): sum of weights must be > 0`)
+    }
+
+    const target = this.rng.next() * total
+    let cumulative = 0
+    for (let i = 0; i < weights.length; i++) {
+      cumulative += weights[i]
+      if (target < cumulative || i === weights.length - 1) {
+        return i
+      }
+    }
+
+    return weights.length - 1
+  }
+
+  private nextOpen01(): number {
+    const u = this.rng.next()
+    return u <= 0 ? Number.MIN_VALUE : u
+  }
+}

--- a/src/engine/distribution.ts
+++ b/src/engine/distribution.ts
@@ -198,11 +198,34 @@ export class Distributions {
 
   fromConfig(config: DistributionConfig): number {
     if (config.type === 'mixture') {
-      const distributions = config.components.map(
-        (component) => () => this.fromBaseConfig(component.distribution)
-      )
-      const weights = config.components.map((component) => component.weight)
-      return this.mixture(distributions, weights)
+      const components = config.components
+      if (components.length === 0) {
+        throw new Error(`fromConfig(config): mixture components must not be empty`)
+      }
+
+      let totalWeight = 0
+      for (let i = 0; i < components.length; i++) {
+        const weight = components[i].weight
+        if (!Number.isFinite(weight) || weight < 0) {
+          throw new Error(
+            `fromConfig(config): every mixture weight must be finite and >= 0`
+          )
+        }
+        totalWeight += weight
+      }
+
+      if (!(totalWeight > 0)) {
+        throw new Error(`fromConfig(config): mixture total weight must be > 0`)
+      }
+
+      const threshold = this.rng.next() * totalWeight
+      let cumulative = 0
+      for (let i = 0; i < components.length; i++) {
+        cumulative += components[i].weight
+        if (threshold < cumulative || i === components.length - 1) {
+          return this.fromBaseConfig(components[i].distribution)
+        }
+      }
     }
 
     return this.fromBaseConfig(config)
@@ -284,7 +307,10 @@ export class Distributions {
   }
 
   private nextOpen01(): number {
-    const u = this.rng.next()
-    return u <= 0 ? Number.MIN_VALUE : u
+    let u = this.rng.next()
+    while (u <= 0 || u >= 1) {
+      u = this.rng.next()
+    }
+    return u
   }
 }

--- a/src/engine/tests/distribution.test.ts
+++ b/src/engine/tests/distribution.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest'
+import { Distributions } from '../distribution'
+import { createRandom } from '../random'
+import { DistributionConfig } from '../types'
+
+function makeDistributions(seed: string): Distributions {
+  return new Distributions(createRandom(seed))
+}
+
+function mean(values: number[]): number {
+  return values.reduce((acc, value) => acc + value, 0) / values.length
+}
+
+function stdDev(values: number[]): number {
+  const avg = mean(values)
+  const variance = values.reduce((acc, value) => acc + (value - avg) ** 2, 0) / values.length
+  return Math.sqrt(variance)
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1] + sorted[mid]) / 2
+  }
+  return sorted[mid]
+}
+
+describe('Distributions', () => {
+  it('is deterministic for the same seed', () => {
+    const a = makeDistributions('same-seed')
+    const b = makeDistributions('same-seed')
+
+    const sampleA = Array.from({ length: 500 }, () => a.logNormal(0, 1))
+    const sampleB = Array.from({ length: 500 }, () => b.logNormal(0, 1))
+
+    expect(sampleA).toEqual(sampleB)
+  })
+
+  it('constant and uniform return expected values', () => {
+    const dist = makeDistributions('constant-uniform')
+
+    expect(dist.constant(42)).toBe(42)
+
+    for (let i = 0; i < 2000; i++) {
+      const value = dist.uniform(5, 10)
+      expect(value).toBeGreaterThanOrEqual(5)
+      expect(value).toBeLessThan(10)
+    }
+  })
+
+  it('exponential(1) has mean approximately 1 over 10,000 samples', () => {
+    const dist = makeDistributions('exp-mean')
+    const values = Array.from({ length: 10_000 }, () => dist.exponential(1))
+    const avg = mean(values)
+
+    expect(avg).toBeGreaterThan(0.95)
+    expect(avg).toBeLessThan(1.05)
+  })
+
+  it('normal(0,1) has mean and stddev near expected values', () => {
+    const dist = makeDistributions('normal-stats')
+    const values = Array.from({ length: 10_000 }, () => dist.normal(0, 1))
+
+    const avg = mean(values)
+    const sd = stdDev(values)
+
+    expect(Math.abs(avg)).toBeLessThan(0.05)
+    expect(sd).toBeGreaterThan(0.95)
+    expect(sd).toBeLessThan(1.05)
+  })
+
+  it('logNormal(0, 1) is positive and right-skewed', () => {
+    const dist = makeDistributions('lognormal-stats')
+    const values = Array.from({ length: 10_000 }, () => dist.logNormal(0, 1))
+    const avg = mean(values)
+    const med = median(values)
+
+    expect(values.every((value) => value > 0)).toBe(true)
+    expect(avg).toBeGreaterThan(med)
+  })
+
+  it('supports poisson, weibull, gamma, beta, pareto, empirical, mixture and binomial', () => {
+    const dist = makeDistributions('all-distributions')
+
+    const poissonValues = Array.from({ length: 10_000 }, () => dist.poisson(4))
+    expect(poissonValues.every((value) => Number.isInteger(value) && value >= 0)).toBe(true)
+    expect(mean(poissonValues)).toBeGreaterThan(3.6)
+    expect(mean(poissonValues)).toBeLessThan(4.4)
+
+    const weibullValues = Array.from({ length: 1000 }, () => dist.weibull(1.5, 2.0))
+    expect(weibullValues.every((value) => value >= 0)).toBe(true)
+
+    const gammaValues = Array.from({ length: 10_000 }, () => dist.gamma(2, 3))
+    expect(gammaValues.every((value) => value > 0)).toBe(true)
+    expect(mean(gammaValues)).toBeGreaterThan(5.4)
+    expect(mean(gammaValues)).toBeLessThan(6.6)
+
+    const betaValues = Array.from({ length: 2000 }, () => dist.beta(2, 5))
+    expect(betaValues.every((value) => value >= 0 && value <= 1)).toBe(true)
+
+    const paretoValues = Array.from({ length: 2000 }, () => dist.pareto(2, 3))
+    expect(paretoValues.every((value) => value >= 3)).toBe(true)
+
+    const empiricalWeighted = Array.from({ length: 1000 }, () =>
+      dist.empirical([10, 20, 30], [0, 1, 0])
+    )
+    expect(empiricalWeighted.every((value) => value === 20)).toBe(true)
+
+    const mixtureValues = Array.from({ length: 10_000 }, () =>
+      dist.mixture(
+        [() => 0, () => 1],
+        [0.8, 0.2]
+      )
+    )
+    const onesRatio = mean(mixtureValues)
+    expect(onesRatio).toBeGreaterThan(0.17)
+    expect(onesRatio).toBeLessThan(0.23)
+
+    const binomialValues = Array.from({ length: 2000 }, () => dist.binomial(10, 0.3))
+    expect(binomialValues.every((value) => Number.isInteger(value) && value >= 0 && value <= 10)).toBe(
+      true
+    )
+  })
+
+  it('dispatches through fromConfig including log-normal and mixture', () => {
+    const dist = makeDistributions('from-config')
+
+    const logNormalConfig: DistributionConfig = { type: 'log-normal', mu: 2.3, sigma: 0.8 }
+    expect(dist.fromConfig(logNormalConfig)).toBeGreaterThan(0)
+
+    const configs: DistributionConfig[] = [
+      { type: 'constant', value: 7 },
+      { type: 'deterministic', value: 7 },
+      { type: 'uniform', min: 1, max: 2 },
+      { type: 'exponential', lambda: 1.2 },
+      { type: 'normal', mean: 1, stdDev: 2 },
+      { type: 'poisson', lambda: 2 },
+      { type: 'weibull', shape: 2, scale: 3 },
+      { type: 'gamma', shape: 2, scale: 3 },
+      { type: 'beta', alpha: 2, beta: 3 },
+      { type: 'pareto', shape: 2, scale: 3 },
+      { type: 'binomial', n: 10, p: 0.2 },
+      { type: 'empirical', samples: [10, 20, 30], interpolation: 'step' },
+      { type: 'empirical', samples: [10, 20, 30], interpolation: 'linear' },
+      {
+        type: 'mixture',
+        components: [
+          { weight: 1, distribution: { type: 'constant', value: 5 } },
+          { weight: 0, distribution: { type: 'constant', value: 9 } }
+        ]
+      }
+    ]
+
+    for (const config of configs) {
+      const value = dist.fromConfig(config)
+      expect(Number.isFinite(value)).toBe(true)
+    }
+
+    expect(
+      dist.fromConfig({
+        type: 'mixture',
+        components: [
+          { weight: 1, distribution: { type: 'constant', value: 5 } },
+          { weight: 0, distribution: { type: 'constant', value: 9 } }
+        ]
+      })
+    ).toBe(5)
+  })
+})


### PR DESCRIPTION
… and tests

## Summary
Implements ticket **T-006 / issue #20** by adding a deterministic, config-driven distribution sampler for the simulation engine.

This PR introduces a `Distributions` class that uses the injected seeded `RandomGenerator` (no `Math.random()`), so sampling is reproducible across runs with the same seed.

## What Changed
- Added full sampler implementation in [src/engine/distribution.ts](/Users/hritvikmohan/Desktop/HM25/ns-simulator/src/engine/distribution.ts).
- Added unit tests in [src/engine/tests/distribution.test.ts](/Users/hritvikmohan/Desktop/HM25/ns-simulator/src/engine/tests/distribution.test.ts).
- Implemented distribution methods:
  - `constant`
  - `uniform`
  - `exponential`
  - `normal` (Box-Muller with cached spare sample)
  - `logNormal`
  - `poisson`
  - `weibull`
  - `gamma` (Marsaglia-Tsang + shape<1 transform)
  - `beta`
  - `pareto`
  - `empirical`
  - `mixture`
- Added `fromConfig(config: DistributionConfig)` dispatch covering base types and `mixture`.
- Added support for existing schema variants in this repo:
  - `deterministic`
  - `binomial`
  - empirical `interpolation` (`step` / `linear`)
- Added parameter validation and explicit error messages for invalid inputs.

## Why
Simulation behavior depends on stochastic sampling (latency, arrivals, failures). A centralized deterministic sampler is required for:
- realism (non-constant behavior),
- consistency across modules,
- deterministic replay/debugging with seeds.

## Validation
- `npx vitest run src/engine/tests/distribution.test.ts`
- `npm run typecheck:node`

Both pass.

## AC Coverage (T-006)
- [x] Distribution methods implemented and exported via `Distributions`
- [x] `fromConfig({ type: "log-normal", mu: 2.3, sigma: 0.8 })` works
- [x] Deterministic behavior with same seed
- [x] `exponential(1)` mean sanity check over 10,000 samples
- [x] `logNormal(0, 1)` positivity + right-skew sanity check
- [x] `normal` mean/stddev sanity check
- [x] Unit tests for distribution functionality
