### PR TITLE
chore: remove npmmirror pins for Electron downloads

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-electron_mirror=https://npmmirror.com/mirrors/electron/
-electron_builder_binaries_mirror=https://npmmirror.com/mirrors/electron-builder-binaries/

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -41,5 +41,3 @@ npmRebuild: false
 publish:
   provider: generic
   url: https://example.com/auto-updates
-electronDownload:
-  mirror: https://npmmirror.com/mirrors/electron/


### PR DESCRIPTION
## Summary

Removes the `npmmirror.com` pins that redirected Electron's binary downloads away from official sources.

- `.npmrc` — deleted (it contained nothing but `electron_mirror` and `electron_builder_binaries_mirror`)
- `electron-builder.yml` — dropped the `electronDownload.mirror` override

**Why:** the mirror served both the Electron native binary *and* the `SHASUMS256.txt` used to verify it, making it a single trusted party for both the artifact and its own integrity check. It's also a China-based CDN, which is a reliability risk for GitHub's US/EU-hosted runners. Downloads now come from Electron's official GitHub releases.

Developers who need a mirror for local connectivity can set one in their personal `~/.npmrc` instead of committing it for the whole team.

## Test plan

- [x] `rm -rf node_modules && npm ci` with a **cleared Electron cache** — succeeded, fetched `electron-v38.8.6-darwin-arm64.zip` fresh from official releases
- [x] `postinstall` (`electron-builder install-app-deps`) passes — exercises the electron-builder binaries path the second pin was overriding
- [x] `npm run lint` — exit 0
- [x] `npm run typecheck` — exit 0
- [x] `npm run build:all` (dual-target web + Electron) — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)