### PR TITLE
Fix simulation results tray

### DIFF
--- a/src/renderer/src/components/layout/WorkspaceLayout.tsx
+++ b/src/renderer/src/components/layout/WorkspaceLayout.tsx
@@ -1,5 +1,6 @@
 import { Suspense, lazy, useCallback, useEffect, useRef, useState } from 'react'
 import { Panel, PanelGroup, ImperativePanelHandle } from 'react-resizable-panels'
+import { AlertTriangle } from 'lucide-react'
 
 // Store
 import useStore from '@renderer/store/useStore'
@@ -71,6 +72,8 @@ export const WorkspaceLayout = () => {
     tone: 'warning'
   })
   const [lastRunContext, setLastRunContext] = useState<ScenarioRunContext | null>(null)
+  const [lastRunTopologyJson, setLastRunTopologyJson] = useState<string | null>(null)
+  const [isTopologyStale, setIsTopologyStale] = useState(false)
 
   // Panel refs — panels stay in the DOM always; we collapse/expand imperatively
   // so that opening one side never redistributes the other side's size.
@@ -180,6 +183,31 @@ export const WorkspaceLayout = () => {
     }
   }, [sim.status, clearSimulationMetrics])
 
+  const simReset = sim.reset
+
+  useEffect(() => {
+    if (nodes.length === 0) {
+      setShowResults(false)
+      setIsTopologyStale(false)
+      setLastRunTopologyJson(null)
+      simReset()
+      clearSimulationMetrics()
+      setLastRunContext(null)
+      return
+    }
+
+    if (lastRunTopologyJson) {
+      const { topology } = serialize()
+      const currentJson = topology ? JSON.stringify(topology) : null
+      if (currentJson !== lastRunTopologyJson) {
+        setIsTopologyStale(true)
+        setShowResults(false)
+      } else {
+        setIsTopologyStale(false)
+      }
+    }
+  }, [serialize, lastRunTopologyJson, nodes.length, simReset, clearSimulationMetrics])
+
   function startSimulation() {
     const { topology, errors, runContext } = serialize()
 
@@ -202,6 +230,8 @@ export const WorkspaceLayout = () => {
 
     setRunIssues({ messages: validation.warnings ?? [], tone: 'warning' })
     setShowResults(true)
+    setIsTopologyStale(false)
+    setLastRunTopologyJson(JSON.stringify(topology))
     setLastRunContext(runContext)
     clearSimulationMetrics()
     const flowStore = useStore.getState()
@@ -306,12 +336,26 @@ export const WorkspaceLayout = () => {
             <PanelGroup direction="vertical" autoSaveId="main-layout-vertical">
               {/* Canvas */}
               <Panel defaultSize={showResults ? 65 : 100} minSize={10} order={1}>
-                <FlowCanvas
-                  onNodeDoubleClick={(_, node) => {
-                    selectGraphElements({ nodeId: node.id })
-                    setIsRightOpen(true)
-                  }}
-                />
+                <div className="relative h-full w-full">
+                  <FlowCanvas
+                    onNodeDoubleClick={(_, node) => {
+                      selectGraphElements({ nodeId: node.id })
+                      setIsRightOpen(true)
+                    }}
+                  />
+                  {isTopologyStale && (
+                    <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 px-5 py-3 bg-nss-warning/10 border border-nss-warning/30 text-nss-warning rounded-lg shadow-lg backdrop-blur-sm pointer-events-auto">
+                      <AlertTriangle className="w-5 h-5" />
+                      <span className="text-sm font-medium">Topology changed. Run simulation again to see results.</span>
+                      <button 
+                        onClick={startSimulation}
+                        className="ml-2 px-4 py-1.5 text-sm font-semibold bg-nss-warning/20 hover:bg-nss-warning/30 text-nss-warning rounded-md transition-colors"
+                      >
+                        Run
+                      </button>
+                    </div>
+                  )}
+                </div>
               </Panel>
 
               {/* Results Tray */}

--- a/src/renderer/src/components/layout/WorkspaceLayout.tsx
+++ b/src/renderer/src/components/layout/WorkspaceLayout.tsx
@@ -61,6 +61,21 @@ function PanelFallback({ label }: { label: string }) {
   )
 }
 
+function getTopologyHash(topology: any): string | null {
+  if (!topology) return null
+  try {
+    const clone = JSON.parse(JSON.stringify(topology))
+    if (Array.isArray(clone.nodes)) {
+      clone.nodes.forEach((n: any) => {
+        delete n.position
+      })
+    }
+    return JSON.stringify(clone)
+  } catch {
+    return null
+  }
+}
+
 export const WorkspaceLayout = () => {
   // Sidebar State
   const [isLeftOpen, setIsLeftOpen] = useState(true)
@@ -198,7 +213,7 @@ export const WorkspaceLayout = () => {
 
     if (lastRunTopologyJson) {
       const { topology } = serialize()
-      const currentJson = topology ? JSON.stringify(topology) : null
+      const currentJson = getTopologyHash(topology)
       if (currentJson !== lastRunTopologyJson) {
         setIsTopologyStale(true)
         setShowResults(false)
@@ -231,7 +246,7 @@ export const WorkspaceLayout = () => {
     setRunIssues({ messages: validation.warnings ?? [], tone: 'warning' })
     setShowResults(true)
     setIsTopologyStale(false)
-    setLastRunTopologyJson(JSON.stringify(topology))
+    setLastRunTopologyJson(getTopologyHash(topology))
     setLastRunContext(runContext)
     clearSimulationMetrics()
     const flowStore = useStore.getState()

--- a/src/renderer/src/components/layout/WorkspaceLayout.tsx
+++ b/src/renderer/src/components/layout/WorkspaceLayout.tsx
@@ -344,12 +344,12 @@ export const WorkspaceLayout = () => {
                     }}
                   />
                   {isTopologyStale && (
-                    <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 px-5 py-3 bg-nss-warning/10 border border-nss-warning/30 text-nss-warning rounded-lg shadow-lg backdrop-blur-sm pointer-events-auto">
-                      <AlertTriangle className="w-5 h-5" />
+                    <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 px-5 py-3 bg-yellow-50 border border-yellow-300 text-yellow-800 rounded-lg shadow-lg pointer-events-auto">
+                      <AlertTriangle className="w-5 h-5 text-yellow-600" />
                       <span className="text-sm font-medium">Topology changed. Run simulation again to see results.</span>
                       <button 
                         onClick={startSimulation}
-                        className="ml-2 px-4 py-1.5 text-sm font-semibold bg-nss-warning/20 hover:bg-nss-warning/30 text-nss-warning rounded-md transition-colors"
+                        className="ml-2 px-4 py-1.5 text-sm font-semibold bg-yellow-200 hover:bg-yellow-300 text-yellow-900 rounded-md transition-colors shadow-sm"
                       >
                         Run
                       </button>


### PR DESCRIPTION
this is the image after running the basic topoplogy with the simulation results tray
<img width="1800" height="1169" alt="Screenshot 2026-07-10 at 15 21 08" src="https://github.com/user-attachments/assets/b3c6156e-1858-49ef-be40-cddb72cd150f" />


this is the image after changing the topology (deleting the edge in between)
<img width="589" height="326" alt="Screenshot 2026-07-10 at 15 23 04" src="https://github.com/user-attachments/assets/494bdc9d-6bf0-4012-82d6-1bc46ef0a9c1" />


in this this pop up will come at the lower bottom of the screen if you hinder with the previous run simulation i.e., if you delete or add new edges or nodes or change particular settings within nodes or edges but the pop up will not come if you change the arragement of the topology , will only come on actually changing the topology / architecture diagram

fixes #184  