### PR TITLE
feat: use double-click for opening node properties sidebar

### DIFF
--- a/src/renderer/src/components/canvas/FlowCanvas.tsx
+++ b/src/renderer/src/components/canvas/FlowCanvas.tsx
@@ -9,7 +9,8 @@ import ReactFlow, {
   Edge,
   Connection,
   ConnectionLineType,
-  updateEdge
+  updateEdge,
+  Node
 } from 'reactflow'
 import 'reactflow/dist/style.css'
 import { EdgeSimulationData } from '@renderer/types/ui'

--- a/src/renderer/src/components/canvas/FlowCanvas.tsx
+++ b/src/renderer/src/components/canvas/FlowCanvas.tsx
@@ -26,7 +26,11 @@ import { useHandleProximity } from './hooks/useHandleProximity'
 import MagneticConnectionLine from './MagneticConnectionLine'
 import { MAGNETIC_CONNECTION_RADIUS_PX } from './magneticSnapConfig'
 
-const FlowCanvasInternal = () => {
+interface FlowCanvasProps {
+  onNodeDoubleClick?: (event: React.MouseEvent, node: Node) => void
+}
+
+const FlowCanvasInternal = ({ onNodeDoubleClick }: FlowCanvasProps) => {
   const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance | null>(null)
   const [selectedEdge, setSelectedEdge] = useState<Edge | null>(null)
 
@@ -147,6 +151,7 @@ const FlowCanvasInternal = () => {
         onNodeDragStop={onNodeDragStop}
         onEdgeClick={onEdgeClick}
         onPaneClick={onPaneClick}
+        onNodeDoubleClick={onNodeDoubleClick}
       >
         <Background variant={BackgroundVariant.Dots} gap={30} size={1.2} color={GRID_COLOR} />
         <Controls className="!bg-nss-surface !border-nss-border" />
@@ -169,8 +174,8 @@ const FlowCanvasInternal = () => {
   )
 }
 
-export const FlowCanvas = () => (
+export const FlowCanvas = (props: FlowCanvasProps) => (
   <ReactFlowProvider>
-    <FlowCanvasInternal />
+    <FlowCanvasInternal {...props} />
   </ReactFlowProvider>
 )

--- a/src/renderer/src/components/layout/WorkspaceLayout.tsx
+++ b/src/renderer/src/components/layout/WorkspaceLayout.tsx
@@ -93,6 +93,7 @@ export const WorkspaceLayout = () => {
   const updateScenario = useStore((s) => s.updateScenario)
   const setSimulationMetrics = useStore((s) => s.setSimulationMetrics)
   const clearSimulationMetrics = useStore((s) => s.clearSimulationMetrics)
+  const selectGraphElements = useStore((s) => s.selectGraphElements)
   const { confirm, dialog } = useConfirmDialog()
   const confirmDiscardChanges = useCallback(
     () =>
@@ -284,7 +285,12 @@ export const WorkspaceLayout = () => {
             <PanelGroup direction="vertical" autoSaveId="main-layout-vertical">
               {/* Canvas */}
               <Panel defaultSize={showResults ? 65 : 100} minSize={10} order={1}>
-                <FlowCanvas onNodeDoubleClick={() => setIsRightOpen(true)} />
+                <FlowCanvas
+                  onNodeDoubleClick={(_, node) => {
+                    selectGraphElements({ nodeId: node.id })
+                    setIsRightOpen(true)
+                  }}
+                />
               </Panel>
 
               {/* Results Tray */}

--- a/src/renderer/src/components/layout/WorkspaceLayout.tsx
+++ b/src/renderer/src/components/layout/WorkspaceLayout.tsx
@@ -138,9 +138,7 @@ export const WorkspaceLayout = () => {
   }, [])
 
   useEffect(() => {
-    if (selectedNodeId) {
-      setIsRightOpen(true)
-    } else {
+    if (!selectedNodeId) {
       setIsRightOpen(false)
     }
   }, [selectedNodeId])
@@ -286,7 +284,7 @@ export const WorkspaceLayout = () => {
             <PanelGroup direction="vertical" autoSaveId="main-layout-vertical">
               {/* Canvas */}
               <Panel defaultSize={showResults ? 65 : 100} minSize={10} order={1}>
-                <FlowCanvas />
+                <FlowCanvas onNodeDoubleClick={() => setIsRightOpen(true)} />
               </Panel>
 
               {/* Results Tray */}


### PR DESCRIPTION
## Description
This PR improves the canvas User Experience by decoupling node selection from the properties sidebar behavior. Previously, single-clicking a node immediately opened the right sidebar, which caused jarring layout shifts during rapid node selection or multi-select workflows.

## Changes Included
* **Single Click Selection:** Clicking a node once now *only* selects the node visually on the canvas.
* **Double Click Properties:** Added the `onNodeDoubleClick` event listener to `<ReactFlow>`. The right-hand properties sidebar will now only slide open when a user intentionally double-clicks a specific node.
* **Selection Clearing:** Maintained the existing behavior where deselecting nodes (clicking the empty canvas background) smoothly closes the sidebar if it is currently open.
* **State Management:** Refactored `WorkspaceLayout.tsx` to handle the new explicit open triggers rather than binding the panel strictly to the `selectedNodeId` lifecycle.

## Testing Instructions
1. Single-click a node. Verify it is selected (blue border) but the right sidebar does *not* open.
2. Double-click the node. Verify the properties sidebar slides open.
3. Click the empty canvas background. Verify the sidebar closes.
