### PR TITLE
added sharding and partitioning nodes

### DIFF
--- a/src/renderer/src/components/nodes/ServiceNode.tsx
+++ b/src/renderer/src/components/nodes/ServiceNode.tsx
@@ -30,7 +30,11 @@ import {
   ServerCog,
   BookOpen,
   Bell,
-  LineChart
+  LineChart,
+  Hash,
+  Boxes,
+  SplitSquareHorizontal,
+  SquareStack
 } from 'lucide-react'
 
 import UniversalHandle from '@renderer/components/ui/UniversalHandle'
@@ -82,7 +86,11 @@ const ICON_LOOKUP: Record<string, LucideIcon> = {
   'log-aggregator': Library,
   tracing: Radar,
   alerting: BellRing,
-  'health-check': HeartPulse
+  'health-check': HeartPulse,
+  hashing: Hash,
+  sharding: Boxes,
+  partition: SplitSquareHorizontal,
+  shard: SquareStack
 }
 
 const ServiceNode = ({ id, data, selected }: NodeProps<ServiceNodeData>) => {

--- a/src/renderer/src/config/catalogConfig.ts
+++ b/src/renderer/src/config/catalogConfig.ts
@@ -116,5 +116,10 @@ export const CATALOG_CONFIG: CatalogCategory[] = [
       'alerting-engine',
       'health-check-monitor'
     ])
+  },
+  {
+    id: 'partitioning-sharding',
+    title: 'Data Partitioning',
+    items: getItems(['hashing', 'sharding', 'partition-node', 'shard-node'])
   }
 ]

--- a/src/renderer/src/config/nodeRegistry.ts
+++ b/src/renderer/src/config/nodeRegistry.ts
@@ -41,7 +41,11 @@ import {
   LineChart,
   Sliders,
   Key,
-  ToggleLeft
+  ToggleLeft,
+  Hash,
+  Boxes,
+  SplitSquareHorizontal,
+  SquareStack
 } from 'lucide-react'
 import { getTheme } from './themeConfig'
 
@@ -487,6 +491,44 @@ export const NODE_REGISTRY: Record<string, NodeDef> = {
     icon: HeartPulse,
     lookupKey: 'health-check',
     defaultData: { iconKey: 'health-check', status: 'healthy', throughput: 100, load: 5 }
+  },
+
+  // Partitioning & Sharding
+  hashing: {
+    id: 'hashing',
+    type: 'serviceNode',
+    label: 'Hashing',
+    subLabel: 'Hash Router',
+    icon: Hash,
+    lookupKey: 'hashing',
+    defaultData: { iconKey: 'hashing', status: 'healthy', throughput: 10000, load: 15 }
+  },
+  sharding: {
+    id: 'sharding',
+    type: 'serviceNode',
+    label: 'Sharding',
+    subLabel: 'Distribution logic',
+    icon: Boxes,
+    lookupKey: 'sharding',
+    defaultData: { iconKey: 'sharding', status: 'healthy', throughput: 15000, load: 20 }
+  },
+  'partition-node': {
+    id: 'partition-node',
+    type: 'serviceNode',
+    label: 'Partition',
+    subLabel: 'Logical Slice',
+    icon: SplitSquareHorizontal,
+    lookupKey: 'partition',
+    defaultData: { iconKey: 'partition', status: 'healthy', throughput: 5000, load: 10 }
+  },
+  'shard-node': {
+    id: 'shard-node',
+    type: 'serviceNode',
+    label: 'Shard',
+    subLabel: 'Physical Slice',
+    icon: SquareStack,
+    lookupKey: 'shard',
+    defaultData: { iconKey: 'shard', status: 'healthy', throughput: 5000, load: 30 }
   }
 }
 

--- a/src/renderer/src/config/themeConfig.ts
+++ b/src/renderer/src/config/themeConfig.ts
@@ -90,6 +90,12 @@ export const THEME_CONFIG: Record<string, ColorTheme> = {
   alerting: { bg: 'bg-red-500', border: 'border-red-600', text: 'text-red-600' },
   'health-check': { bg: 'bg-emerald-400', border: 'border-emerald-500', text: 'text-emerald-500' },
 
+  // Partitioning & Sharding
+  hashing: { bg: 'bg-fuchsia-500', border: 'border-fuchsia-600', text: 'text-fuchsia-600' },
+  sharding: { bg: 'bg-indigo-500', border: 'border-indigo-600', text: 'text-indigo-600' },
+  partition: { bg: 'bg-cyan-500', border: 'border-cyan-600', text: 'text-cyan-600' },
+  shard: { bg: 'bg-emerald-500', border: 'border-emerald-600', text: 'text-emerald-600' },
+
   // Fallbacks
   default: { bg: 'bg-slate-500', border: 'border-slate-600', text: 'text-slate-600' }
 }


### PR DESCRIPTION
This PR introduces the new **Data Partitioning and Sharding** technique components to the simulator, resolving [#63](https://github.com/Newton-School/ns-simulator/issues/63). 

These new nodes allow users to model data distribution, request routing, and physical/logical dataset segmentation at the technique and architecture level.

## Changes Made
This PR modifies the core node registry, UI mapping, and styling to cleanly integrate four new node types (`hashing`, `sharding`, `partition-node`, `shard-node`):

1. **`src/renderer/src/config/nodeRegistry.ts`**
   - Added standard library imports from `lucide-react` for the new icons: `Hash`, `Boxes`, `SplitSquareHorizontal`, and `SquareStack`.
   - Populated the `NODE_REGISTRY` with objects for the four new nodes (defined as `serviceNode`), complete with their load/throughput default metrics and visual descriptors.

2. **`src/renderer/src/config/themeConfig.ts`**
   - Added custom color palettes to the `THEME_CONFIG` object for each new node key (`hashing` -> Fuchsia, `sharding` -> Indigo, `partition` -> Cyan, `shard` -> Emerald) to maintain consistent aesthetics with existing components.

3. **`src/renderer/src/config/catalogConfig.ts`**
   - Introduced a new top-level `Data Partitioning` category to the left-hand UI sidebar catalog.
   - Pushed the four new node IDs to this category so they are draggable onto the canvas.

4. **`src/renderer/src/components/features/nodes/ServiceNode.tsx`**
   - Exported the newly added Lucide icons and successfully mapped them into the component's internal `ICON_LOOKUP` routing object, ensuring the canvas dynamically renders them once dropped.

## Output
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/f4b48192-c00f-48d0-9117-ab4e7e294369" />
