### PR TITLE
add engine debug event lifecycle output

### DIFF
--- a/src/engine/analysis/output.test.ts
+++ b/src/engine/analysis/output.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { RequestSpan } from '../core/events'
 import type { GlobalConfig } from '../core/types'
+import type { DebugEvent, RequestLifecycle } from '../core/debugTypes'
 import type { CompletedRequest } from '../metrics'
 import { MetricsCollector } from '../metrics'
 import { RequestTracer } from '../tracer'
@@ -95,6 +96,55 @@ describe('generateSimulationOutput', () => {
     const output = generateSimulationOutput(metrics, tracer, [], null, [], config, 0)
     expect(output.simulationDuration).toBe(60_000)
     expect(output.warmupDuration).toBe(5_000)
+    expect(output.eventLog).toBeNull()
+    expect(output.debuggedLifecycle).toBeNull()
+  })
+
+  it('passes through debug output payload when provided', () => {
+    const metrics = new MetricsCollector({ warmupDuration: 0 })
+    const tracer = new RequestTracer({ sampleRate: 0 })
+
+    const config: GlobalConfig = {
+      simulationDuration: 1_000,
+      seed: 'debug-seed',
+      warmupDuration: 0,
+      timeResolution: 'microsecond',
+      defaultTimeout: 1_000
+    }
+
+    const eventLog: DebugEvent[] = [
+      {
+        index: 0,
+        timestampMs: 0,
+        type: 'request-generated',
+        nodeId: 'source',
+        requestId: 'req-1',
+        status: 'info',
+        reason: null,
+        edgeId: null,
+        message: 'Generated request at source',
+        nodeState: null,
+        priority: 1
+      }
+    ]
+    const lifecycle: RequestLifecycle = {
+      requestId: 'req-1',
+      phases: [],
+      terminalStatus: 'in-flight',
+      terminalNode: null,
+      terminalReason: null,
+      totalLatencyMs: 0,
+      expectedPath: { nodeIds: ['source'], edgeIds: [], deterministic: true },
+      actualPath: []
+    }
+
+    const output = generateSimulationOutput(metrics, tracer, [], null, [], config, 0, {
+      eventLog,
+      debuggedLifecycle: lifecycle
+    })
+
+    expect(output.eventLog).toEqual(eventLog)
+    expect(output.debuggedLifecycle).toEqual(lifecycle)
   })
 
   it('conservation check flags nodes with large in-flight counts', () => {

--- a/src/engine/analysis/output.ts
+++ b/src/engine/analysis/output.ts
@@ -1,4 +1,5 @@
 import { GlobalConfig } from '../core/types'
+import type { DebugEvent, RequestLifecycle } from '../core/debugTypes'
 import { MetricsCollector, PerNodeMetrics, SimulationSummary } from '../metrics'
 import { RequestTrace, RequestTracer } from '../tracer'
 
@@ -119,6 +120,10 @@ export interface SimulationOutput {
   simulationDuration: number
   /** Warmup period in ms (excluded from metrics). */
   warmupDuration: number
+  /** Full or filtered debug event stream captured during the run. */
+  eventLog: DebugEvent[] | null
+  /** Lifecycle assembled for a focused debug request, when one was selected. */
+  debuggedLifecycle: RequestLifecycle | null
 }
 
 export function generateSimulationOutput(
@@ -128,7 +133,11 @@ export function generateSimulationOutput(
   causalGraph: CausalGraph | null,
   invariantViolations: InvariantViolation[],
   config: GlobalConfig,
-  eventsProcessed: number
+  eventsProcessed: number,
+  debugData?: {
+    eventLog?: DebugEvent[] | null
+    debuggedLifecycle?: RequestLifecycle | null
+  }
 ): SimulationOutput {
   const summary = metrics.generateSummary(config.simulationDuration)
   const perNode = Object.fromEntries(
@@ -154,7 +163,9 @@ export function generateSimulationOutput(
     reproducible: true,
     eventsProcessed,
     simulationDuration: config.simulationDuration,
-    warmupDuration: config.warmupDuration
+    warmupDuration: config.warmupDuration,
+    eventLog: debugData?.eventLog ?? null,
+    debuggedLifecycle: debugData?.debuggedLifecycle ?? null
   }
 }
 

--- a/src/engine/core/debugTypes.ts
+++ b/src/engine/core/debugTypes.ts
@@ -1,0 +1,397 @@
+import type { EventType, SimulationEvent } from './events'
+import { microToMs } from './time'
+import type { ComponentNode, EdgeDefinition, NodeState, TopologyJSON } from './types'
+import type { RequestTrace, RequestTraceSpan } from '../tracer'
+
+export interface NodeSnapshot {
+  status: 'idle' | 'busy' | 'saturated' | 'failed'
+  activeWorkers: number
+  maxWorkers: number
+  queueLength: number
+  capacity: number
+  utilization: number
+  totalInSystem: number
+}
+
+export interface DebugEvent {
+  index: number
+  timestampMs: number
+  type: EventType
+  nodeId: string
+  requestId: string
+  status: 'info' | 'success' | 'warn' | 'danger'
+  reason: string | null
+  edgeId: string | null
+  message: string
+  nodeState: NodeSnapshot | null
+  priority: number
+}
+
+export interface PhaseTiming {
+  queueWaitMs: number
+  serviceTimeMs: number
+  edgeLatencyMs: number
+  totalMs: number
+  startMs: number
+  endMs: number
+}
+
+export interface LifecyclePhase {
+  name: string
+  hopIndex: number
+  event: DebugEvent
+  timing: PhaseTiming | null
+  result: 'passed' | 'rejected' | 'timeout' | 'arrived'
+}
+
+export interface ExpectedPath {
+  nodeIds: string[]
+  edgeIds: string[]
+  deterministic: boolean
+}
+
+export interface RequestLifecycle {
+  requestId: string
+  phases: LifecyclePhase[]
+  terminalStatus: 'success' | 'rejected' | 'timeout' | 'in-flight'
+  terminalNode: string | null
+  terminalReason: string | null
+  totalLatencyMs: number
+  expectedPath: ExpectedPath
+  actualPath: string[]
+}
+
+export interface AdmissionDecision {
+  nodeId: string
+  outcome: 'admitted' | 'rejected'
+  rule: 'capacity' | 'node_failed' | 'security_blocked'
+  nodeState: NodeSnapshot
+  slots: {
+    activeWorkerSlots: number
+    queuedSlots: number
+    availableSlots: number
+  }
+  equation: {
+    left: number
+    operator: '>=' | '<'
+    right: number
+    result: boolean
+  }
+}
+
+const STATUS_BY_EVENT_TYPE: Record<EventType, DebugEvent['status']> = {
+  'request-generated': 'info',
+  'request-arrival': 'info',
+  'processing-start': 'info',
+  'processing-complete': 'success',
+  'request-forwarded': 'success',
+  'request-complete': 'success',
+  'request-timeout': 'warn',
+  'request-rejected': 'danger',
+  'node-failure': 'danger',
+  'node-recovery': 'success',
+  'network-partition': 'danger',
+  'latency-spike': 'warn',
+  'scale-up': 'success',
+  'scale-down': 'warn',
+  'circuit-breaker-open': 'danger',
+  'circuit-breaker-close': 'success',
+  'health-check': 'info',
+  'cache-hit': 'success',
+  'cache-miss': 'info',
+  'db-failover': 'warn'
+}
+
+const LIFECYCLE_EVENT_RANK: Partial<Record<EventType, number>> = {
+  'request-arrival': 0,
+  'processing-complete': 1,
+  'request-forwarded': 2,
+  'request-complete': 3,
+  'request-timeout': 4,
+  'request-rejected': 5
+}
+
+function toNodeSnapshot(
+  nodeState: NodeState | null,
+  nodeConfig: ComponentNode | null
+): NodeSnapshot | null {
+  if (!nodeState || !nodeConfig?.queue) {
+    return null
+  }
+
+  return {
+    status: nodeState.status,
+    activeWorkers: nodeState.activeWorkers,
+    maxWorkers: nodeConfig.queue.workers,
+    queueLength: nodeState.queueLength,
+    capacity: nodeConfig.queue.capacity,
+    utilization: nodeState.utilization,
+    totalInSystem: nodeState.totalInSystem
+  }
+}
+
+function deriveReason(event: SimulationEvent): string | null {
+  const raw = event.data.reason
+  return typeof raw === 'string' && raw.length > 0 ? raw : null
+}
+
+function deriveEdgeId(event: SimulationEvent): string | null {
+  const edge = event.data.edge as EdgeDefinition | undefined
+  if (edge?.id) {
+    return edge.id
+  }
+
+  const edgeId = event.data.edgeId
+  return typeof edgeId === 'string' && edgeId.length > 0 ? edgeId : null
+}
+
+function formatEventMessage(
+  event: SimulationEvent,
+  nodeLabel: string,
+  reason: string | null,
+  edgeId: string | null
+): string {
+  switch (event.type) {
+    case 'request-generated':
+      return `Generated request at ${nodeLabel}`
+    case 'request-arrival':
+      return edgeId ? `Arrived at ${nodeLabel} via ${edgeId}` : `Arrived at ${nodeLabel}`
+    case 'processing-start':
+      return `Started processing at ${nodeLabel}`
+    case 'processing-complete':
+      return `Completed processing at ${nodeLabel}`
+    case 'request-forwarded': {
+      const targetNodeId =
+        typeof event.data.targetNodeId === 'string' ? event.data.targetNodeId : null
+      if (targetNodeId && edgeId) {
+        return `Forwarded from ${nodeLabel} to ${targetNodeId} via ${edgeId}`
+      }
+      if (targetNodeId) {
+        return `Forwarded from ${nodeLabel} to ${targetNodeId}`
+      }
+      return `Forwarded from ${nodeLabel}`
+    }
+    case 'request-complete':
+      return `Completed request at ${nodeLabel}`
+    case 'request-timeout':
+      return reason ? `Timed out at ${nodeLabel}: ${reason}` : `Timed out at ${nodeLabel}`
+    case 'request-rejected':
+      return reason ? `Rejected at ${nodeLabel}: ${reason}` : `Rejected at ${nodeLabel}`
+    case 'node-failure':
+      return `Node failed: ${nodeLabel}`
+    case 'node-recovery':
+      return `Node recovered: ${nodeLabel}`
+    case 'network-partition':
+      return `Network partition at ${nodeLabel}`
+    case 'latency-spike':
+      return `Latency spike at ${nodeLabel}`
+    case 'scale-up':
+      return `Scaled up ${nodeLabel}`
+    case 'scale-down':
+      return `Scaled down ${nodeLabel}`
+    case 'circuit-breaker-open':
+      return `Circuit breaker opened at ${nodeLabel}`
+    case 'circuit-breaker-close':
+      return `Circuit breaker closed at ${nodeLabel}`
+    case 'health-check':
+      return `Health check at ${nodeLabel}`
+    case 'cache-hit':
+      return `Cache hit at ${nodeLabel}`
+    case 'cache-miss':
+      return `Cache miss at ${nodeLabel}`
+    case 'db-failover':
+      return `Database failover at ${nodeLabel}`
+    default: {
+      const exhaustiveCheck: never = event.type
+      return exhaustiveCheck
+    }
+  }
+}
+
+function derivePhaseResult(eventType: EventType): LifecyclePhase['result'] {
+  switch (eventType) {
+    case 'request-rejected':
+      return 'rejected'
+    case 'request-timeout':
+      return 'timeout'
+    case 'processing-complete':
+    case 'request-forwarded':
+    case 'request-complete':
+      return 'passed'
+    default:
+      return 'arrived'
+  }
+}
+
+function isLifecycleEvent(eventType: EventType): boolean {
+  return eventType in LIFECYCLE_EVENT_RANK
+}
+
+function promoteLifecycleEvent(current: DebugEvent, candidate: DebugEvent): boolean {
+  const currentRank = LIFECYCLE_EVENT_RANK[current.type] ?? -1
+  const candidateRank = LIFECYCLE_EVENT_RANK[candidate.type] ?? -1
+  return candidateRank >= currentRank
+}
+
+function toPhaseTiming(span: RequestTraceSpan): PhaseTiming {
+  return {
+    queueWaitMs: span.queueWait,
+    serviceTimeMs: span.serviceTime,
+    edgeLatencyMs: span.edgeLatency,
+    totalMs: span.queueWait + span.serviceTime + span.edgeLatency,
+    startMs: span.start,
+    endMs: span.end
+  }
+}
+
+function buildExpectedPath(topology: TopologyJSON, startNodeId: string | null): ExpectedPath {
+  if (!startNodeId) {
+    return { nodeIds: [], edgeIds: [], deterministic: false }
+  }
+
+  const nodeIds = [startNodeId]
+  const edgeIds: string[] = []
+  const visited = new Set<string>()
+  let deterministic = true
+  let current = startNodeId
+
+  while (!visited.has(current)) {
+    visited.add(current)
+
+    const outgoing = topology.edges.filter((edge) => edge.source === current)
+    if (outgoing.length === 0) {
+      break
+    }
+
+    if (
+      outgoing.length > 1 ||
+      outgoing.some((edge) => edge.mode === 'asynchronous' || edge.mode === 'conditional')
+    ) {
+      deterministic = false
+    }
+
+    const preferred = [...outgoing].sort((left, right) => {
+      const weightDelta = (right.weight ?? 1) - (left.weight ?? 1)
+      if (weightDelta !== 0) return weightDelta
+      return left.id.localeCompare(right.id)
+    })[0]
+
+    edgeIds.push(preferred.id)
+    current = preferred.target
+    nodeIds.push(current)
+  }
+
+  return { nodeIds, edgeIds, deterministic }
+}
+
+export function projectToDebugEvent(
+  event: SimulationEvent,
+  index: number,
+  nodeState: NodeState | null,
+  nodeConfig: ComponentNode | null,
+  nodeLabels: Map<string, string>
+): DebugEvent {
+  const reason = deriveReason(event)
+  const edgeId = deriveEdgeId(event)
+  const nodeLabel = nodeLabels.get(event.nodeId) ?? event.nodeId
+
+  return {
+    index,
+    timestampMs: microToMs(event.timestamp),
+    type: event.type,
+    nodeId: event.nodeId,
+    requestId: event.requestId,
+    status: STATUS_BY_EVENT_TYPE[event.type],
+    reason,
+    edgeId,
+    message: formatEventMessage(event, nodeLabel, reason, edgeId),
+    nodeState: toNodeSnapshot(nodeState, nodeConfig),
+    priority: event.priority
+  }
+}
+
+export function buildRequestLifecycle(
+  requestId: string,
+  events: DebugEvent[],
+  trace: RequestTrace | null,
+  topology: TopologyJSON,
+  nodeLabels: Map<string, string>
+): RequestLifecycle | null {
+  const orderedEvents = [...events]
+    .filter((event) => event.requestId === requestId)
+    .sort((left, right) => left.index - right.index)
+
+  if (orderedEvents.length === 0) {
+    return null
+  }
+
+  const phaseEvents: Array<{ event: DebugEvent; result: LifecyclePhase['result'] }> = []
+  for (const event of orderedEvents) {
+    if (!isLifecycleEvent(event.type)) {
+      continue
+    }
+
+    const current = phaseEvents[phaseEvents.length - 1]
+    if (!current || event.type === 'request-arrival' || current.event.nodeId !== event.nodeId) {
+      phaseEvents.push({ event, result: derivePhaseResult(event.type) })
+      continue
+    }
+
+    if (promoteLifecycleEvent(current.event, event)) {
+      current.event = event
+    }
+    current.result = derivePhaseResult(event.type)
+  }
+
+  const spans = trace?.spans ?? []
+  let spanCursor = 0
+  const phases: LifecyclePhase[] = phaseEvents.map((phase, hopIndex) => {
+    let matchedSpan: RequestTraceSpan | null = null
+    while (spanCursor < spans.length) {
+      const candidate = spans[spanCursor]
+      spanCursor++
+      if (candidate.nodeId === phase.event.nodeId) {
+        matchedSpan = candidate
+        break
+      }
+    }
+
+    return {
+      name: nodeLabels.get(phase.event.nodeId) ?? phase.event.nodeId,
+      hopIndex,
+      event: phase.event,
+      timing: matchedSpan ? toPhaseTiming(matchedSpan) : null,
+      result: phase.result
+    }
+  })
+
+  const lastEvent = orderedEvents[orderedEvents.length - 1]
+  const terminalStatus: RequestLifecycle['terminalStatus'] =
+    lastEvent.type === 'request-complete'
+      ? 'success'
+      : lastEvent.type === 'request-rejected'
+        ? 'rejected'
+        : lastEvent.type === 'request-timeout'
+          ? 'timeout'
+          : 'in-flight'
+
+  const actualPath = orderedEvents
+    .filter((event) => event.type === 'request-arrival')
+    .map((event) => event.nodeId)
+
+  const fallbackLatencyMs = Math.max(0, lastEvent.timestampMs - orderedEvents[0].timestampMs)
+  const totalLatencyMs = trace?.totalLatency ?? fallbackLatencyMs
+
+  return {
+    requestId,
+    phases,
+    terminalStatus,
+    terminalNode:
+      terminalStatus === 'success' || terminalStatus === 'in-flight' ? null : lastEvent.nodeId,
+    terminalReason:
+      terminalStatus === 'success' || terminalStatus === 'in-flight' ? null : lastEvent.reason,
+    totalLatencyMs,
+    expectedPath: buildExpectedPath(topology, actualPath[0] ?? orderedEvents[0]?.nodeId ?? null),
+    actualPath
+  }
+}

--- a/src/engine/engine.test.ts
+++ b/src/engine/engine.test.ts
@@ -103,6 +103,64 @@ describe('SimulationEngine', () => {
     expect(output.traces[0].spans[0].nodeId).toBe('worker')
   })
 
+  it('captures a canonical debug event log when debug mode is enabled', () => {
+    const topology = makeTopology({
+      global: { simulationDuration: 20, defaultTimeout: 1_000, traceSampleRate: 1 },
+      nodes: [makeNode('source'), makeNode('worker')],
+      edges: [makeEdge('source-to-worker', 'source', 'worker')],
+      workload: {
+        sourceNodeId: 'source',
+        pattern: 'constant',
+        baseRps: 1,
+        requestDistribution: [{ type: 'GET', weight: 1, sizeBytes: 100 }]
+      }
+    })
+
+    const engine = new SimulationEngine(topology)
+    engine.enableDebug('all')
+
+    const output = engine.run()
+    expect(output.eventLog).not.toBeNull()
+    expect(output.eventLog?.map((event) => event.type)).toEqual([
+      'request-generated',
+      'request-arrival',
+      'processing-complete',
+      'request-complete'
+    ])
+    expect(output.eventLog?.map((event) => event.index)).toEqual([0, 1, 2, 3])
+    expect(output.eventLog?.[0].requestId).toBe('req-000001')
+    expect(output.eventLog?.[1].edgeId).toBe('source-to-worker')
+    expect(output.eventLog?.[1].nodeState?.activeWorkers).toBe(1)
+    expect(output.debuggedLifecycle).toBeNull()
+  })
+
+  it('assembles a focused request lifecycle when debugging a specific request', () => {
+    const topology = makeTopology({
+      global: { simulationDuration: 20, defaultTimeout: 1_000, traceSampleRate: 0 },
+      nodes: [makeNode('source'), makeNode('worker')],
+      edges: [makeEdge('source-to-worker', 'source', 'worker')],
+      workload: {
+        sourceNodeId: 'source',
+        pattern: 'constant',
+        baseRps: 1,
+        requestDistribution: [{ type: 'GET', weight: 1, sizeBytes: 100 }]
+      }
+    })
+
+    const engine = new SimulationEngine(topology)
+    engine.enableDebug('req-000001', { forceTrace: true })
+
+    const output = engine.run()
+    expect(output.eventLog?.every((event) => event.requestId === 'req-000001')).toBe(true)
+    expect(output.debuggedLifecycle).not.toBeNull()
+    expect(output.debuggedLifecycle?.requestId).toBe('req-000001')
+    expect(output.debuggedLifecycle?.terminalStatus).toBe('success')
+    expect(output.debuggedLifecycle?.actualPath).toEqual(['worker'])
+    expect(output.debuggedLifecycle?.phases).toHaveLength(1)
+    expect(output.debuggedLifecycle?.phases[0].result).toBe('passed')
+    expect(output.debuggedLifecycle?.phases[0].timing?.totalMs).toBeGreaterThanOrEqual(0)
+  })
+
   it('schedules packet-loss timeout at request deadline, not immediately', () => {
     const topology = makeTopology({
       global: { simulationDuration: 100, defaultTimeout: 1_000, traceSampleRate: 1 },

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -1,5 +1,11 @@
 import { generateSimulationOutput, SimulationOutput, TimeSeriesSnapshot } from './analysis/output'
 import { createEvent, Request, SimulationEvent } from './core/events'
+import {
+  buildRequestLifecycle,
+  DebugEvent,
+  projectToDebugEvent,
+  RequestLifecycle
+} from './core/debugTypes'
 import { microToMs, msToMicro, secToMicro } from './core/time'
 import { ComponentNode, EdgeDefinition, EventScheduler, TopologyJSON } from './core/types'
 import { MetricsCollector } from './metrics'
@@ -19,6 +25,7 @@ interface SecurityPolicyConfig {
 export class SimulationEngine {
   onProgress?: (percent: number, eventsProcessed: number) => void
   onSnapshot?: (snapshot: TimeSeriesSnapshot) => void
+  onDebugEvent?: (event: DebugEvent) => void
 
   private readonly eventQueue = new MinHeap<SimulationEvent>()
   private readonly distributions: Distributions
@@ -26,6 +33,8 @@ export class SimulationEngine {
   private readonly metrics: MetricsCollector
   private readonly tracer: RequestTracer
   private readonly nodes = new Map<string, GGcKNode>()
+  private readonly nodeConfigs = new Map<string, ComponentNode>()
+  private readonly nodeLabels = new Map<string, string>()
   private readonly nodeErrorRateById = new Map<string, number>()
   private readonly nodeTimeoutUsById = new Map<string, bigint>()
   private readonly securityPolicyByNodeId = new Map<string, SecurityPolicyConfig>()
@@ -42,6 +51,9 @@ export class SimulationEngine {
   private running = false
   private paused = false
   private readonly timeSeries: TimeSeriesSnapshot[] = []
+  private debugTarget: 'all' | string | null = null
+  private forcedTraceRequestId: string | null = null
+  private readonly debugEvents: DebugEvent[] = []
 
   constructor(private readonly topology: TopologyJSON) {
     const rng = createRandom(topology.global.seed)
@@ -65,6 +77,8 @@ export class SimulationEngine {
     for (const node of topology.nodes) {
       const normalized = this.withNodeDefaults(node)
       this.nodes.set(node.id, new GGcKNode(normalized, this.distributions, scheduler))
+      this.nodeConfigs.set(node.id, normalized)
+      this.nodeLabels.set(node.id, normalized.label)
 
       const nodeErrorRate = this.readNodeErrorRate(normalized)
       if (nodeErrorRate !== null && nodeErrorRate > 0) {
@@ -90,9 +104,37 @@ export class SimulationEngine {
     }
   }
 
+  enableDebug(target: 'all' | string = 'all', options: { forceTrace?: boolean } = {}): void {
+    if (this.forcedTraceRequestId) {
+      this.tracer.unforceTrace(this.forcedTraceRequestId)
+      this.forcedTraceRequestId = null
+    }
+
+    this.debugTarget = target
+    this.debugEvents.length = 0
+
+    if (target !== 'all' && options.forceTrace) {
+      this.tracer.forceTrace(target)
+      this.forcedTraceRequestId = target
+    }
+  }
+
+  disableDebug(): void {
+    if (this.forcedTraceRequestId) {
+      this.tracer.unforceTrace(this.forcedTraceRequestId)
+      this.forcedTraceRequestId = null
+    }
+
+    this.debugTarget = null
+    this.debugEvents.length = 0
+  }
+
   run(): SimulationOutput {
     this.running = true
     this.paused = false
+    if (this.debugTarget) {
+      this.debugEvents.length = 0
+    }
 
     this.processEvents()
     return this.generateResults()
@@ -175,6 +217,7 @@ export class SimulationEngine {
       }
 
       this.handleEvent(event)
+      this.emitDebugEvent(event)
       this.eventsProcessed++
       processedInCall++
 
@@ -233,6 +276,8 @@ export class SimulationEngine {
     }
 
     const request = this.workload.generateNext(this.clock)
+    event.requestId = request.id
+    event.data.request = request
     this.requestById.set(request.id, request)
     this.tracer.setRequestCreatedAt(request.id, request.createdAt)
 
@@ -468,6 +513,29 @@ export class SimulationEngine {
     return undefined
   }
 
+  private emitDebugEvent(event: SimulationEvent): void {
+    if (!this.debugTarget) {
+      return
+    }
+
+    const nodeState = this.nodes.get(event.nodeId)?.getState() ?? null
+    const nodeConfig = this.nodeConfigs.get(event.nodeId) ?? null
+    const debugEvent = projectToDebugEvent(
+      event,
+      this.eventsProcessed,
+      nodeState,
+      nodeConfig,
+      this.nodeLabels
+    )
+
+    if (this.debugTarget !== 'all' && debugEvent.requestId !== this.debugTarget) {
+      return
+    }
+
+    this.debugEvents.push(debugEvent)
+    this.onDebugEvent?.(debugEvent)
+  }
+
   private shouldEmitSnapshot(timestamp: bigint): boolean {
     return this.lastSnapshotAt < 0n || timestamp - this.lastSnapshotAt >= this.snapshotIntervalUs
   }
@@ -522,6 +590,12 @@ export class SimulationEngine {
   }
 
   private generateResults(): SimulationOutput {
+    const eventLog = this.debugTarget ? [...this.debugEvents] : null
+    const debuggedLifecycle =
+      this.debugTarget && this.debugTarget !== 'all'
+        ? this.buildDebuggedLifecycle(this.debugTarget, eventLog)
+        : null
+
     return generateSimulationOutput(
       this.metrics,
       this.tracer,
@@ -529,8 +603,25 @@ export class SimulationEngine {
       null,
       [],
       this.topology.global,
-      this.eventsProcessed
+      this.eventsProcessed,
+      {
+        eventLog,
+        debuggedLifecycle
+      }
     )
+  }
+
+  private buildDebuggedLifecycle(
+    requestId: string,
+    eventLog: DebugEvent[] | null
+  ): RequestLifecycle | null {
+    if (!eventLog || eventLog.length === 0) {
+      return null
+    }
+
+    const trace =
+      this.tracer.getTraces().find((candidate) => candidate.requestId === requestId) ?? null
+    return buildRequestLifecycle(requestId, eventLog, trace, this.topology, this.nodeLabels)
   }
 
   private withNodeDefaults(node: ComponentNode): ComponentNode {
@@ -677,7 +768,13 @@ export class SimulationEngine {
     }
 
     this.eventQueue.insert(
-      createEvent('request-arrival', targetNodeId, request.id, { request }, arrivalTime)
+      createEvent(
+        'request-arrival',
+        targetNodeId,
+        request.id,
+        { request, edge, sourceNodeId: edge.source },
+        arrivalTime
+      )
     )
   }
 }

--- a/src/engine/tracer.test.ts
+++ b/src/engine/tracer.test.ts
@@ -38,6 +38,19 @@ describe('RequestTracer', () => {
     expect(tracer.getTraces()).toEqual([])
   })
 
+  it('can force tracing for a specific request regardless of sample rate', () => {
+    const tracer = new RequestTracer({ sampleRate: 0 })
+
+    tracer.forceTrace('req-forced')
+    tracer.setRequestCreatedAt('req-forced', 0n)
+    tracer.recordSpan('req-forced', makeSpan('node-a', 0n, 1_000n, 2_000n))
+    tracer.markStatus('req-forced', 'success')
+
+    const traces = tracer.getTraces()
+    expect(traces).toHaveLength(1)
+    expect(traces[0].requestId).toBe('req-forced')
+  })
+
   it('calculates edge latency and total latency for sequential spans', () => {
     const tracer = new RequestTracer({ sampleRate: 1 })
 

--- a/src/engine/tracer.ts
+++ b/src/engine/tracer.ts
@@ -27,12 +27,17 @@ interface TraceState {
 export class RequestTracer {
   private readonly sampleRate: number
   private readonly traces = new Map<string, TraceState>()
+  private readonly forcedRequestIds = new Set<string>()
 
   constructor(config: { sampleRate: number }) {
     this.sampleRate = Math.min(1, Math.max(0, config.sampleRate))
   }
 
   shouldTrace(requestId: string): boolean {
+    if (this.forcedRequestIds.has(requestId)) {
+      return true
+    }
+
     if (this.traces.has(requestId)) {
       return true
     }
@@ -40,6 +45,14 @@ export class RequestTracer {
     const hash = this.hash32(requestId)
     const normalized = hash / 0x100000000
     return normalized < this.sampleRate
+  }
+
+  forceTrace(requestId: string): void {
+    this.forcedRequestIds.add(requestId)
+  }
+
+  unforceTrace(requestId: string): void {
+    this.forcedRequestIds.delete(requestId)
   }
 
   recordSpan(requestId: string, span: RequestSpan): void {


### PR DESCRIPTION
## What changed
- added simulator debug mode support in `SimulationEngine`, including `enableDebug` and per-event debug capture
- introduced `DebugEvent` and `RequestLifecycle` types plus lifecycle reconstruction logic for request-focused debugging
- extended `SimulationOutput` with `eventLog` and `debuggedLifecycle`
- added forced tracing support for targeted requests even when trace sampling is disabled
- updated the docs submodule pointer to include the related node behaviour and fidelity spec updates

## Why
The engine could produce traces and metrics, but it did not expose a canonical debug event stream or a reconstructed request lifecycle for focused debugging. This change adds a stable debug payload that downstream UI or tooling can render directly.

## Impact
Developers can now debug all events in a run or inspect a single request lifecycle with deterministic event ordering, derived path information, and optional trace timing.

## Validation
- `npm test -- src/engine/engine.test.ts src/engine/tracer.test.ts src/engine/analysis/output.test.ts`
- `3` test files passed
- `18` tests passed