### PR TITLE
added event listeners and cross button features for simulation tray

### DIFF
--- a/src/renderer/src/components/simulation/SimulationControls.tsx
+++ b/src/renderer/src/components/simulation/SimulationControls.tsx
@@ -239,7 +239,10 @@ export function SimulationControls({
               Workload
             </p>
             <button
+              type="button"
               onClick={() => setIsOpen(false)}
+              aria-label="Close workload tray"
+              title="Close"
               className="text-nss-muted hover:text-nss-text transition-colors"
             >
               <X size={14} />

--- a/src/renderer/src/components/simulation/SimulationControls.tsx
+++ b/src/renderer/src/components/simulation/SimulationControls.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Pause, Play, Square } from 'lucide-react'
+import { Pause, Play, Square, X } from 'lucide-react'
 import type { WorkloadProfile } from '../../../../engine/core/types'
 import type { ScenarioState, SourceNodeOption } from '@renderer/types/ui'
 
@@ -130,11 +130,11 @@ export function SimulationControls({
       if (event.key === 'Escape') setIsOpen(false)
     }
 
-    document.addEventListener('mousedown', onMouseDown)
-    document.addEventListener('keydown', onKeyDown)
+    document.addEventListener('mousedown', onMouseDown, true)
+    document.addEventListener('keydown', onKeyDown, true)
     return () => {
-      document.removeEventListener('mousedown', onMouseDown)
-      document.removeEventListener('keydown', onKeyDown)
+      document.removeEventListener('mousedown', onMouseDown, true)
+      document.removeEventListener('keydown', onKeyDown, true)
     }
   }, [isOpen])
 
@@ -234,9 +234,17 @@ export function SimulationControls({
 
       {isOpen && (
         <div className="absolute top-full left-1/2 -translate-x-1/2 mt-2 z-50 bg-nss-panel border border-nss-border rounded-lg shadow-2xl p-4 w-80 font-sans">
-          <p className="text-[10px] font-semibold uppercase tracking-widest text-nss-muted mb-2">
-            Workload
-          </p>
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-[10px] font-semibold uppercase tracking-widest text-nss-muted">
+              Workload
+            </p>
+            <button
+              onClick={() => setIsOpen(false)}
+              className="text-nss-muted hover:text-nss-text transition-colors"
+            >
+              <X size={14} />
+            </button>
+          </div>
 
           <Field label="Source" className="mb-2">
             <select


### PR DESCRIPTION
this is the solution for the issue #172 

<img width="269" height="329" alt="Screenshot 2026-07-01 at 20 25 41" src="https://github.com/user-attachments/assets/7aded1f7-e7de-49b2-bbdf-b95ed4c12afa" />



added the cross button as well as you can press the esc key to close it and also click anywhere in the canvas to also close the tray