### PR TITLE
Add simulation observability, live traffic monitoring, and shared edge inspection

### DIFF
--- a/src/engine/__samples__/direct-client-server-clean.json
+++ b/src/engine/__samples__/direct-client-server-clean.json
@@ -1,0 +1,77 @@
+{
+  "version": "2.0.0",
+  "nodes": [
+    {
+      "id": "client",
+      "type": "serviceNode",
+      "position": { "x": 80, "y": 260 },
+      "data": {
+        "schemaVersion": 2,
+        "templateId": "client-user",
+        "componentType": "api-endpoint",
+        "structuralRole": "source",
+        "profile": "source",
+        "rendererType": "serviceNode",
+        "label": "Client App",
+        "subLabel": "Even (constant) source",
+        "iconKey": "monitor",
+        "source": {
+          "requestDistribution": [{ "type": "GET", "weight": 1, "sizeBytes": 1024 }],
+          "defaultWorkload": { "pattern": "constant", "baseRps": 120 }
+        }
+      }
+    },
+    {
+      "id": "api",
+      "type": "computeNode",
+      "position": { "x": 680, "y": 260 },
+      "data": {
+        "schemaVersion": 2,
+        "templateId": "backend-server",
+        "componentType": "microservice",
+        "structuralRole": "processor",
+        "profile": "compute-service",
+        "rendererType": "computeNode",
+        "label": "API Server",
+        "subLabel": "1 worker, near capacity",
+        "iconKey": "SERVER",
+        "sim": {
+          "queue": { "workers": 1, "capacity": 2, "discipline": "fifo" },
+          "processing": { "distribution": { "type": "constant", "value": 8 }, "timeout": 250 }
+        }
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "client-to-api",
+      "type": "packet",
+      "source": "client",
+      "target": "api",
+      "sourceHandle": "right-1-source",
+      "targetHandle": "left-1-target",
+      "animated": true,
+      "data": {
+        "protocol": "https",
+        "mode": "synchronous",
+        "latencyDistributionType": "constant",
+        "latencyValue": 9,
+        "bandwidth": 1000,
+        "maxConcurrentRequests": 200,
+        "packetLossRate": 0,
+        "errorRate": 0
+      }
+    }
+  ],
+  "scenario": {
+    "global": {
+      "simulationDuration": 15000,
+      "warmupDuration": 2000,
+      "seed": "sample-direct-client-server-clean",
+      "defaultTimeout": 1000,
+      "traceSampleRate": 0.05
+    },
+    "selectedSourceNodeId": "client",
+    "workloadOverride": { "pattern": "constant", "baseRps": 120 }
+  }
+}

--- a/src/engine/__samples__/direct-client-server-jitter.json
+++ b/src/engine/__samples__/direct-client-server-jitter.json
@@ -1,0 +1,78 @@
+{
+  "version": "2.0.0",
+  "nodes": [
+    {
+      "id": "client",
+      "type": "serviceNode",
+      "position": { "x": 80, "y": 260 },
+      "data": {
+        "schemaVersion": 2,
+        "templateId": "client-user",
+        "componentType": "api-endpoint",
+        "structuralRole": "source",
+        "profile": "source",
+        "rendererType": "serviceNode",
+        "label": "Client App",
+        "subLabel": "Even (constant) source",
+        "iconKey": "monitor",
+        "source": {
+          "requestDistribution": [{ "type": "GET", "weight": 1, "sizeBytes": 1024 }],
+          "defaultWorkload": { "pattern": "constant", "baseRps": 120 }
+        }
+      }
+    },
+    {
+      "id": "api",
+      "type": "computeNode",
+      "position": { "x": 680, "y": 260 },
+      "data": {
+        "schemaVersion": 2,
+        "templateId": "backend-server",
+        "componentType": "microservice",
+        "structuralRole": "processor",
+        "profile": "compute-service",
+        "rendererType": "computeNode",
+        "label": "API Server",
+        "subLabel": "1 worker, near capacity",
+        "iconKey": "SERVER",
+        "sim": {
+          "queue": { "workers": 1, "capacity": 2, "discipline": "fifo" },
+          "processing": { "distribution": { "type": "constant", "value": 8 }, "timeout": 250 }
+        }
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "client-to-api",
+      "type": "packet",
+      "source": "client",
+      "target": "api",
+      "sourceHandle": "right-1-source",
+      "targetHandle": "left-1-target",
+      "animated": true,
+      "data": {
+        "protocol": "https",
+        "mode": "synchronous",
+        "latencyDistributionType": "log-normal",
+        "latencyMu": 2.1,
+        "latencySigma": 0.35,
+        "bandwidth": 1000,
+        "maxConcurrentRequests": 200,
+        "packetLossRate": 0,
+        "errorRate": 0
+      }
+    }
+  ],
+  "scenario": {
+    "global": {
+      "simulationDuration": 15000,
+      "warmupDuration": 2000,
+      "seed": "sample-direct-client-server-jitter",
+      "defaultTimeout": 1000,
+      "traceSampleRate": 0.05
+    },
+    "selectedSourceNodeId": "client",
+    "workloadOverride": { "pattern": "constant", "baseRps": 120 }
+  }
+}

--- a/src/engine/analysis/output.ts
+++ b/src/engine/analysis/output.ts
@@ -3,7 +3,8 @@ import type {
   CanonicalEventRecord,
   DebugEvent,
   EventCountsByType,
-  RequestLifecycle
+  RequestLifecycle,
+  RequestOutcomeRecord
 } from '../core/event-stream'
 import { createEmptyEventCounts } from '../core/event-stream'
 import { MetricsCollector, PerEdgeMetrics, PerNodeMetrics, SimulationSummary } from '../metrics'
@@ -159,6 +160,12 @@ export interface SimulationOutput {
   eventLog: DebugEvent[] | null
   /** Lifecycle assembled for a focused debug request, when one was selected. */
   debuggedLifecycle: RequestLifecycle | null
+  /**
+   * Complete, unsampled per-request outcome ledger: one row per generated
+   * request keyed on terminal fate (success/timeout/rejected/connection_reset)
+   * plus in-flight survivors at cutoff. `Σ(rows by status) === requests generated`.
+   */
+  requestOutcomes: RequestOutcomeRecord[]
 }
 
 export function generateSimulationOutput(
@@ -175,6 +182,7 @@ export function generateSimulationOutput(
     eventLog?: DebugEvent[] | null
     debuggedLifecycle?: RequestLifecycle | null
     statusTimeline?: StatusWindow[]
+    requestOutcomes?: RequestOutcomeRecord[]
   }
 ): SimulationOutput {
   const summary = metrics.generateSummary(config.simulationDuration)
@@ -208,7 +216,8 @@ export function generateSimulationOutput(
     simulationDuration: config.simulationDuration,
     warmupDuration: config.warmupDuration,
     eventLog: debugData?.eventLog ?? null,
-    debuggedLifecycle: debugData?.debuggedLifecycle ?? null
+    debuggedLifecycle: debugData?.debuggedLifecycle ?? null,
+    requestOutcomes: debugData?.requestOutcomes ?? []
   }
 }
 

--- a/src/engine/core/event-stream.ts
+++ b/src/engine/core/event-stream.ts
@@ -24,6 +24,36 @@ export type TerminalRequestStatus = 'success' | 'timeout' | 'rejected' | 'connec
 export type AdmissionDecisionStatus = 'accepted' | 'queued' | 'rejected' | 'timed-out'
 export type DebugEventStatus = 'info' | 'success' | 'timeout' | 'rejected' | 'failure'
 
+/**
+ * Per-request final fate. `in-flight` is not a terminal status — it marks a
+ * request that had not finished (neither completed nor failed) when the run hit
+ * its cutoff. It exists so the outcome log can account for every generated
+ * request explicitly instead of letting unfinished ones silently vanish.
+ */
+export type RequestOutcomeStatus = TerminalRequestStatus | 'in-flight'
+
+/**
+ * A complete, unsampled ledger row for one request's outcome. Sourced from the
+ * engine's terminal funnel (`markRequestTerminal`) plus the in-flight survivors
+ * at cutoff, so `Σ(records by status) === requests generated`. This is the
+ * canonical source for the results-tray Event Log: one row per request, keyed on
+ * terminal fate, carrying attempt count so the retry signal survives the collapse.
+ */
+export interface RequestOutcomeRecord {
+  requestId: string
+  status: RequestOutcomeStatus
+  /** Wall-clock-independent sim time (ms) the request was generated. */
+  createdAtMs: number
+  /** Sim time (ms) the request reached its terminal status; null while in flight. */
+  terminalAtMs: number | null
+  /** Node the request terminated at, or the last node it reached if still in flight. */
+  nodeId: string | null
+  /** Total processing attempts for this request (retries + 1). */
+  attempts: number
+  /** End-to-end latency (ms) for terminal requests; null while in flight. */
+  latencyMs: number | null
+}
+
 export type JsonSafeValue =
   | string
   | number

--- a/src/engine/engine.test.ts
+++ b/src/engine/engine.test.ts
@@ -236,6 +236,63 @@ describe('SimulationEngine', () => {
     expect(engine.getEventCountsByType()['request-rejected']).toBeGreaterThan(0)
   })
 
+  it('emits a complete per-request outcome ledger that conserves against generated requests', () => {
+    // Fast service so requests actually complete within the window, but arrival
+    // rate well above throughput so the tiny queue also rejects — a mix of fates.
+    const worker: ComponentNode = {
+      ...makeNode('worker'),
+      queue: { workers: 1, capacity: 1, discipline: 'fifo' },
+      processing: { distribution: { type: 'constant', value: 1 }, timeout: 1_000 }
+    }
+    const topology = makeTopology({
+      global: { simulationDuration: 40, defaultTimeout: 1_000, traceSampleRate: 1 },
+      nodes: [makeNode('source'), worker],
+      edges: [makeEdge('source-to-worker', 'source', 'worker')],
+      workload: {
+        sourceNodeId: 'source',
+        pattern: 'constant',
+        baseRps: 2_000,
+        requestDistribution: [{ type: 'GET', weight: 1, sizeBytes: 100 }]
+      }
+    })
+    const output = new SimulationEngine(topology).run()
+
+    const generated = output.eventStream.filter(
+      (event) => event.type === 'request-generated'
+    ).length
+    expect(generated).toBeGreaterThan(0)
+
+    // Every generated request appears exactly once, with a unique id.
+    const ids = new Set(output.requestOutcomes.map((row) => row.requestId))
+    expect(ids.size).toBe(output.requestOutcomes.length)
+    expect(output.requestOutcomes.length).toBe(generated)
+
+    // This saturating run must actually exercise both success and rejection.
+    const byStatus = output.requestOutcomes.reduce<Record<string, number>>((acc, row) => {
+      acc[row.status] = (acc[row.status] ?? 0) + 1
+      return acc
+    }, {})
+    expect(byStatus.success ?? 0).toBeGreaterThan(0)
+    expect(byStatus.rejected ?? 0).toBeGreaterThan(0)
+
+    // Conservation: Σ(rows by status, including in-flight) === generated.
+    const summed = Object.values(byStatus).reduce((sum, count) => sum + count, 0)
+    expect(summed).toBe(generated)
+
+    // Terminal rows carry a latency and a resolved node; in-flight rows carry neither.
+    for (const row of output.requestOutcomes) {
+      expect(row.attempts).toBeGreaterThanOrEqual(1)
+      if (row.status === 'in-flight') {
+        expect(row.terminalAtMs).toBeNull()
+        expect(row.latencyMs).toBeNull()
+      } else {
+        expect(row.terminalAtMs).not.toBeNull()
+        expect(row.latencyMs).not.toBeNull()
+        expect(row.latencyMs ?? -1).toBeGreaterThanOrEqual(0)
+      }
+    }
+  })
+
   it('records trait decisions and rejects requests when a beforeArrival trait rejects them', () => {
     const rejectAllTrait: NodeBehaviourTrait = {
       name: 'test.reject-all',
@@ -1057,6 +1114,40 @@ describe('SimulationEngine', () => {
     expect(Number(arrivalEvent?.timestampUs)).toBeLessThan(10_100)
   })
 
+  it('amortizes protocol overhead for streaming edges', () => {
+    const makeOutput = (mode: EdgeDefinition['mode']) =>
+      new SimulationEngine(
+        makeTopology({
+          global: { simulationDuration: 20, defaultTimeout: 1_000, traceSampleRate: 1 },
+          nodes: [makeNode('source'), makeNode('dst')],
+          edges: [
+            makeEdge('source-to-dst', 'source', 'dst', {
+              mode,
+              protocol: 'websocket',
+              latency: { distribution: { type: 'constant', value: 0 }, pathType: 'same-dc' }
+            })
+          ],
+          workload: {
+            sourceNodeId: 'source',
+            pattern: 'constant',
+            baseRps: 1,
+            requestDistribution: [{ type: 'GET', weight: 1, sizeBytes: 100 }]
+          }
+        })
+      ).run()
+
+    const syncArrival = makeOutput('synchronous').eventStream.find(
+      (event) => event.type === 'request-arrived'
+    )
+    const streamingArrival = makeOutput('streaming').eventStream.find(
+      (event) => event.type === 'request-arrived'
+    )
+
+    expect(Number(syncArrival?.timestampUs)).toBeGreaterThan(90)
+    expect(Number(streamingArrival?.timestampUs)).toBeLessThan(40)
+    expect(Number(streamingArrival?.timestampUs)).toBeLessThan(Number(syncArrival?.timestampUs))
+  })
+
   it('uses path-type-derived latency profiles when the edge is still on defaults', () => {
     const makeDerivedEdge = (id: string, pathType: EdgeDefinition['latency']['pathType']) =>
       makeEdge(id, 'source', 'dst', {
@@ -1113,39 +1204,6 @@ describe('SimulationEngine', () => {
     )
 
     expect(crossRegionArrival).toBeGreaterThan(sameRackArrival)
-  })
-  it('amortizes protocol overhead for streaming edges', () => {
-    const makeOutput = (mode: EdgeDefinition['mode']) =>
-      new SimulationEngine(
-        makeTopology({
-          global: { simulationDuration: 20, defaultTimeout: 1_000, traceSampleRate: 1 },
-          nodes: [makeNode('source'), makeNode('dst')],
-          edges: [
-            makeEdge('source-to-dst', 'source', 'dst', {
-              mode,
-              protocol: 'websocket',
-              latency: { distribution: { type: 'constant', value: 0 }, pathType: 'same-dc' }
-            })
-          ],
-          workload: {
-            sourceNodeId: 'source',
-            pattern: 'constant',
-            baseRps: 1,
-            requestDistribution: [{ type: 'GET', weight: 1, sizeBytes: 100 }]
-          }
-        })
-      ).run()
-
-    const syncArrival = makeOutput('synchronous').eventStream.find(
-      (event) => event.type === 'request-arrived'
-    )
-    const streamingArrival = makeOutput('streaming').eventStream.find(
-      (event) => event.type === 'request-arrived'
-    )
-
-    expect(Number(syncArrival?.timestampUs)).toBeGreaterThan(90)
-    expect(Number(streamingArrival?.timestampUs)).toBeLessThan(40)
-    expect(Number(streamingArrival?.timestampUs)).toBeLessThan(Number(syncArrival?.timestampUs))
   })
 
   it('forks requests on async fan-out so each branch has a distinct request id', () => {

--- a/src/engine/engine.test.ts
+++ b/src/engine/engine.test.ts
@@ -1114,6 +1114,39 @@ describe('SimulationEngine', () => {
 
     expect(crossRegionArrival).toBeGreaterThan(sameRackArrival)
   })
+  it('amortizes protocol overhead for streaming edges', () => {
+    const makeOutput = (mode: EdgeDefinition['mode']) =>
+      new SimulationEngine(
+        makeTopology({
+          global: { simulationDuration: 20, defaultTimeout: 1_000, traceSampleRate: 1 },
+          nodes: [makeNode('source'), makeNode('dst')],
+          edges: [
+            makeEdge('source-to-dst', 'source', 'dst', {
+              mode,
+              protocol: 'websocket',
+              latency: { distribution: { type: 'constant', value: 0 }, pathType: 'same-dc' }
+            })
+          ],
+          workload: {
+            sourceNodeId: 'source',
+            pattern: 'constant',
+            baseRps: 1,
+            requestDistribution: [{ type: 'GET', weight: 1, sizeBytes: 100 }]
+          }
+        })
+      ).run()
+
+    const syncArrival = makeOutput('synchronous').eventStream.find(
+      (event) => event.type === 'request-arrived'
+    )
+    const streamingArrival = makeOutput('streaming').eventStream.find(
+      (event) => event.type === 'request-arrived'
+    )
+
+    expect(Number(syncArrival?.timestampUs)).toBeGreaterThan(90)
+    expect(Number(streamingArrival?.timestampUs)).toBeLessThan(40)
+    expect(Number(streamingArrival?.timestampUs)).toBeLessThan(Number(syncArrival?.timestampUs))
+  })
 
   it('forks requests on async fan-out so each branch has a distinct request id', () => {
     const topology = makeTopology({

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -1226,7 +1226,10 @@ export class SimulationEngine {
       : edge.latency.distribution
     const propagationMs = Math.max(0, this.distributions.fromConfig(latencyDistribution))
     const transmissionMs = request.sizeBytes / (edge.bandwidth * 125)
-    const protocolOverheadMs = getProtocolLatencyOverheadMs(edge.protocol)
+    // Streaming links reuse an already-open channel, so only a small framing
+    // cost remains on each message instead of the full per-request setup cost.
+    const protocolOverheadMs =
+      getProtocolLatencyOverheadMs(edge.protocol) * (edge.mode === 'streaming' ? 0.25 : 1)
     const utilization =
       edge.maxConcurrentRequests > 0
         ? Math.min(0.98, activeTransfers / edge.maxConcurrentRequests)

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -15,6 +15,7 @@ import {
   EventStreamRecorder,
   NodeSnapshot,
   RequestLifecycle,
+  RequestOutcomeRecord,
   TerminalRequestStatus,
   eventInputFromSimulationEvent,
   projectToDebugEvent
@@ -132,6 +133,12 @@ export class SimulationEngine {
 
   private readonly requestById = new Map<string, Request>()
   private readonly terminalStatusByRequestId = new Map<string, TerminalRequestStatus>()
+  /**
+   * Complete, unsampled per-request outcome ledger, filled at the single
+   * `markRequestTerminal` funnel. In-flight survivors are appended at cutoff in
+   * {@link generateResults}, so every generated request is accounted for exactly once.
+   */
+  private readonly requestOutcomeById = new Map<string, RequestOutcomeRecord>()
   private readonly simulationDurationUs: bigint
   private readonly snapshotIntervalUs = secToMicro(1)
 
@@ -1453,7 +1460,55 @@ export class SimulationEngine {
   private markRequestTerminal(request: Request, status: TerminalRequestStatus): void {
     request.metadata.__terminal = status
     this.terminalStatusByRequestId.set(request.id, status)
+    // First terminal wins: races are already tombstoned upstream, but guard so a
+    // stray second transition can never double-count a request in the ledger.
+    if (!this.requestOutcomeById.has(request.id)) {
+      const createdAtMs = microToMs(request.createdAt)
+      const terminalAtMs = microToMs(this.clock)
+      this.requestOutcomeById.set(request.id, {
+        requestId: request.id,
+        status,
+        createdAtMs,
+        terminalAtMs,
+        nodeId: request.path.length > 0 ? request.path[request.path.length - 1] : null,
+        attempts: (request.retryCount ?? 0) + 1,
+        latencyMs: Math.max(0, terminalAtMs - createdAtMs)
+      })
+    }
     this.requestById.delete(request.id)
+  }
+
+  /**
+   * Snapshot in-flight survivors at cutoff as explicit `in-flight` outcome rows,
+   * then return the full ledger sorted by terminal time (in-flight last, ordered
+   * by creation). Requests still in {@link requestById} never reached
+   * `markRequestTerminal`, so they are neither completed nor failed — surfacing
+   * them keeps the log honest instead of letting arrival/completion counts differ
+   * with no visible explanation.
+   */
+  private buildRequestOutcomes(): RequestOutcomeRecord[] {
+    for (const request of this.requestById.values()) {
+      if (this.requestOutcomeById.has(request.id)) {
+        continue
+      }
+      this.requestOutcomeById.set(request.id, {
+        requestId: request.id,
+        status: 'in-flight',
+        createdAtMs: microToMs(request.createdAt),
+        terminalAtMs: null,
+        nodeId: request.path.length > 0 ? request.path[request.path.length - 1] : null,
+        attempts: (request.retryCount ?? 0) + 1,
+        latencyMs: null
+      })
+    }
+
+    return [...this.requestOutcomeById.values()].sort((a, b) => {
+      const aKey = a.terminalAtMs ?? Number.POSITIVE_INFINITY
+      const bKey = b.terminalAtMs ?? Number.POSITIVE_INFINITY
+      if (aKey !== bKey) return aKey - bKey
+      if (a.createdAtMs !== b.createdAtMs) return a.createdAtMs - b.createdAtMs
+      return a.requestId.localeCompare(b.requestId)
+    })
   }
 
   private takeSnapshot(): TimeSeriesSnapshot {
@@ -1517,7 +1572,8 @@ export class SimulationEngine {
       {
         eventLog,
         debuggedLifecycle,
-        statusTimeline: this.buildStatusTimeline()
+        statusTimeline: this.buildStatusTimeline(),
+        requestOutcomes: this.buildRequestOutcomes()
       }
     )
   }

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -328,3 +328,33 @@ body.react-flow-connecting .custom-target-handle.magnetic-snap-winner {
 .connection-snap-ring {
   animation: connection-snap-ring 0.75s ease-out infinite;
 }
+
+/* Busiest-node cards: grow/collapse their own height so neighbours slide up to
+   fill a departing card instead of leaving a hole. The resting state is visible,
+   so a dropped/throttled frame can never leave a card stuck invisible or collapsed. */
+@keyframes nss-node-card-enter {
+  from {
+    opacity: 0;
+    max-height: 0;
+    margin-bottom: 0;
+  }
+  to {
+    opacity: 1;
+    max-height: 3.25rem;
+    margin-bottom: 0.5rem;
+  }
+}
+
+.nss-node-card-enter {
+  animation: nss-node-card-enter 220ms ease-out;
+}
+
+.nss-node-card-exit {
+  opacity: 0 !important;
+  max-height: 0 !important;
+  margin-bottom: 0 !important;
+  transition:
+    opacity 180ms ease-out,
+    max-height 220ms ease-out,
+    margin-bottom 220ms ease-out;
+}

--- a/src/renderer/src/components/canvas/CanvasLegend.tsx
+++ b/src/renderer/src/components/canvas/CanvasLegend.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useRef, useState } from 'react'
+import { clsx } from 'clsx'
+import { Info } from 'lucide-react'
+import { useShallow } from 'zustand/react/shallow'
+import {
+  CANVAS_PRE_RUN_LEGEND_NOTE,
+  CANVAS_RUNTIME_LEGEND_SECTIONS,
+  type CanvasLegendItem
+} from '@renderer/config/canvasLegendConfig'
+import { getMetricLensLabel } from '@renderer/config/metricLensConfig'
+import { METRIC_LENS_TOOLTIPS } from '@renderer/config/tooltipCatalog'
+import useStore from '@renderer/store/useStore'
+
+function LegendSwatch({ item }: { item: CanvasLegendItem }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-nss-border bg-nss-panel px-2 py-1 text-[11px] text-nss-text">
+      <span
+        className={clsx(
+          'shrink-0',
+          item.shape === 'dot' ? 'h-2 w-2 rounded-full' : 'h-2.5 w-2.5 rounded-[4px]',
+          item.swatchClassName
+        )}
+      />
+      <span>{item.label}</span>
+    </span>
+  )
+}
+
+export function CanvasLegend() {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const { metricLens, hasRuntimeMetrics } = useStore(
+    useShallow((state) => ({
+      metricLens: state.metricLens,
+      hasRuntimeMetrics: Object.keys(state.simulationMetricsByNode).length > 0
+    }))
+  )
+  const lensLabel = getMetricLensLabel(metricLens)
+
+  useEffect(() => {
+    if (!open) return
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handlePointerDown)
+    document.addEventListener('keydown', handleEscape)
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+      document.removeEventListener('keydown', handleEscape)
+    }
+  }, [open])
+
+  return (
+    <div ref={containerRef} className="absolute top-4 right-4 z-10 flex flex-col items-end gap-2">
+      <button
+        type="button"
+        aria-label={open ? 'Close legend' : 'Open legend'}
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+        className={clsx(
+          'inline-flex h-8 w-8 items-center justify-center rounded-full border bg-nss-surface/95 shadow-lg backdrop-blur transition-colors focus:outline-none focus:ring-2 focus:ring-nss-primary/50',
+          open
+            ? 'border-nss-primary/50 text-nss-primary'
+            : 'border-nss-border text-nss-muted hover:text-nss-text'
+        )}
+      >
+        <Info size={14} />
+      </button>
+
+      {open ? (
+        <aside className="w-[280px] max-w-[calc(100vw-2rem)] rounded-2xl border border-nss-border bg-nss-surface/95 shadow-lg backdrop-blur">
+          <div className="border-b border-nss-border px-3 py-2.5">
+            <div className="mt-1 text-xs font-semibold text-nss-text">{lensLabel} lens</div>
+            <div className="mt-1 text-[11px] leading-snug text-nss-muted">
+              {METRIC_LENS_TOOLTIPS[metricLens]}
+            </div>
+          </div>
+
+          <div className="space-y-3 px-3 py-3">
+            {hasRuntimeMetrics ? (
+              CANVAS_RUNTIME_LEGEND_SECTIONS.map((section) => (
+                <section key={section.title} className="space-y-1.5">
+                  <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-nss-muted">
+                    {section.title}
+                  </div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {section.items.map((item) => (
+                      <LegendSwatch key={`${section.title}-${item.label}`} item={item} />
+                    ))}
+                  </div>
+                </section>
+              ))
+            ) : (
+              <p className="text-[11px] leading-snug text-nss-muted">
+                {CANVAS_PRE_RUN_LEGEND_NOTE}
+              </p>
+            )}
+          </div>
+        </aside>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/canvas/FlowCanvas.tsx
+++ b/src/renderer/src/components/canvas/FlowCanvas.tsx
@@ -13,13 +13,12 @@ import ReactFlow, {
   Node
 } from 'reactflow'
 import 'reactflow/dist/style.css'
-import { EdgeSimulationData } from '@renderer/types/ui'
-import type { CanvasNodeDataV2 } from '../../../../engine/catalog/nodeSpecTypes'
 
 import EmptyFlowState from '../ui/EmptyFlowState'
+import { CanvasLegend } from './CanvasLegend'
 import { MetricLensSwitcher } from './MetricLensSwitcher'
 // Hooks & Config
-import { EdgePropertiesPanel, EdgePropertiesPanelValue } from '../ui/EdgePropertiesPanel'
+import useStore from '@renderer/store/useStore'
 
 import { useFlowStore } from './hooks/useFlowStore'
 import { useFlowDnD } from './hooks/useFlowDnD'
@@ -36,19 +35,11 @@ interface FlowCanvasProps {
 
 const FlowCanvasInternal = ({ showMetricLens = false, onNodeDoubleClick }: FlowCanvasProps) => {
   const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance | null>(null)
-  const [selectedEdge, setSelectedEdge] = useState<Edge | null>(null)
 
-  const {
-    nodes,
-    edges,
-    onNodesChange,
-    onEdgesChange,
-    onConnect,
-    addNode,
-    setNodes,
-    setEdges,
-    updateEdgeData
-  } = useFlowStore()
+  const { nodes, edges, onNodesChange, onEdgesChange, onConnect, addNode, setNodes, setEdges } =
+    useFlowStore()
+
+  const selectGraphElements = useStore((state) => state.selectGraphElements)
 
   const { edgeTypes, defaultEdgeOptions } = useFlowConfig()
 
@@ -89,46 +80,19 @@ const FlowCanvasInternal = ({ showMetricLens = false, onNodeDoubleClick }: FlowC
     prevNodeCount.current = nodes.length
   }, [nodes.length, reactFlowInstance])
 
-  const onEdgeClick = useCallback((event: React.MouseEvent, edge: Edge) => {
-    event.stopPropagation()
-    setSelectedEdge(edge)
-  }, [])
+  // Edge selection lives in the shared store so the right-hand inspector
+  // (PropertiesPanel) can render its properties, exactly like node config.
+  const onEdgeClick = useCallback(
+    (event: React.MouseEvent, edge: Edge) => {
+      event.stopPropagation()
+      selectGraphElements({ edgeId: edge.id })
+    },
+    [selectGraphElements]
+  )
 
   const onPaneClick = useCallback(() => {
-    setSelectedEdge(null)
-  }, [])
-
-  const handleEdgePropertiesChange = useCallback(
-    (patch: Partial<EdgePropertiesPanelValue>) => {
-      if (!selectedEdge) return
-
-      const { label, ...dataPatch } = patch
-      const hasDataPatch = Object.keys(dataPatch).length > 0
-
-      updateEdgeData(selectedEdge.id, {
-        ...(label !== undefined ? { label } : {}),
-        ...(hasDataPatch ? { data: dataPatch as Partial<EdgeSimulationData> } : {})
-      })
-
-      setSelectedEdge((prev) =>
-        prev
-          ? {
-              ...prev,
-              ...(label !== undefined ? { label } : {}),
-              ...(hasDataPatch
-                ? {
-                    data: {
-                      ...((prev.data as Record<string, unknown> | undefined) ?? {}),
-                      ...dataPatch
-                    }
-                  }
-                : {})
-            }
-          : null
-      )
-    },
-    [selectedEdge, updateEdgeData]
-  )
+    selectGraphElements({})
+  }, [selectGraphElements])
 
   return (
     <div style={{ width: '100%', height: '100%' }} className="bg-nss-bg relative">
@@ -162,30 +126,10 @@ const FlowCanvasInternal = ({ showMetricLens = false, onNodeDoubleClick }: FlowC
         <MiniMap className="!bg-nss-surface !border-nss-border" />
       </ReactFlow>
       {!isEmpty && showMetricLens && <MetricLensSwitcher />}
+      {!isEmpty && showMetricLens && <CanvasLegend />}
 
       {/* Empty State */}
       <EmptyFlowState isEmpty={isEmpty} />
-
-      {selectedEdge && (
-        <EdgePropertiesPanel
-          sourceNodeData={
-            nodes.find((node) => node.id === selectedEdge.source)?.data as
-              | CanvasNodeDataV2
-              | undefined
-          }
-          targetNodeData={
-            nodes.find((node) => node.id === selectedEdge.target)?.data as
-              | CanvasNodeDataV2
-              | undefined
-          }
-          value={{
-            label: (selectedEdge.label as string) || '',
-            ...(((selectedEdge.data as EdgeSimulationData | undefined) ?? {}) as EdgeSimulationData)
-          }}
-          onChange={handleEdgePropertiesChange}
-          onClose={() => setSelectedEdge(null)}
-        />
-      )}
     </div>
   )
 }

--- a/src/renderer/src/components/canvas/MetricLensSwitcher.tsx
+++ b/src/renderer/src/components/canvas/MetricLensSwitcher.tsx
@@ -1,24 +1,15 @@
 import { useEffect } from 'react'
 import { clsx } from 'clsx'
 import { useShallow } from 'zustand/react/shallow'
-import type { MetricLens, PreRunMetricLens, RuntimeMetricLens } from '@renderer/types/ui'
+import type { MetricLens } from '@renderer/types/ui'
+import {
+  PRE_RUN_LENSES,
+  RUNTIME_LENSES,
+  type MetricLensOption
+} from '@renderer/config/metricLensConfig'
+import { METRIC_LENS_TOOLTIPS } from '@renderer/config/tooltipCatalog'
+import { HoverTooltip } from '@renderer/components/ui/Tooltip'
 import useStore from '@renderer/store/useStore'
-
-type MetricLensOption<T extends MetricLens = MetricLens> = { id: T; label: string }
-
-const PRE_RUN_LENSES: Array<MetricLensOption<PreRunMetricLens>> = [
-  { id: 'concurrency', label: 'Concurrency' },
-  { id: 'queueCapacity', label: 'Queue Capacity' },
-  { id: 'timeout', label: 'Timeout' }
-]
-
-const RUNTIME_LENSES: Array<MetricLensOption<RuntimeMetricLens>> = [
-  { id: 'traffic', label: 'Traffic' },
-  { id: 'saturation', label: 'Saturation' },
-  { id: 'latency', label: 'Latency' },
-  { id: 'errors', label: 'Errors' },
-  { id: 'throughput', label: 'Throughput' }
-]
 
 function includesLens(lenses: Array<MetricLensOption>, metricLens: MetricLens): boolean {
   return lenses.some((lens) => lens.id === metricLens)
@@ -49,19 +40,23 @@ export const MetricLensSwitcher = () => {
   return (
     <div className="absolute top-4 left-4 z-10 flex gap-1.5 p-1 rounded-full bg-nss-surface border border-nss-border shadow-lg">
       {lenses.map((lens) => (
-        <button
-          key={lens.id}
-          type="button"
-          onClick={() => setMetricLens(lens.id)}
-          className={clsx(
-            'px-3 py-1 text-xs font-semibold rounded-full transition-colors',
-            activeLens === lens.id
-              ? 'bg-nss-primary/20 border border-nss-primary/50 text-nss-primary'
-              : 'border border-transparent text-nss-muted hover:text-nss-text'
+        <HoverTooltip key={lens.id} content={METRIC_LENS_TOOLTIPS[lens.id]} width={240}>
+          {(triggerProps) => (
+            <button
+              type="button"
+              onClick={() => setMetricLens(lens.id)}
+              className={clsx(
+                'px-3 py-1 text-xs font-semibold rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-nss-primary/50',
+                activeLens === lens.id
+                  ? 'bg-nss-primary/20 border border-nss-primary/50 text-nss-primary'
+                  : 'border border-transparent text-nss-muted hover:text-nss-text'
+              )}
+              {...triggerProps}
+            >
+              {lens.label}
+            </button>
           )}
-        >
-          {lens.label}
-        </button>
+        </HoverTooltip>
       ))}
     </div>
   )

--- a/src/renderer/src/components/canvas/PacketEdge.tsx
+++ b/src/renderer/src/components/canvas/PacketEdge.tsx
@@ -1,10 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { BaseEdge, getSmoothStepPath, EdgeProps, EdgeLabelRenderer } from 'reactflow'
 import type { AnyNodeData, EdgeSimulationData } from '@renderer/types/ui'
-import {
-  getEdgeModePresentation,
-  inferCanvasEdgeMode
-} from '@renderer/config/edgeSemantics'
+import { getEdgeModePresentation, inferCanvasEdgeMode } from '@renderer/config/edgeSemantics'
 import useStore, { type EdgeFlowRunConfig, type EdgeFlowState } from '@renderer/store/useStore'
 import { getRoutingPreviewSnapshot } from '@renderer/utils/routingStrategyPreview'
 import { failureRateLevelFromRatio } from '@renderer/utils/failureRatePresentation'

--- a/src/renderer/src/components/canvas/PacketEdge.tsx
+++ b/src/renderer/src/components/canvas/PacketEdge.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { BaseEdge, getSmoothStepPath, EdgeProps, EdgeLabelRenderer } from 'reactflow'
+import type { AnyNodeData, EdgeSimulationData } from '@renderer/types/ui'
+import {
+  getEdgeModePresentation,
+  inferCanvasEdgeMode
+} from '@renderer/config/edgeSemantics'
 import useStore, { type EdgeFlowRunConfig, type EdgeFlowState } from '@renderer/store/useStore'
 import { getRoutingPreviewSnapshot } from '@renderer/utils/routingStrategyPreview'
 import { failureRateLevelFromRatio } from '@renderer/utils/failureRatePresentation'
@@ -102,6 +107,7 @@ function packetSpeedJitter(
 export const PacketEdge = ({
   id,
   source,
+  target,
   sourceX,
   sourceY,
   targetX,
@@ -111,6 +117,7 @@ export const PacketEdge = ({
   style = {},
   markerEnd,
   label,
+  data,
   selected
 }: EdgeProps) => {
   const [edgePath, labelX, labelY] = getSmoothStepPath({
@@ -137,6 +144,10 @@ export const PacketEdge = ({
   const nodes = useStore((state) => state.nodes)
   const edges = useStore((state) => state.edges)
   const metricsByNode = useStore((state) => state.simulationMetricsByNode)
+  const targetNodeData = nodes.find((node) => node.id === target)?.data as AnyNodeData | undefined
+  const edgeData = (data ?? {}) as EdgeSimulationData
+  const edgeMode = inferCanvasEdgeMode(edgeData, targetNodeData)
+  const edgeModePresentation = getEdgeModePresentation(edgeMode)
   const routingPreview = useMemo(() => {
     if (!routingVisualization || routingVisualization.sourceNodeId !== source) return null
 
@@ -293,6 +304,14 @@ export const PacketEdge = ({
             ? 'text-nss-warning'
             : 'text-nss-primary'
   ].join(' ')
+  const showModeBadge = selected || edgeMode !== 'synchronous'
+  const modeBadgeTitle = [
+    `${edgeModePresentation.title}: ${edgeModePresentation.summary}`,
+    edgeModePresentation.simulationEffect,
+    edgeModePresentation.note
+  ]
+    .filter(Boolean)
+    .join(' ')
 
   const pointForProgress = (progress: number) => {
     if (!pathRef.current || pathLength <= 0) {
@@ -324,12 +343,12 @@ export const PacketEdge = ({
         style={{
           ...style,
           strokeWidth: trafficStrokeWidth,
+          strokeDasharray: edgeModePresentation.strokeDasharray,
           stroke: isRoutingPreviewEdge
             ? 'var(--nss-border-high)'
             : selected
               ? FLOW_PRIMARY_COLOR
               : (failureStroke ?? 'var(--nss-border-high)'),
-          strokeDasharray: 'none',
           opacity: isRoutingPreviewEdge
             ? routingPreview?.isSelected
               ? 1
@@ -414,7 +433,7 @@ export const PacketEdge = ({
         style={{ pointerEvents: 'all', ...(selected ? { opacity: 1 } : {}) }}
       />
 
-      {(hasLabel || isRoutingPreviewEdge || flowStatus === 'complete' || flow) && (
+      {(hasLabel || showModeBadge || isRoutingPreviewEdge || flowStatus === 'complete' || flow) && (
         <EdgeLabelRenderer>
           <div
             style={{
@@ -425,6 +444,14 @@ export const PacketEdge = ({
             className="nodrag nopan"
           >
             <div className="flex flex-col items-center gap-1">
+              {showModeBadge && (
+                <span
+                  className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold leading-none tracking-wide ${edgeModePresentation.badgeClassName}`}
+                  title={modeBadgeTitle}
+                >
+                  {edgeModePresentation.shortLabel}
+                </span>
+              )}
               {hasLabel && (
                 <span className="bg-nss-bg px-2 py-0.5 text-[11px] font-bold uppercase leading-none tracking-wide text-nss-text">
                   {label.toString()}

--- a/src/renderer/src/components/layout/WorkspaceLayout.tsx
+++ b/src/renderer/src/components/layout/WorkspaceLayout.tsx
@@ -189,6 +189,7 @@ export const WorkspaceLayout = () => {
   const { handleSave, handleOpen, loadFromData } = useFlowPersistence(confirmDiscardChanges)
 
   const selectedNodeId = nodes.find((n) => n.selected)?.id
+  const selectedEdgeId = edges.find((e) => e.selected)?.id
   const hasElectronCloseBridge = typeof window.nssimulator?.onCloseRequest === 'function'
   const handleLeftSidebarTabSelect = useCallback((tab: LibrarySidebarTab) => {
     setLeftSidebarTab(tab)
@@ -234,10 +235,18 @@ export const WorkspaceLayout = () => {
   }, [])
 
   useEffect(() => {
-    if (!selectedNodeId) {
+    if (!selectedNodeId && !selectedEdgeId) {
       setIsRightOpen(false)
     }
-  }, [selectedNodeId])
+  }, [selectedNodeId, selectedEdgeId])
+
+  // Selecting an edge opens the inspector on its properties, mirroring how
+  // double-clicking a node opens the node config.
+  useEffect(() => {
+    if (selectedEdgeId) {
+      setIsRightOpen(true)
+    }
+  }, [selectedEdgeId])
 
   // Simulation
   const sim = useSimulation()
@@ -503,6 +512,8 @@ export const WorkspaceLayout = () => {
                         stopped={sim.stopped}
                         progress={sim.progress}
                         eventsProcessed={sim.eventsProcessed}
+                        runStartedAtMs={sim.runStartedAtMs}
+                        snapshot={sim.snapshot}
                         results={sim.results}
                         error={sim.error}
                         runContext={lastRunContext}

--- a/src/renderer/src/components/library/LibrarySidebar.tsx
+++ b/src/renderer/src/components/library/LibrarySidebar.tsx
@@ -306,7 +306,7 @@ function ScenarioCard({
             <p className="text-[10px] font-semibold uppercase tracking-wide text-nss-muted">
               {scenario.subtitle}
             </p>
-            <p className="mt-1 whitespace-pre-wrap font-mono text-[11px] leading-relaxed text-nss-text">
+            <p className="mt-1 whitespace-pre-wrap text-[11px] leading-relaxed text-nss-text">
               {scenario.diagram}
             </p>
           </div>

--- a/src/renderer/src/components/nodes/ComputeNode.tsx
+++ b/src/renderer/src/components/nodes/ComputeNode.tsx
@@ -11,7 +11,8 @@ import { useFlowStore } from '@renderer/components/canvas/hooks/useFlowStore'
 import { NodeMetricContent } from './NodeMetricContent'
 import {
   NODE_HEALTH_STYLES,
-  getEffectiveNodeStatus,
+  getRuntimeCapacityStyle,
+  getRuntimeReliabilityStatus,
   getIdentityChip,
   getLensCard,
   getPreRunMetric,
@@ -39,6 +40,11 @@ const ComputeNode = ({ id, data, selected }: NodeProps<ComputeNodeData>) => {
     utilization,
     queueDepth,
     errorRate,
+    postWarmupArrived,
+    successLatencySamples,
+    timeToErrorSamples,
+    latencyWindowErrorRate,
+    timeToErrorByCause,
     postWarmupRejected,
     postWarmupTimedOut,
     hasRuntime,
@@ -47,20 +53,30 @@ const ComputeNode = ({ id, data, selected }: NodeProps<ComputeNodeData>) => {
   const lens = useMetricLens()
   const lensCard = hasRuntime && lens !== 'traffic' ? getLensCard(lens, data, metrics) : null
   const preRunMetric = isPreRunMetricLens(lens) ? getPreRunMetric(lens, data) : null
-  const status = getEffectiveNodeStatus(data, { utilization, errorRate, queueDepth }, hasRuntime)
-  const isOverloaded = status === 'critical'
+  const reliabilityStatus = getRuntimeReliabilityStatus(
+    'healthy',
+    {
+      postWarmupArrived,
+      successLatencySamples,
+      timeToErrorSamples,
+      latencyWindowErrorRate,
+      timeToErrorByCause,
+      errorRate
+    },
+    hasRuntime
+  )
+  const capacityStyle = getRuntimeCapacityStyle({ utilization, queueDepth }, hasRuntime)
   const isInactive = isRuntimeNodeInactive(hasRuntime, active)
   const safeColor = theme.bg || 'bg-nss-primary'
 
   const containerClassName = useMemo(() => {
     const base = 'group relative min-w-[180px] bg-nss-surface rounded-lg border-2'
-    const statusStyle = NODE_HEALTH_STYLES[status]
     if (isInactive) return `${base} border-nss-border opacity-40 grayscale`
     if (selected) {
-      return `${base} ${statusStyle.border} ring-2 ${statusStyle.ring} ${statusStyle.shadow}`
+      return `${base} ${capacityStyle.border} ring-2 ${capacityStyle.ring} ${capacityStyle.shadow}`
     }
-    return `${base} ${statusStyle.border} ${statusStyle.shadow}`
-  }, [isInactive, selected, status])
+    return `${base} ${capacityStyle.border} ${capacityStyle.shadow}`
+  }, [capacityStyle, isInactive, selected])
 
   return (
     <BaseNode id={id} selected={selected} containerClassName={containerClassName}>
@@ -70,11 +86,7 @@ const ComputeNode = ({ id, data, selected }: NodeProps<ComputeNodeData>) => {
             <div
               className={`
                 p-2 rounded-md flex items-center justify-center shrink-0
-                ${
-                  isOverloaded
-                    ? 'bg-nss-danger/10 border-nss-danger/30 text-nss-danger'
-                    : `bg-opacity-50 ${safeColor}`
-                }
+                ${hasRuntime ? capacityStyle.iconAccent : `bg-opacity-50 ${safeColor}`}
               `}
             >
               <Icon size={16} />
@@ -88,11 +100,11 @@ const ComputeNode = ({ id, data, selected }: NodeProps<ComputeNodeData>) => {
                 textClassName="text-xs font-bold uppercase tracking-wide w-full"
                 inputClassName="text-xs font-bold uppercase tracking-wide w-full"
               />
-              <span className="text-[10px] text-nss-muted font-mono px-1">{data.profile}</span>
+              <span className="text-[10px] text-nss-muted px-1">{data.profile}</span>
             </div>
             <div
-              className={`w-2 h-2 rounded-full transition-colors duration-300 shrink-0 ${NODE_HEALTH_STYLES[status].dot}`}
-              title={`Status: ${status}`}
+              className={`w-2 h-2 rounded-full transition-colors duration-300 shrink-0 ${NODE_HEALTH_STYLES[reliabilityStatus].dot}`}
+              title={`Reliability: ${reliabilityStatus}`}
             />
           </div>
 

--- a/src/renderer/src/components/nodes/LensMetricCard.tsx
+++ b/src/renderer/src/components/nodes/LensMetricCard.tsx
@@ -18,7 +18,7 @@ interface LensMetricCardProps {
  */
 export const LensMetricCard = ({ card }: LensMetricCardProps) => (
   <div>
-    <div className="flex items-baseline gap-1.5 font-mono">
+    <div className="flex items-baseline gap-1.5 tabular-nums">
       <span className="text-lg font-bold text-nss-text">{card.value}</span>
       <span className="text-xs text-nss-muted">{card.limit}</span>
       <span className={clsx('ml-auto text-sm', GLYPH_COLOR[card.tone])}>{card.glyph}</span>

--- a/src/renderer/src/components/nodes/NodeHeader.tsx
+++ b/src/renderer/src/components/nodes/NodeHeader.tsx
@@ -63,7 +63,7 @@ export const NodeHeader = memo(
         <div className="flex items-center gap-3 shrink-0">
           <div
             className={`w-2 h-2 rounded-full transition-colors duration-300 ${NODE_HEALTH_STYLES[status].dot}`}
-            title={`Status: ${status}`}
+            title={`Reliability: ${status}`}
           />
           {children}
         </div>

--- a/src/renderer/src/components/nodes/NodeMetricCell.tsx
+++ b/src/renderer/src/components/nodes/NodeMetricCell.tsx
@@ -1,20 +1,32 @@
+import { TooltipInfo } from '@renderer/components/ui/Tooltip'
+
 export function NodeMetricCell({
   label,
   value,
-  tone = 'text-nss-text'
+  tone = 'text-nss-text',
+  tooltip
 }: {
   label: string
   value: string
   tone?: string
+  tooltip?: string
 }) {
   return (
     <div className="min-w-0">
-      <div className="text-[9px] text-nss-muted uppercase tracking-wide font-semibold leading-tight">
-        {label}
+      <div className="flex items-center gap-1">
+        <div className="text-[9px] text-nss-muted uppercase tracking-wide font-semibold leading-tight">
+          {label}
+        </div>
+        {tooltip ? (
+          <TooltipInfo
+            label={`Explain ${label}`}
+            content={tooltip}
+            width={220}
+            className="h-3 w-3 text-[8px]"
+          />
+        ) : null}
       </div>
-      <div
-        className={`mt-1 font-mono text-[12px] leading-tight tabular-nums whitespace-nowrap ${tone}`}
-      >
+      <div className={`mt-1 text-[12px] leading-tight tabular-nums whitespace-nowrap ${tone}`}>
         {value}
       </div>
     </div>

--- a/src/renderer/src/components/nodes/RuntimeNodeMetrics.tsx
+++ b/src/renderer/src/components/nodes/RuntimeNodeMetrics.tsx
@@ -1,3 +1,4 @@
+import { RUNTIME_NODE_METRIC_TOOLTIPS } from '@renderer/config/tooltipCatalog'
 import { NodeMetricCell } from './NodeMetricCell'
 
 type RuntimeNodeMetricsProps = {
@@ -26,11 +27,13 @@ export function RuntimeNodeMetrics({
       <NodeMetricCell
         label="Completed / Received"
         value={`${fmtCount(completed)} / ${fmtCount(arrived)}`}
+        tooltip={RUNTIME_NODE_METRIC_TOOLTIPS.completedReceived}
       />
       <NodeMetricCell
         label="Rejected / Timed Out"
         value={`${fmtCount(rejected)} / ${fmtCount(timedOut)}`}
         tone={hasFailures ? 'text-nss-danger' : 'text-nss-success'}
+        tooltip={RUNTIME_NODE_METRIC_TOOLTIPS.rejectedTimedOut}
       />
     </div>
   )

--- a/src/renderer/src/components/nodes/SecurityNode.tsx
+++ b/src/renderer/src/components/nodes/SecurityNode.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from 'react'
+import { memo, useCallback, useMemo } from 'react'
 import { NodeProps } from 'reactflow'
 import { NodeHeader } from '@renderer/components/nodes/NodeHeader'
 import { NodeSettingsMenu } from '@renderer/components/nodes/NodeSettingsMenu'
@@ -11,7 +11,8 @@ import BaseNode from '@renderer/components/nodes/BaseNode'
 import { useFlowStore } from '@renderer/components/canvas/hooks/useFlowStore'
 import { NodeMetricContent } from './NodeMetricContent'
 import {
-  getEffectiveNodeStatus,
+  getRuntimeCapacityStyle,
+  getRuntimeReliabilityStatus,
   getIdentityChip,
   getLensCard,
   getPreRunMetric,
@@ -39,6 +40,11 @@ const SecurityNode = ({ id, data, selected }: NodeProps<SecurityNodeData>) => {
     errorRate,
     queueDepth,
     utilization,
+    postWarmupArrived,
+    successLatencySamples,
+    timeToErrorSamples,
+    latencyWindowErrorRate,
+    timeToErrorByCause,
     postWarmupRejected,
     postWarmupTimedOut,
     hasRuntime,
@@ -47,22 +53,43 @@ const SecurityNode = ({ id, data, selected }: NodeProps<SecurityNodeData>) => {
   const lens = useMetricLens()
   const lensCard = hasRuntime && lens !== 'traffic' ? getLensCard(lens, data, metrics) : null
   const preRunMetric = isPreRunMetricLens(lens) ? getPreRunMetric(lens, data) : null
-  const status = getEffectiveNodeStatus(data, { utilization, errorRate, queueDepth }, hasRuntime)
+  const reliabilityStatus = getRuntimeReliabilityStatus(
+    'healthy',
+    {
+      postWarmupArrived,
+      successLatencySamples,
+      timeToErrorSamples,
+      latencyWindowErrorRate,
+      timeToErrorByCause,
+      errorRate
+    },
+    hasRuntime
+  )
+  const capacityStyle = getRuntimeCapacityStyle({ utilization, queueDepth }, hasRuntime)
   const isInactive = isRuntimeNodeInactive(hasRuntime, active)
+  const containerClassName = useMemo(() => {
+    const base =
+      'group relative w-64 bg-nss-surface rounded-lg border transition-all duration-200 overflow-visible'
+    if (isInactive) return `${base} border-nss-border`
+    if (selected) {
+      return `${base} ${capacityStyle.border} ring-2 ${capacityStyle.ring} ${capacityStyle.shadow}`
+    }
+    return `${base} ${capacityStyle.border} ${capacityStyle.hoverBorder} ${capacityStyle.shadow}`
+  }, [capacityStyle, isInactive, selected])
 
   return (
     <BaseNode
       id={id}
       selected={selected}
       selectionVariant="warning"
-      healthStatus={isInactive ? undefined : status}
+      containerClassName={containerClassName}
     >
       {({ isMenuOpen, onMenuClose, onMenuToggle }) => (
         <div className={isInactive ? 'opacity-40 grayscale' : undefined}>
           <NodeHeader
             label={data.label || 'Security Element'}
             icon={IconComponent}
-            status={status}
+            status={reliabilityStatus}
             color={theme}
             onLabelChange={handleLabelChange}
           >

--- a/src/renderer/src/components/nodes/ServiceNode.tsx
+++ b/src/renderer/src/components/nodes/ServiceNode.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from 'react'
+import { memo, useCallback, useMemo } from 'react'
 import { NodeProps } from 'reactflow'
 import { NodeHeader } from '@renderer/components/nodes/NodeHeader'
 import { NodeSettingsMenu } from '@renderer/components/nodes/NodeSettingsMenu'
@@ -11,7 +11,8 @@ import BaseNode from '@renderer/components/nodes/BaseNode'
 import { useFlowStore } from '@renderer/components/canvas/hooks/useFlowStore'
 import { NodeMetricContent } from './NodeMetricContent'
 import {
-  getEffectiveNodeStatus,
+  getRuntimeCapacityStyle,
+  getRuntimeReliabilityStatus,
   getIdentityChip,
   getLensCard,
   getPreRunMetric,
@@ -39,6 +40,11 @@ const ServiceNode = ({ id, data, selected }: NodeProps<ServiceNodeData>) => {
     errorRate,
     queueDepth,
     utilization,
+    postWarmupArrived,
+    successLatencySamples,
+    timeToErrorSamples,
+    latencyWindowErrorRate,
+    timeToErrorByCause,
     postWarmupRejected,
     postWarmupTimedOut,
     hasRuntime,
@@ -47,25 +53,46 @@ const ServiceNode = ({ id, data, selected }: NodeProps<ServiceNodeData>) => {
   const lens = useMetricLens()
   const lensCard = hasRuntime && lens !== 'traffic' ? getLensCard(lens, data, metrics) : null
   const preRunMetric = isPreRunMetricLens(lens) ? getPreRunMetric(lens, data) : null
-  const status = getEffectiveNodeStatus(data, { utilization, errorRate, queueDepth }, hasRuntime)
+  const reliabilityStatus = getRuntimeReliabilityStatus(
+    'healthy',
+    {
+      postWarmupArrived,
+      successLatencySamples,
+      timeToErrorSamples,
+      latencyWindowErrorRate,
+      timeToErrorByCause,
+      errorRate
+    },
+    hasRuntime
+  )
+  const capacityStyle = getRuntimeCapacityStyle({ utilization, queueDepth }, hasRuntime)
 
   // After a simulation run, nodes that received zero post-warmup traffic are
   // visually muted so users can see at a glance which nodes stayed inactive.
   const isInactive = isRuntimeNodeInactive(hasRuntime, active)
+  const containerClassName = useMemo(() => {
+    const base =
+      'group relative w-64 bg-nss-surface rounded-lg border transition-all duration-200 overflow-visible'
+    if (isInactive) return `${base} border-nss-border`
+    if (selected) {
+      return `${base} ${capacityStyle.border} ring-2 ${capacityStyle.ring} ${capacityStyle.shadow}`
+    }
+    return `${base} ${capacityStyle.border} ${capacityStyle.hoverBorder} ${capacityStyle.shadow}`
+  }, [capacityStyle, isInactive, selected])
 
   return (
     <BaseNode
       id={id}
       selected={selected}
       selectionVariant="primary"
-      healthStatus={isInactive ? undefined : status}
+      containerClassName={containerClassName}
     >
       {({ isMenuOpen, onMenuClose, onMenuToggle }) => (
         <div className={isInactive ? 'opacity-40 grayscale' : undefined}>
           <NodeHeader
             label={data.label || 'Service'}
             icon={IconComponent}
-            status={status}
+            status={reliabilityStatus}
             color={theme}
             onLabelChange={handleLabelChange}
           >

--- a/src/renderer/src/components/nodes/nodePresentation.ts
+++ b/src/renderer/src/components/nodes/nodePresentation.ts
@@ -5,7 +5,6 @@ import type {
   PreRunMetricLens
 } from '@renderer/types/ui'
 import {
-  failureRateLevelFromPercent,
   failureRateLevelFromRatio,
   formatFailurePercentLabel
 } from '@renderer/utils/failureRatePresentation'
@@ -13,6 +12,11 @@ import {
   ERROR_CAUSE_LABELS,
   dominantTimeToErrorCause
 } from '@renderer/utils/errorCausePresentation'
+import {
+  deriveCapacityStatus,
+  deriveCombinedRuntimeTone,
+  deriveReliabilityStatus
+} from '@renderer/utils/nodeHealthThresholds'
 import type { WorkloadWithoutRuntimeFields } from '@renderer/utils/workloadDefaults'
 import { ACK_AND_RELEASE_COMPONENT_TYPES } from '../../../../engine/traits/ackAndRelease'
 import { HEALTH_AWARE_COMPONENT_TYPES } from '../../../../engine/traits/healthAwareRouting'
@@ -54,6 +58,47 @@ export const NODE_HEALTH_STYLES = {
   }
 } satisfies Record<NodeHealthStatus, NodeHealthStyle>
 
+export type NodeCapacityVisualBand = 'headroom' | 'steady' | 'tight' | 'saturated'
+
+export interface NodeCapacityStyle {
+  border: string
+  ring: string
+  hoverBorder: string
+  shadow: string
+  iconAccent: string
+}
+
+export const NODE_CAPACITY_STYLES = {
+  headroom: {
+    border: 'border-nss-success/70',
+    ring: 'ring-nss-success',
+    hoverBorder: 'hover:border-nss-success',
+    shadow: 'shadow-[0_0_14px_rgba(16,185,129,0.18)]',
+    iconAccent: 'bg-nss-success/10 border border-nss-success/30 text-nss-success'
+  },
+  steady: {
+    border: 'border-nss-primary/60',
+    ring: 'ring-nss-primary',
+    hoverBorder: 'hover:border-nss-primary/80',
+    shadow: 'shadow-[0_0_14px_rgba(59,130,246,0.22)]',
+    iconAccent: 'bg-nss-primary/10 border border-nss-primary/30 text-nss-primary'
+  },
+  tight: {
+    border: 'border-nss-warning',
+    ring: 'ring-nss-warning',
+    hoverBorder: 'hover:border-nss-warning',
+    shadow: 'shadow-[0_0_18px_rgba(245,158,11,0.28)]',
+    iconAccent: 'bg-nss-warning/10 border border-nss-warning/30 text-nss-warning'
+  },
+  saturated: {
+    border: 'border-orange-400',
+    ring: 'ring-orange-400',
+    hoverBorder: 'hover:border-orange-300',
+    shadow: 'shadow-[0_0_20px_rgba(251,146,60,0.34)]',
+    iconAccent: 'bg-orange-400/10 border border-orange-300/40 text-orange-300'
+  }
+} satisfies Record<NodeCapacityVisualBand, NodeCapacityStyle>
+
 export interface SummaryMetric {
   label: string
   value?: string | number
@@ -84,15 +129,17 @@ export function getRuntimeNodeStatus(
 ): NodeHealthStatus {
   if (!hasRuntime) return fallbackStatus
 
-  const utilization = metrics.utilization ?? 0
-  const queueDepth = metrics.queueDepth ?? 0
-  const failureLevel = failureRateLevelFromPercent(metrics.errorRate)
+  const tone = deriveCombinedRuntimeTone({
+    utilization: metrics.utilization ?? 0,
+    queueDepth: metrics.queueDepth ?? 0,
+    errorRatePercent: metrics.errorRate ?? 0
+  })
 
-  if (failureLevel === 'crit' || utilization >= 90) {
+  if (tone === 'crit') {
     return 'critical'
   }
 
-  if (failureLevel === 'warn' || utilization >= 75 || queueDepth >= 1) {
+  if (tone === 'warn') {
     return 'degraded'
   }
 
@@ -105,6 +152,61 @@ export function getEffectiveNodeStatus(
   hasRuntime: boolean
 ): NodeHealthStatus {
   return getRuntimeNodeStatus(getNodeStatus(data), metrics, hasRuntime)
+}
+
+export function getRuntimeReliabilityStatus(
+  fallbackStatus: NodeHealthStatus,
+  metrics: Pick<
+    NodeSimulationMetrics,
+    | 'postWarmupArrived'
+    | 'successLatencySamples'
+    | 'timeToErrorSamples'
+    | 'latencyWindowErrorRate'
+    | 'timeToErrorByCause'
+    | 'errorRate'
+  >,
+  hasRuntime: boolean
+): NodeHealthStatus {
+  if (!hasRuntime) return fallbackStatus
+
+  const reliability = deriveReliabilityStatus({
+    postWarmupArrived: metrics.postWarmupArrived ?? 0,
+    successLatencySamples: metrics.successLatencySamples ?? 0,
+    timeToErrorSamples: metrics.timeToErrorSamples ?? 0,
+    latencyWindowErrorRate: metrics.latencyWindowErrorRate ?? (metrics.errorRate ?? 0) / 100,
+    timeToErrorByCause: metrics.timeToErrorByCause
+  })
+
+  if (reliability.tone === 'crit') return 'critical'
+  if (reliability.tone === 'warn') return 'degraded'
+  return 'healthy'
+}
+
+export function getRuntimeCapacityVisualBand(
+  metrics: Pick<NodeSimulationMetrics, 'utilization' | 'queueDepth'>,
+  hasRuntime: boolean
+): NodeCapacityVisualBand {
+  if (!hasRuntime) return 'headroom'
+
+  const utilization = metrics.utilization ?? 0
+  const queueDepth = metrics.queueDepth ?? 0
+  const capacity = deriveCapacityStatus({
+    utilization,
+    queueDepth,
+    utilizationUnit: 'percent'
+  })
+
+  if (capacity.level === 'saturated') return 'saturated'
+  if (capacity.level === 'tight') return 'tight'
+  if (utilization >= 40) return 'steady'
+  return 'headroom'
+}
+
+export function getRuntimeCapacityStyle(
+  metrics: Pick<NodeSimulationMetrics, 'utilization' | 'queueDepth'>,
+  hasRuntime: boolean
+): NodeCapacityStyle {
+  return NODE_CAPACITY_STYLES[getRuntimeCapacityVisualBand(metrics, hasRuntime)]
 }
 
 export function isRuntimeNodeInactive(hasRuntime: boolean, active?: boolean): boolean {
@@ -324,6 +426,18 @@ function formatLatencyMetric(value: number | null | undefined): string {
   return value === null || value === undefined ? 'N/A' : `${value.toFixed(2)}ms`
 }
 
+function formatWorkerUsage(activeWorkers: number, workers: number): string {
+  if (workers <= 1) {
+    return activeWorkers.toFixed(2)
+  }
+
+  return activeWorkers.toFixed(1)
+}
+
+function formatWorkerLimit(workers: number): string {
+  return `/ ${workers} worker${workers === 1 ? '' : 's'} avg`
+}
+
 function toneFromFailureRatio(value: number): NodeHealthStatus {
   const level = failureRateLevelFromRatio(value)
   if (level === 'crit') return 'critical'
@@ -439,22 +553,18 @@ export function getLensCard(
       }
       const utilization = metrics.utilization
       const activeWorkers = Math.min(workers, (utilization / 100) * workers)
-      const tone = getRuntimeNodeStatus(
-        'healthy',
-        { utilization, errorRate: metrics.errorRate, queueDepth: metrics.queueDepth },
-        true
-      )
-      const verdict =
-        tone === 'critical'
-          ? 'saturated'
-          : tone === 'degraded'
-            ? 'approaching saturation'
-            : 'healthy'
+      const capacity = deriveCapacityStatus({
+        utilization,
+        queueDepth: metrics.queueDepth,
+        workers,
+        utilizationUnit: 'percent'
+      })
+      const tone: NodeHealthStatus = capacity.level === 'headroom' ? 'healthy' : 'degraded'
       return {
-        value: activeWorkers.toFixed(1),
-        limit: `/ ${workers} workers`,
-        glyph: GLYPH_BY_TONE[tone],
-        why: `${utilization.toFixed(0)}% utilized — ${verdict} · click for detail`,
+        value: formatWorkerUsage(activeWorkers, workers),
+        limit: formatWorkerLimit(workers),
+        glyph: capacity.level === 'headroom' ? '✓' : '⚠',
+        why: `${capacity.utilizationPercent.toFixed(1)}% average utilization - ${capacity.label.toLowerCase()} · click for detail`,
         tone
       }
     }

--- a/src/renderer/src/components/properties/MetricItem.tsx
+++ b/src/renderer/src/components/properties/MetricItem.tsx
@@ -24,7 +24,7 @@ export const MetricItem = ({
       </div>
 
       {/* Value: Uses custom textColor (defaulting to nss-text) */}
-      <div className={clsx('font-mono text-lg truncate', textColor)}>
+      <div className={clsx('text-lg truncate tabular-nums', textColor)}>
         {value}
         {unit && <span className={clsx('text-xs ml-0.5', textColor)}>{unit}</span>}
       </div>

--- a/src/renderer/src/components/properties/NodeMetricsDetail.tsx
+++ b/src/renderer/src/components/properties/NodeMetricsDetail.tsx
@@ -133,8 +133,8 @@ export const NodeMetricsDetail = ({ metrics }: NodeMetricsDetailProps) => {
           <div className="space-y-1.5">
             {rejectionEntries.map(([reason, count]) => (
               <div key={reason} className="flex items-center justify-between text-xs">
-                <span className="font-mono text-nss-muted">{reason}</span>
-                <span className="font-mono font-semibold text-nss-warning">{count}</span>
+                <span className="text-nss-muted">{reason}</span>
+                <span className="font-semibold text-nss-warning tabular-nums">{count}</span>
               </div>
             ))}
           </div>
@@ -156,8 +156,8 @@ export const NodeMetricsDetail = ({ metrics }: NodeMetricsDetailProps) => {
           <div className="space-y-1.5">
             {traitCounterEntries.map(([key, value]) => (
               <div key={key} className="flex items-center justify-between text-xs">
-                <span className="font-mono text-nss-muted">{key}</span>
-                <span className="font-mono font-semibold text-nss-text">{value}</span>
+                <span className="text-nss-muted">{key}</span>
+                <span className="font-semibold text-nss-text tabular-nums">{value}</span>
               </div>
             ))}
           </div>

--- a/src/renderer/src/components/properties/PropertiesHeader.tsx
+++ b/src/renderer/src/components/properties/PropertiesHeader.tsx
@@ -44,7 +44,7 @@ export const PropertiesHeader = ({ data }: PropertiesHeaderProps) => {
             </span>
           </div>
           <div className="mt-1 flex items-center gap-2">
-            <span className="text-[10px] text-nss-muted font-mono uppercase truncate">
+            <span className="text-[10px] text-nss-muted uppercase truncate">
               {data.subLabel || subLabel}
             </span>
             <span className="text-[10px] px-1.5 py-0.5 rounded border border-nss-border bg-nss-surface text-nss-muted uppercase tracking-wide">

--- a/src/renderer/src/components/properties/PropertiesPanel.tsx
+++ b/src/renderer/src/components/properties/PropertiesPanel.tsx
@@ -2,12 +2,14 @@ import { useEffect, useState } from 'react'
 import { clsx } from 'clsx'
 import { Settings } from 'lucide-react'
 import type { FieldPath } from '@renderer/config/fieldConfig'
-import type { AnyNodeData } from '@renderer/types/ui'
+import type { AnyNodeData, EdgeSimulationData } from '@renderer/types/ui'
 import { useNodeMetrics } from '@renderer/hooks/useNodeMetrics'
+import type { CanvasNodeDataV2 } from '../../../../engine/catalog/nodeSpecTypes'
 import useStore from '../../store/useStore'
 import { PropertiesHeader } from './PropertiesHeader'
 import { PropertiesForm } from './PropertiesForm'
 import { NodeMetricsDetail } from './NodeMetricsDetail'
+import { EdgePropertiesPanel, type EdgePropertiesPanelValue } from '../ui/EdgePropertiesPanel'
 
 const EmptyState = () => (
   <div className="h-full bg-nss-panel border-l border-nss-border flex flex-col items-center justify-center text-nss-muted gap-2">
@@ -76,9 +78,13 @@ type PanelTab = 'metrics' | 'config'
 
 export const PropertiesPanel = () => {
   const nodes = useStore((state) => state.nodes)
+  const edges = useStore((state) => state.edges)
   const updateNodeData = useStore((state) => state.updateNodeData)
+  const updateEdgeData = useStore((state) => state.updateEdgeData)
+  const selectGraphElements = useStore((state) => state.selectGraphElements)
 
   const selectedNode = nodes.find((node) => node.selected)
+  const selectedEdge = edges.find((edge) => edge.selected)
   const metrics = useNodeMetrics(selectedNode?.id ?? '')
   const [tab, setTab] = useState<PanelTab>('metrics')
 
@@ -89,45 +95,80 @@ export const PropertiesPanel = () => {
     setTab(metrics.hasRuntime ? 'metrics' : 'config')
   }, [selectedNode?.id, metrics.hasRuntime])
 
-  if (!selectedNode) return <EmptyState />
+  // A selected node takes precedence over an edge in the shared inspector.
+  if (selectedNode) {
+    const data = selectedNode.data as AnyNodeData
 
-  const data = selectedNode.data as AnyNodeData
+    const handleUpdate = (path: FieldPath, value: unknown) => {
+      updateNodeData(selectedNode.id, setPathValue(data, path, value))
+    }
 
-  const handleUpdate = (path: FieldPath, value: unknown) => {
-    updateNodeData(selectedNode.id, setPathValue(data, path, value))
+    return (
+      <div className="h-full w-full bg-nss-panel border-l border-nss-border flex flex-col text-nss-text font-sans shadow-xl">
+        <PropertiesHeader data={data} />
+
+        {metrics.hasRuntime && (
+          <div className="flex gap-1 border-b border-nss-border px-3 pt-3">
+            {(['metrics', 'config'] as const).map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => setTab(option)}
+                className={clsx(
+                  'rounded-t px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wide transition-colors',
+                  tab === option
+                    ? 'bg-nss-surface text-nss-text border border-b-0 border-nss-border'
+                    : 'text-nss-muted hover:text-nss-text'
+                )}
+              >
+                {option === 'metrics' ? 'Results' : 'Config'}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <div className="flex-1 overflow-y-auto custom-scrollbar p-5 bg-nss-panel">
+          {metrics.hasRuntime && tab === 'metrics' ? (
+            <NodeMetricsDetail metrics={metrics} />
+          ) : (
+            <PropertiesForm nodeId={selectedNode.id} data={data} onUpdate={handleUpdate} />
+          )}
+        </div>
+      </div>
+    )
   }
 
-  return (
-    <div className="h-full w-full bg-nss-panel border-l border-nss-border flex flex-col text-nss-text font-sans shadow-xl">
-      <PropertiesHeader data={data} />
+  if (selectedEdge) {
+    const sourceNodeData = nodes.find((node) => node.id === selectedEdge.source)?.data as
+      | CanvasNodeDataV2
+      | undefined
+    const targetNodeData = nodes.find((node) => node.id === selectedEdge.target)?.data as
+      | CanvasNodeDataV2
+      | undefined
 
-      {metrics.hasRuntime && (
-        <div className="flex gap-1 border-b border-nss-border px-3 pt-3">
-          {(['metrics', 'config'] as const).map((option) => (
-            <button
-              key={option}
-              type="button"
-              onClick={() => setTab(option)}
-              className={clsx(
-                'rounded-t px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wide transition-colors',
-                tab === option
-                  ? 'bg-nss-surface text-nss-text border border-b-0 border-nss-border'
-                  : 'text-nss-muted hover:text-nss-text'
-              )}
-            >
-              {option === 'metrics' ? 'Results' : 'Config'}
-            </button>
-          ))}
-        </div>
-      )}
+    const handleEdgeChange = (patch: Partial<EdgePropertiesPanelValue>) => {
+      const { label, ...dataPatch } = patch
+      const hasDataPatch = Object.keys(dataPatch).length > 0
 
-      <div className="flex-1 overflow-y-auto custom-scrollbar p-5 bg-nss-panel">
-        {metrics.hasRuntime && tab === 'metrics' ? (
-          <NodeMetricsDetail metrics={metrics} />
-        ) : (
-          <PropertiesForm nodeId={selectedNode.id} data={data} onUpdate={handleUpdate} />
-        )}
-      </div>
-    </div>
-  )
+      updateEdgeData(selectedEdge.id, {
+        ...(label !== undefined ? { label } : {}),
+        ...(hasDataPatch ? { data: dataPatch as Partial<EdgeSimulationData> } : {})
+      })
+    }
+
+    return (
+      <EdgePropertiesPanel
+        sourceNodeData={sourceNodeData}
+        targetNodeData={targetNodeData}
+        value={{
+          label: (selectedEdge.label as string) || '',
+          ...(((selectedEdge.data as EdgeSimulationData | undefined) ?? {}) as EdgeSimulationData)
+        }}
+        onChange={handleEdgeChange}
+        onClose={() => selectGraphElements({})}
+      />
+    )
+  }
+
+  return <EmptyState />
 }

--- a/src/renderer/src/components/samples/SampleScenarioPicker.tsx
+++ b/src/renderer/src/components/samples/SampleScenarioPicker.tsx
@@ -45,7 +45,7 @@ export function SampleScenarioPicker({ samples, onLoad, onClose }: SampleScenari
                   <p className="mt-0.5 text-xs text-nss-muted">{sample.subtitle}</p>
                 </div>
 
-                <p className="mt-3 rounded border border-nss-border bg-nss-panel px-3 py-2 font-mono text-xs text-nss-text">
+                <p className="mt-3 rounded border border-nss-border bg-nss-panel px-3 py-2 text-xs text-nss-text">
                   {sample.diagram}
                 </p>
 

--- a/src/renderer/src/components/simulation/ResultsTray.tsx
+++ b/src/renderer/src/components/simulation/ResultsTray.tsx
@@ -1,17 +1,52 @@
-import { useEffect, useId, useMemo, useState } from 'react'
-import type { CSSProperties, KeyboardEvent } from 'react'
-import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react'
-import type { SimulationOutput, StatusWindow } from '../../../../engine/analysis/output'
-import type { DebugEvent } from '../../../../engine/core/event-stream'
-import { projectToDebugEvent } from '../../../../engine/core/event-stream'
+import { Fragment, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
+import type { ButtonHTMLAttributes, CSSProperties, HTMLAttributes } from 'react'
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+  Pause,
+  Play,
+  Search,
+  X
+} from 'lucide-react'
+import type {
+  SimulationOutput,
+  StatusWindow,
+  TimeSeriesSnapshot
+} from '../../../../engine/analysis/output'
+import type {
+  CanonicalEventRecord,
+  CanonicalEventType,
+  DebugEvent,
+  RequestOutcomeRecord
+} from '../../../../engine/core/event-stream'
 import type { SimulationStatus } from '../../hooks/useSimulation'
-import useStore from '../../store/useStore'
+import useStore, { type EdgeFlowRenderEvent } from '../../store/useStore'
+import { HoverTooltip, TooltipInfo } from '@renderer/components/ui/Tooltip'
+import {
+  RESULTS_CONTEXTUAL_TOOLTIPS,
+  RESULTS_E2E_PERCENTILE_TOOLTIPS,
+  RESULTS_HEALTH_CHECK_TOOLTIPS,
+  RESULTS_PER_NODE_COLUMN_TOOLTIPS,
+  RESULTS_SUMMARY_TOOLTIPS,
+  formatInFlightAtCutoffBanner
+} from '@renderer/config/tooltipCatalog'
 import type { EdgeSimulationData, ScenarioRunContext } from '@renderer/types/ui'
 import {
   ERROR_CAUSE_LABELS,
   dominantTimeToErrorCause
 } from '@renderer/utils/errorCausePresentation'
 import { failureRateLevelFromRatio } from '@renderer/utils/failureRatePresentation'
+import {
+  capacityRank,
+  deriveCapacityStatus,
+  deriveReliabilityStatus,
+  reliabilityRank,
+  toneRank,
+  type CapacityStatus,
+  type ReliabilityStatus
+} from '@renderer/utils/nodeHealthThresholds'
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -20,6 +55,8 @@ interface ResultsTrayProps {
   stopped: boolean
   progress: number
   eventsProcessed: number
+  runStartedAtMs: number | null
+  snapshot: TimeSeriesSnapshot | null
   results: SimulationOutput | null
   error: string | null
   runContext: ScenarioRunContext | null
@@ -47,7 +84,7 @@ type SelectedComponent = { kind: 'node'; id: string } | { kind: 'edge'; id: stri
 function fmtMs(ms: number | null): string {
   // `null` means no successful samples in this population/window — show N/A, never a fake 0.
   if (ms === null) return 'N/A'
-  if (ms === 0) return '—'
+  if (ms === 0) return '-'
   if (ms < 1) return `${ms.toFixed(3)}ms`
   if (ms < 1000) return `${ms.toFixed(2)}ms`
   return `${(ms / 1000).toFixed(2)}s`
@@ -62,7 +99,7 @@ function fmtSeconds(ms: number): string {
 }
 
 function fmtRps(rps: number | null): string {
-  return rps === null ? '—' : `${rps.toFixed(1)} rps`
+  return rps === null ? '-' : `${rps.toFixed(1)} rps`
 }
 
 function fmtCv(value: number | null): string {
@@ -70,24 +107,15 @@ function fmtCv(value: number | null): string {
 }
 
 function fmtLambda(lambda: number): string {
-  return lambda === 0 ? '—' : `${lambda.toFixed(2)}`
+  return lambda === 0 ? '-' : `${lambda.toFixed(2)}`
 }
 
 function fmtL(l: number): string {
-  return l === 0 ? '—' : l.toFixed(3)
+  return l === 0 ? '-' : l.toFixed(3)
 }
 
 function fmtW(wSeconds: number): string {
-  return wSeconds === 0 ? '—' : fmtMs(wSeconds * 1000)
-}
-
-function fmtEventTime(timestampMs: number): string {
-  if (timestampMs < 1000) return `${timestampMs.toFixed(3)}ms`
-  return `${(timestampMs / 1000).toFixed(3)}s`
-}
-
-function clampSequence(sequence: number, maxSequence: number): number {
-  return Math.min(maxSequence, Math.max(0, sequence))
+  return wSeconds === 0 ? '-' : fmtMs(wSeconds * 1000)
 }
 
 function totalReplayEventCount(output: SimulationOutput): number {
@@ -96,7 +124,7 @@ function totalReplayEventCount(output: SimulationOutput): number {
 
 const SECTION_TITLE = 'text-[11px] font-semibold text-nss-muted uppercase tracking-wider'
 const SURFACE_CARD = 'bg-nss-surface border border-nss-border rounded-md'
-const EVENT_LOG_PAGE_SIZE = 50
+const TRAFFIC_EVENT_LOG_SIZE = 24
 const RESULTS_TABS: Array<{ id: ResultsTab; label: string }> = [
   { id: 'overview', label: 'Overview' },
   { id: 'bottlenecks', label: 'Bottlenecks' },
@@ -104,48 +132,15 @@ const RESULTS_TABS: Array<{ id: ResultsTab; label: string }> = [
   { id: 'traffic', label: 'Traffic' }
 ]
 
-const E2E_PERCENTILE_TOOLTIPS: Record<'p50' | 'p90' | 'p95' | 'p99' | 'max', string> = {
-  p50: 'Median end-to-end latency. Half of requests were faster than this, half slower.',
-  p90: '90th percentile — 10% of requests were slower than this value.',
-  p95: '95th percentile — typical SLO target for latency-sensitive services.',
-  p99: '99th percentile tail latency — 1% of requests were slower. Most user-facing SLOs live here.',
-  max: 'Slowest observed request. Useful for spotting outliers; not a reliable tail metric.'
-}
-
-const HEALTH_CHECK_TOOLTIPS = {
-  slo: "Compares each node's measured p99 latency and availability against the SLO targets you configured on the node.",
-  errorRate:
-    'Breakdown of rejected, timed-out, and connection-reset requests by node. Rejections happen when the queue is full; timeouts happen when the client waits too long; connection resets happen when in-flight work is explicitly dropped.',
-  littlesLaw:
-    "Little's Law (L = λ·W) is a queueing-theory identity that must hold in steady state. Violations usually indicate either measurement noise at low utilization, or that the simulation never reached steady state. At very low L (<0.1), relative errors can be large while absolute differences are sub-request — treat these as noise.",
-  conservation:
-    'Verifies that for every node: arrived = processed + rejected + timed out + connection reset + in-flight at cutoff. Small non-zero in-flight counts are expected when the run ends with requests still being processed.',
-  warmup:
-    "Checks that warmup duration is at least 10× the max observed p99. If it isn't, post-warmup metrics may still be contaminated by startup transients."
-} as const
-
-const PER_NODE_COLUMN_TOOLTIPS = {
-  arrived: 'Requests that reached this node during the post-warmup window.',
-  done: 'Requests this node finished processing before the simulation cutoff (post-warmup).',
-  reject: "Requests turned away because the node's queue was full.",
-  timedOut: "Requests that exceeded this node's processing timeout.",
-  reset:
-    'Requests explicitly terminated with connection_reset while queued, in service, or released from a hung recovery path.',
-  errorRate:
-    'Rejected + timed out + connection reset, divided by post-warmup arrivals at this node. Read the latency columns with this value, never by themselves.',
-  arrivalCV:
-    'Coefficient of variation of inter-arrival gaps at this node. 0 = perfectly even; ≈1 = Poisson. If this is higher than the offered CV, upstream jitter or contention bunched requests before this node.',
-  inFlight:
-    'Requests that had arrived at this node but were still queued or processing when the simulation ended.',
-  avgQueue: 'Time-averaged queue depth (requests waiting, not yet being processed).',
-  util: 'Fraction of workers busy on average. Below 70% is comfortable; above 80% queueing grows sharply; near 100% the node is saturated.',
-  p50: 'Median service + queue time at this node only. Does not include network/link latency.',
-  p95: '95th percentile per-hop latency at this node.',
-  p99: '99th percentile per-hop latency at this node. Per-hop p99s do not sum to end-to-end p99.',
-  lambda: 'Arrival rate (λ, requests per second) during the post-warmup window.',
-  w: 'Mean time a request spends at this node (W, service + queue). End-to-end latency is roughly the sum of W across the path.',
-  l: "Average number of requests concurrently at this node (L). By Little's Law, L = λ·W."
-} as const
+const LIVE_PATTERN_BAR_COUNT = 24
+type TrafficStatusFilter = 'all' | EdgeFlowRenderEvent['status']
+const TRAFFIC_STATUS_FILTERS: Array<{ id: TrafficStatusFilter; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'success', label: 'Success' },
+  { id: 'timeout', label: 'Timeout' },
+  { id: 'edge-error', label: 'Edge Error' },
+  { id: 'packet-loss', label: 'Packet Loss' }
+]
 
 function eventStatusClass(status: DebugEvent['status']): string {
   switch (status) {
@@ -161,120 +156,15 @@ function eventStatusClass(status: DebugEvent['status']): string {
   }
 }
 
-function includesTerm(value: string | undefined, term: string): boolean {
-  return value?.toLowerCase().includes(term) ?? false
-}
-
 function labelForNode(nodeId: string | undefined, lookup: EventGraphLookup): string | undefined {
   return nodeId ? lookup.nodeLabelById.get(nodeId) : undefined
 }
 
-function nodeDisplayName(event: DebugEvent, lookup: EventGraphLookup): string {
-  return labelForNode(event.nodeId, lookup) ?? event.nodeId ?? '—'
-}
-
-function routeDisplayName(event: DebugEvent, lookup: EventGraphLookup): string {
-  const edge = event.edgeId ? lookup.edgeById.get(event.edgeId) : undefined
-  const sourceId = event.sourceNodeId ?? edge?.source
-  const targetId = event.targetNodeId ?? edge?.target
-  const source = labelForNode(sourceId, lookup) ?? sourceId
-  const target = labelForNode(targetId, lookup) ?? targetId
-
-  return source || target ? `${source ?? '—'} → ${target ?? '—'}` : '—'
-}
-
-function edgeDisplay(
-  event: DebugEvent,
-  lookup: EventGraphLookup
-): { primary: string; secondary?: string; title?: string } {
-  const edge = event.edgeId ? lookup.edgeById.get(event.edgeId) : undefined
-  const route = routeDisplayName(event, lookup)
-  const hasRoute = route !== '—'
-  const protocolMode = [edge?.protocol, edge?.mode].filter(Boolean).join(' / ')
-  const primary = edge?.label ?? (hasRoute ? route : event.edgeId) ?? '—'
-  const secondaryParts: string[] = []
-
-  if (edge?.label && hasRoute) {
-    secondaryParts.push(route)
-  }
-  if (protocolMode) {
-    secondaryParts.push(protocolMode)
-  }
-
-  return {
-    primary,
-    secondary: secondaryParts.length > 0 ? secondaryParts.join(' • ') : undefined,
-    title: [event.edgeId, edge?.label, route, protocolMode].filter(Boolean).join(' | ')
-  }
-}
-
-function eventMatchesQuery(event: DebugEvent, query: string, lookup: EventGraphLookup): boolean {
-  const normalized = query.trim()
-  if (normalized.length === 0) {
-    return true
-  }
-
-  return normalized
-    .split(/\s+OR\s+/i)
-    .some((group) =>
-      group.split(/\s+AND\s+/i).every((term) => eventMatchesTerm(event, term, lookup))
-    )
-}
-
-function eventMatchesTerm(event: DebugEvent, rawTerm: string, lookup: EventGraphLookup): boolean {
-  const term = rawTerm.trim()
-  if (term.length === 0) {
-    return true
-  }
-
-  const edge = event.edgeId ? lookup.edgeById.get(event.edgeId) : undefined
-  const sourceId = event.sourceNodeId ?? edge?.source
-  const targetId = event.targetNodeId ?? edge?.target
-
-  const [field, ...rest] = term.split(':')
-  const value = rest.join(':').toLowerCase()
-  if (!value) {
-    return event.message.toLowerCase().includes(term.toLowerCase())
-  }
-
-  switch (field.toLowerCase()) {
-    case 'request':
-      return includesTerm(event.requestId, value)
-    case 'node':
-      return (
-        includesTerm(event.nodeId, value) ||
-        includesTerm(labelForNode(event.nodeId, lookup), value) ||
-        includesTerm(sourceId, value) ||
-        includesTerm(labelForNode(sourceId, lookup), value) ||
-        includesTerm(targetId, value) ||
-        includesTerm(labelForNode(targetId, lookup), value)
-      )
-    case 'edge':
-      return (
-        includesTerm(event.edgeId, value) ||
-        includesTerm(edge?.label, value) ||
-        includesTerm(edge?.protocol, value) ||
-        includesTerm(edge?.mode, value) ||
-        includesTerm(sourceId, value) ||
-        includesTerm(labelForNode(sourceId, lookup), value) ||
-        includesTerm(targetId, value) ||
-        includesTerm(labelForNode(targetId, lookup), value)
-      )
-    case 'status':
-      return event.status.toLowerCase() === value
-    case 'type':
-      return event.type.toLowerCase() === value
-    default:
-      return event.message.toLowerCase().includes(term.toLowerCase())
-  }
-}
-
-function RunContextPanel({ runContext }: { runContext: ScenarioRunContext }) {
-  const workload = runContext.workload
-  const patternExtras: string[] = []
+function workloadPatternDetails(workload: ScenarioRunContext['workload']): string[] {
+  const details: string[] = []
 
   if (workload.pattern === 'bursty' && workload.bursty) {
-    patternExtras.push(
+    details.push(
       `${workload.bursty.burstRps} burst rps`,
       `${workload.bursty.burstDuration}ms burst`,
       `${workload.bursty.normalDuration}ms normal`
@@ -282,7 +172,7 @@ function RunContextPanel({ runContext }: { runContext: ScenarioRunContext }) {
   }
 
   if (workload.pattern === 'spike' && workload.spike) {
-    patternExtras.push(
+    details.push(
       `${workload.spike.spikeRps} spike rps`,
       `t=${workload.spike.spikeTime}ms`,
       `${workload.spike.spikeDuration}ms duration`
@@ -290,11 +180,489 @@ function RunContextPanel({ runContext }: { runContext: ScenarioRunContext }) {
   }
 
   if (workload.pattern === 'sawtooth' && workload.sawtooth) {
-    patternExtras.push(
+    details.push(
       `${workload.sawtooth.peakRps} peak rps`,
       `${workload.sawtooth.rampDuration}ms ramp`
     )
   }
+
+  return details
+}
+
+function livePatternPhaseLabel(
+  workload: ScenarioRunContext['workload'],
+  currentSimMs: number
+): string | null {
+  switch (workload.pattern) {
+    case 'constant':
+    case 'replay':
+      return 'even arrivals'
+
+    case 'poisson':
+      return 'random gaps'
+
+    case 'bursty': {
+      if (!workload.bursty) return null
+      const burstDuration = Math.max(1, workload.bursty.burstDuration)
+      const normalDuration = Math.max(1, workload.bursty.normalDuration)
+      const cycle = burstDuration + normalDuration
+      return currentSimMs % cycle < burstDuration ? 'burst' : 'base'
+    }
+
+    case 'spike': {
+      if (!workload.spike) return null
+      return currentSimMs >= workload.spike.spikeTime &&
+        currentSimMs < workload.spike.spikeTime + workload.spike.spikeDuration
+        ? 'spike'
+        : 'base'
+    }
+
+    case 'sawtooth': {
+      if (!workload.sawtooth) return null
+      const rampDuration = Math.max(1, workload.sawtooth.rampDuration)
+      const progress = (currentSimMs % rampDuration) / rampDuration
+      if (progress > 0.66) return 'ramp high'
+      if (progress > 0.33) return 'ramp mid'
+      return 'ramp low'
+    }
+
+    case 'diurnal': {
+      const multipliers = workload.diurnal?.hourlyMultipliers
+      if (!multipliers) return null
+      const hourPosition = (((currentSimMs / 1000 / 60 / 60) % 24) + 24) % 24
+      const hour = Math.floor(hourPosition)
+      const value = multipliers[hour] ?? 1
+      if (value > 1.1) return 'peak'
+      if (value < 0.8) return 'low'
+      return 'normal'
+    }
+
+    default:
+      return null
+  }
+}
+
+function liveNodeStatusClass(status: string): string {
+  switch (status) {
+    case 'failed':
+      return 'text-nss-danger bg-nss-danger/10 border-nss-danger/20'
+    case 'saturated':
+      return 'text-nss-warning bg-nss-warning/10 border-nss-warning/20'
+    case 'busy':
+      return 'text-nss-primary bg-nss-primary/10 border-nss-primary/20'
+    default:
+      return 'text-nss-muted bg-nss-surface border-nss-border'
+  }
+}
+
+function edgeFlowStatusClass(status: 'success' | 'edge-error' | 'packet-loss' | 'timeout'): string {
+  switch (status) {
+    case 'success':
+      return 'text-nss-success bg-nss-success/10 border-nss-success/20'
+    case 'timeout':
+      return 'text-nss-warning bg-nss-warning/10 border-nss-warning/20'
+    case 'edge-error':
+    case 'packet-loss':
+      return 'text-nss-danger bg-nss-danger/10 border-nss-danger/20'
+  }
+}
+
+function upperBoundTrafficEventTime(events: EdgeFlowRenderEvent[], currentSimMs: number): number {
+  let low = 0
+  let high = events.length
+
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2)
+    if (events[mid]?.startedAtMs <= currentSimMs) {
+      low = mid + 1
+    } else {
+      high = mid
+    }
+  }
+
+  return low
+}
+
+function trafficEventsUpToTime(
+  events: EdgeFlowRenderEvent[],
+  currentSimMs: number,
+  limit = TRAFFIC_EVENT_LOG_SIZE
+): EdgeFlowRenderEvent[] {
+  const endIndex = upperBoundTrafficEventTime(events, currentSimMs)
+  const startIndex = Math.max(0, endIndex - limit)
+  return events.slice(startIndex, endIndex)
+}
+
+function edgeFlowStatusLabel(status: EdgeFlowRenderEvent['status']): string {
+  switch (status) {
+    case 'edge-error':
+      return 'edge error'
+    case 'packet-loss':
+      return 'packet loss'
+    default:
+      return status
+  }
+}
+
+function trafficFilterButtonClass(
+  filter: TrafficStatusFilter,
+  activeFilter: TrafficStatusFilter
+): string {
+  if (filter === 'all') {
+    return activeFilter === 'all'
+      ? 'border-nss-primary bg-nss-primary/15 text-nss-primary'
+      : 'border-nss-border bg-nss-surface text-nss-muted hover:text-nss-text hover:bg-nss-bg'
+  }
+
+  if (activeFilter === filter) {
+    return `${edgeFlowStatusClass(filter)} ring-1 ring-inset ring-current/25`
+  }
+
+  switch (filter) {
+    case 'success':
+      return 'border-nss-border bg-nss-surface text-nss-muted hover:border-nss-success/20 hover:bg-nss-success/10 hover:text-nss-success'
+    case 'timeout':
+      return 'border-nss-border bg-nss-surface text-nss-muted hover:border-nss-warning/20 hover:bg-nss-warning/10 hover:text-nss-warning'
+    case 'edge-error':
+    case 'packet-loss':
+      return 'border-nss-border bg-nss-surface text-nss-muted hover:border-nss-danger/20 hover:bg-nss-danger/10 hover:text-nss-danger'
+  }
+}
+
+// ─── Request outcome log ──────────────────────────────────────────────────────
+// Post-run Event Log source: one row per request keyed on terminal fate. Chips
+// are terminal OUTCOMES a user filters for — never lifecycle transitions, which
+// live in the per-row drill-down instead. `in-flight` is a confidence state
+// (unfinished at cutoff), styled muted, never as an alarm.
+
+type OutcomeStatus = RequestOutcomeRecord['status']
+type OutcomeStatusFilter = 'all' | OutcomeStatus
+
+const OUTCOME_PAGE_SIZE = 50
+
+const OUTCOME_STATUS_ORDER: OutcomeStatus[] = [
+  'success',
+  'rejected',
+  'timeout',
+  'connection_reset',
+  'in-flight'
+]
+
+const OUTCOME_STATUS_LABEL: Record<OutcomeStatus, string> = {
+  success: 'Success',
+  rejected: 'Rejected',
+  timeout: 'Timeout',
+  connection_reset: 'Reset',
+  'in-flight': 'In-flight'
+}
+
+function outcomeStatusBadgeClass(status: OutcomeStatus): string {
+  switch (status) {
+    case 'success':
+      return 'text-nss-success bg-nss-success/10 border-nss-success/20'
+    case 'timeout':
+      return 'text-nss-warning bg-nss-warning/10 border-nss-warning/20'
+    case 'rejected':
+    case 'connection_reset':
+      return 'text-nss-danger bg-nss-danger/10 border-nss-danger/20'
+    // In-flight is a confidence caveat, not a fault: muted, never red or green.
+    case 'in-flight':
+      return 'text-nss-muted bg-nss-muted/10 border-nss-muted/30'
+  }
+}
+
+function outcomeFilterButtonClass(
+  filter: OutcomeStatusFilter,
+  activeFilter: OutcomeStatusFilter
+): string {
+  if (filter === 'all') {
+    return activeFilter === 'all'
+      ? 'border-nss-primary bg-nss-primary/15 text-nss-primary'
+      : 'border-nss-border bg-nss-surface text-nss-muted hover:text-nss-text hover:bg-nss-bg'
+  }
+
+  if (activeFilter === filter) {
+    return `${outcomeStatusBadgeClass(filter)} ring-1 ring-inset ring-current/25`
+  }
+
+  switch (filter) {
+    case 'success':
+      return 'border-nss-border bg-nss-surface text-nss-muted hover:border-nss-success/20 hover:bg-nss-success/10 hover:text-nss-success'
+    case 'timeout':
+      return 'border-nss-border bg-nss-surface text-nss-muted hover:border-nss-warning/20 hover:bg-nss-warning/10 hover:text-nss-warning'
+    case 'rejected':
+    case 'connection_reset':
+      return 'border-nss-border bg-nss-surface text-nss-muted hover:border-nss-danger/20 hover:bg-nss-danger/10 hover:text-nss-danger'
+    case 'in-flight':
+      return 'border-nss-border bg-nss-surface text-nss-muted hover:border-nss-muted/40 hover:bg-nss-muted/10 hover:text-nss-text'
+  }
+}
+
+function fmtAttempts(attempts: number): string {
+  return attempts === 1 ? '1' : `${attempts}×`
+}
+
+/** Prettify a canonical lifecycle event type for the per-row drill-down. */
+function lifecycleStepLabel(type: CanonicalEventType): string {
+  return type.replace(/^request-/, '').replace(/-/g, ' ')
+}
+
+/** One collapsed lifecycle step, with a repeat count for consecutive duplicates. */
+interface LifecycleStep {
+  key: number
+  label: string
+  reasonCode?: string
+  timeMs: number
+  count: number
+}
+
+/** A run of consecutive lifecycle steps that happened at the same node. */
+interface LifecycleNodeGroup {
+  key: number
+  nodeId: string | null
+  label: string
+  /** Time attributed to this node hop: entry here → entry at the next node. */
+  deltaMs: number
+  steps: LifecycleStep[]
+}
+
+/**
+ * Fold a request's flat, sequence-ordered lifecycle events into per-node groups
+ * for the drill-down tree. Each group's delta is the time from arriving at that
+ * node to arriving at the next one (the last hop runs to the request's final
+ * event), so the group deltas sum to the request's end-to-end latency. Repeated
+ * consecutive steps at a node (e.g. two `trait-evaluated`) collapse into one row
+ * carrying an `×N` count.
+ */
+function buildLifecycleGroups(
+  steps: CanonicalEventRecord[],
+  graphLookup: EventGraphLookup
+): LifecycleNodeGroup[] {
+  if (steps.length === 0) return []
+
+  const groups: LifecycleNodeGroup[] = []
+  for (const event of steps) {
+    const nodeId = event.nodeId ?? null
+    const timeMs = Number(event.timestampUs) / 1000
+    const label = lifecycleStepLabel(event.type)
+    const current = groups[groups.length - 1]
+
+    if (!current || current.nodeId !== nodeId) {
+      groups.push({
+        key: event.sequence,
+        nodeId,
+        label: nodeId ? (labelForNode(nodeId, graphLookup) ?? nodeId) : 'System',
+        deltaMs: 0,
+        steps: [{ key: event.sequence, label, reasonCode: event.reasonCode, timeMs, count: 1 }]
+      })
+      continue
+    }
+
+    const lastStep = current.steps[current.steps.length - 1]
+    if (lastStep.label === label && lastStep.reasonCode === event.reasonCode) {
+      lastStep.count += 1
+    } else {
+      current.steps.push({
+        key: event.sequence,
+        label,
+        reasonCode: event.reasonCode,
+        timeMs,
+        count: 1
+      })
+    }
+  }
+
+  const overallEndMs = Number(steps[steps.length - 1].timestampUs) / 1000
+  for (let index = 0; index < groups.length; index++) {
+    const entryMs = groups[index].steps[0].timeMs
+    const nextEntryMs = index < groups.length - 1 ? groups[index + 1].steps[0].timeMs : overallEndMs
+    groups[index].deltaMs = Math.max(0, nextEntryMs - entryMs)
+  }
+
+  return groups
+}
+
+/**
+ * The per-request drill-down: a node-grouped lifecycle tree. Each node hop is an
+ * independently collapsible branch showing its steps and the wall time spent
+ * before the request moved on.
+ */
+function LifecycleTree({
+  requestId,
+  totalLatencyMs,
+  groups
+}: {
+  requestId: string
+  totalLatencyMs: number | null
+  groups: LifecycleNodeGroup[]
+}) {
+  // All hops start expanded; collapsing is opt-in per branch.
+  const [collapsed, setCollapsed] = useState<ReadonlySet<number>>(() => new Set())
+
+  return (
+    <div className="text-[10px] text-nss-muted">
+      <div className="flex items-center justify-between gap-2 pb-1.5">
+        <span className="font-semibold text-nss-text">{requestId}</span>
+        <span className="rounded border border-nss-border bg-nss-surface px-1.5 py-0.5 tabular-nums text-nss-text">
+          {fmtMs(totalLatencyMs)} total
+        </span>
+      </div>
+      <div className="space-y-0.5 border-l border-nss-border/70 pl-2">
+        {groups.map((group) => {
+          const isOpen = !collapsed.has(group.key)
+          return (
+            <div key={group.key}>
+              <button
+                type="button"
+                onClick={() =>
+                  setCollapsed((current) => {
+                    const next = new Set(current)
+                    if (next.has(group.key)) next.delete(group.key)
+                    else next.add(group.key)
+                    return next
+                  })
+                }
+                className="flex w-full items-center justify-between gap-2 rounded py-0.5 pr-1 text-left outline-none hover:bg-nss-bg/60 focus-visible:bg-nss-bg/60"
+              >
+                <span className="flex min-w-0 items-center gap-1.5">
+                  <span className="w-2 shrink-0 text-nss-muted">{isOpen ? '▾' : '▸'}</span>
+                  <span className="truncate font-semibold text-nss-text">{group.label}</span>
+                </span>
+                <span className="shrink-0 tabular-nums text-nss-muted">
+                  Δ {fmtMs(group.deltaMs)}
+                </span>
+              </button>
+              {isOpen && (
+                <ol className="mb-1 ml-[3px] space-y-0.5 border-l border-nss-border/40 py-0.5 pl-3">
+                  {group.steps.map((step) => (
+                    <li key={step.key} className="flex items-baseline gap-2">
+                      <span className="w-12 shrink-0 tabular-nums text-nss-muted/80">
+                        {fmtChartTime(step.timeMs)}
+                      </span>
+                      <span className="text-nss-text">
+                        {step.label}
+                        {step.count > 1 ? (
+                          <span className="text-nss-muted"> (×{step.count})</span>
+                        ) : null}
+                        {step.reasonCode ? (
+                          <span className="text-nss-muted"> · {step.reasonCode}</span>
+                        ) : null}
+                      </span>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function hash01(input: string): number {
+  let hash = 2166136261
+  for (let index = 0; index < input.length; index++) {
+    hash ^= input.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0) / 4294967295
+}
+
+function workloadRateMultiplierAtMs(
+  workload: ScenarioRunContext['workload'],
+  currentSimMs: number
+): number {
+  const baseRps = Math.max(1, workload.baseRps)
+
+  switch (workload.pattern) {
+    case 'constant':
+    case 'replay':
+      return 1
+
+    case 'poisson': {
+      const bucket = Math.floor(currentSimMs / 900)
+      return 0.55 + hash01(`poisson:${bucket}`) * 0.9
+    }
+
+    case 'bursty': {
+      if (!workload.bursty) return 1
+      const burstDuration = Math.max(1, workload.bursty.burstDuration)
+      const normalDuration = Math.max(1, workload.bursty.normalDuration)
+      const cycle = burstDuration + normalDuration
+      const inBurst = currentSimMs % cycle < burstDuration
+      return inBurst ? Math.max(1.5, Math.min(4, workload.bursty.burstRps / baseRps)) : 1
+    }
+
+    case 'spike': {
+      if (!workload.spike) return 1
+      const inSpike =
+        currentSimMs >= workload.spike.spikeTime &&
+        currentSimMs < workload.spike.spikeTime + workload.spike.spikeDuration
+      return inSpike ? Math.max(1.75, Math.min(5, workload.spike.spikeRps / baseRps)) : 1
+    }
+
+    case 'sawtooth': {
+      if (!workload.sawtooth) return 1
+      const rampDuration = Math.max(1, workload.sawtooth.rampDuration)
+      const progress = (currentSimMs % rampDuration) / rampDuration
+      const currentRps = baseRps + (workload.sawtooth.peakRps - baseRps) * progress
+      return Math.max(0.45, Math.min(5, currentRps / baseRps))
+    }
+
+    case 'diurnal': {
+      const multipliers = workload.diurnal?.hourlyMultipliers
+      if (!multipliers) return 1
+      const hourPosition = (((currentSimMs / 1000 / 60 / 60) % 24) + 24) % 24
+      const hour = Math.floor(hourPosition)
+      const nextHour = (hour + 1) % 24
+      const localT = hourPosition - Math.floor(hourPosition)
+      const current = multipliers[hour] ?? 1
+      const next = multipliers[nextHour] ?? current
+      return Math.max(0.35, Math.min(2.5, current + (next - current) * localT))
+    }
+
+    default:
+      return 1
+  }
+}
+
+function simulatedArrivalBins(
+  workload: ScenarioRunContext['workload'],
+  currentSimMs: number,
+  windowMs: number,
+  binCount: number
+): number[] {
+  const binWidthMs = Math.max(1, windowMs / Math.max(1, binCount))
+
+  return Array.from({ length: binCount }, (_, index) => {
+    const binCenterMs = currentSimMs - windowMs + binWidthMs * index + binWidthMs / 2
+    const base = workloadRateMultiplierAtMs(workload, Math.max(0, binCenterMs))
+
+    if (workload.pattern === 'poisson') {
+      return base * (0.7 + hash01(`arrival:${Math.round(binCenterMs / 80)}:${index}`) * 0.9)
+    }
+
+    return base
+  })
+}
+
+function errorRateAtTime(output: SimulationOutput, currentSimMs: number): number | null {
+  const window =
+    output.summary.latencyWindows.find(
+      (entry) => currentSimMs >= entry.windowStartMs && currentSimMs <= entry.windowEndMs
+    ) ??
+    [...output.summary.latencyWindows]
+      .reverse()
+      .find((entry) => currentSimMs >= entry.windowEndMs) ??
+    output.summary.latencyWindows[0]
+
+  return window ? window.errorRate : null
+}
+
+function RunContextPanel({ runContext }: { runContext: ScenarioRunContext }) {
+  const workload = runContext.workload
+  const patternExtras = workloadPatternDetails(workload)
 
   return (
     <div className="space-y-2">
@@ -312,6 +680,1262 @@ function RunContextPanel({ runContext }: { runContext: ScenarioRunContext }) {
           {patternExtras.join(' • ')}
         </div>
       )}
+    </div>
+  )
+}
+
+function ArrivalPatternStrip({ bins, active }: { bins: number[]; active: boolean }) {
+  const maxBin = Math.max(1, ...bins)
+  const positiveBins = bins.filter((count) => count > 0)
+  const minPositiveBin =
+    positiveBins.length > 0 ? positiveBins.reduce((min, count) => Math.min(min, count), maxBin) : 0
+  const spread = Math.max(0, maxBin - minPositiveBin)
+  const hasMeaningfulVariation = spread > maxBin * 0.08
+
+  return (
+    <div
+      className={`${SURFACE_CARD} relative h-24 overflow-hidden bg-[linear-gradient(180deg,rgba(59,130,246,0.06),rgba(15,23,42,0.04))] px-2 py-2`}
+      aria-label="Live arrival pattern strip"
+    >
+      <div className="pointer-events-none absolute inset-0">
+        {[25, 50, 75].map((marker) => (
+          <div
+            key={marker}
+            className="absolute inset-x-0 border-t border-white/6"
+            style={{ bottom: `${marker}%` } satisfies CSSProperties}
+          />
+        ))}
+      </div>
+
+      <div className="relative z-[1] flex h-full items-end gap-1.5">
+        {bins.map((count, index) => {
+          const height =
+            count <= 0
+              ? 10
+              : hasMeaningfulVariation
+                ? Math.max(
+                    18,
+                    Math.round(22 + ((count - minPositiveBin) / Math.max(spread, 0.0001)) * 68)
+                  )
+                : 64
+
+          return (
+            <div
+              key={index}
+              className="relative flex-1 h-full overflow-hidden rounded-[4px] border border-white/6 bg-black/10"
+            >
+              <div
+                className={`absolute inset-x-0 bottom-0 rounded-[3px] border-t transition-[height,opacity,background-color] duration-200 ${
+                  active
+                    ? 'border-nss-primary/70 bg-nss-primary/80 shadow-[0_0_16px_rgba(59,130,246,0.18)]'
+                    : 'border-sky-300/60 bg-sky-400/55'
+                }`}
+                style={
+                  { height: `${height}%`, opacity: count > 0 ? 1 : 0.28 } satisfies CSSProperties
+                }
+              />
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function TrafficEventLog({
+  currentSimMs,
+  graphLookup,
+  mode
+}: {
+  currentSimMs: number
+  graphLookup: EventGraphLookup
+  mode: 'live' | 'replay'
+}) {
+  const edgeFlowHistory = useStore((state) => state.edgeFlowHistory)
+  const selectGraphElements = useStore((state) => state.selectGraphElements)
+  const [activeEventKey, setActiveEventKey] = useState<string | null>(null)
+  const [statusFilter, setStatusFilter] = useState<TrafficStatusFilter>('all')
+  const eventsAtTime = useMemo(
+    () => trafficEventsUpToTime(edgeFlowHistory, currentSimMs),
+    [currentSimMs, edgeFlowHistory]
+  )
+  const statusCounts = useMemo(() => {
+    const counts: Record<TrafficStatusFilter, number> = {
+      all: eventsAtTime.length,
+      success: 0,
+      timeout: 0,
+      'edge-error': 0,
+      'packet-loss': 0
+    }
+
+    for (const event of eventsAtTime) {
+      counts[event.status] += 1
+    }
+
+    return counts
+  }, [eventsAtTime])
+  const visibleEvents = useMemo(
+    () =>
+      statusFilter === 'all'
+        ? eventsAtTime
+        : eventsAtTime.filter((event) => event.status === statusFilter),
+    [eventsAtTime, statusFilter]
+  )
+
+  useEffect(() => {
+    if (
+      activeEventKey !== null &&
+      !visibleEvents.some(
+        (event) => `${event.requestId}:${event.edgeId}:${event.sequence}` === activeEventKey
+      )
+    ) {
+      setActiveEventKey(null)
+    }
+  }, [activeEventKey, visibleEvents])
+
+  return (
+    <div className={`${SURFACE_CARD} p-3`}>
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-wider text-nss-muted">
+            Event Log
+          </div>
+          <div className="text-[11px] text-nss-muted">
+            {mode === 'live'
+              ? 'Requests append here as the run advances.'
+              : 'This list rewinds and advances with the replay slider.'}
+          </div>
+        </div>
+        <span className="text-[10px] text-nss-muted tabular-nums">
+          {visibleEvents.length.toLocaleString()} visible
+        </span>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        {TRAFFIC_STATUS_FILTERS.map((filter) => (
+          <button
+            key={filter.id}
+            type="button"
+            onClick={() => setStatusFilter(filter.id)}
+            className={`rounded-full border px-2 py-1 text-[10px] font-medium transition-colors ${trafficFilterButtonClass(filter.id, statusFilter)}`}
+            aria-pressed={statusFilter === filter.id}
+          >
+            {statusCounts[filter.id].toLocaleString()} {filter.label}
+          </button>
+        ))}
+      </div>
+
+      {visibleEvents.length > 0 ? (
+        <div className="mt-3 overflow-hidden rounded-md border border-nss-border">
+          <div className="max-h-80 overflow-auto">
+            <table className="w-full text-[11px] tabular-nums">
+              <thead className="sticky top-0 border-b border-nss-border bg-nss-surface text-nss-muted">
+                <tr>
+                  <th className="px-2 py-1.5 text-left">Sim Time</th>
+                  <th className="px-2 py-1.5 text-left">Request</th>
+                  <th className="px-2 py-1.5 text-left">Route</th>
+                  <th className="px-2 py-1.5 text-left">Status</th>
+                  <th className="px-2 py-1.5 text-right">Latency</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleEvents.map((event) => {
+                  const source = labelForNode(event.sourceNodeId, graphLookup) ?? event.sourceNodeId
+                  const target = labelForNode(event.targetNodeId, graphLookup) ?? event.targetNodeId
+                  const edge = graphLookup.edgeById.get(event.edgeId)
+                  const routeLabel = edge?.label ?? `${source} → ${target}`
+                  const routeMeta = [
+                    edge?.label ? `${source} → ${target}` : undefined,
+                    edge?.protocol,
+                    edge?.mode
+                  ]
+                    .filter(Boolean)
+                    .join(' • ')
+                  const rowKey = `${event.requestId}:${event.edgeId}:${event.sequence}`
+                  const isActive = activeEventKey === rowKey
+
+                  return (
+                    <tr
+                      key={rowKey}
+                      tabIndex={0}
+                      aria-selected={isActive}
+                      onClick={() => {
+                        setActiveEventKey(rowKey)
+                        selectGraphElements({ edgeId: event.edgeId })
+                      }}
+                      onKeyDown={(keyboardEvent) => {
+                        if (keyboardEvent.key !== 'Enter' && keyboardEvent.key !== ' ') {
+                          return
+                        }
+
+                        keyboardEvent.preventDefault()
+                        setActiveEventKey(rowKey)
+                        selectGraphElements({ edgeId: event.edgeId })
+                      }}
+                      className={`cursor-pointer border-b border-nss-border outline-none hover:bg-nss-bg focus:bg-nss-bg ${
+                        isActive ? 'bg-nss-primary/10 ring-1 ring-inset ring-nss-primary/30' : ''
+                      }`}
+                    >
+                      <td className="px-2 py-1 text-nss-muted">
+                        {fmtChartTime(event.startedAtMs)}
+                      </td>
+                      <td className="px-2 py-1 text-nss-text">
+                        <div className="truncate">{event.requestId}</div>
+                        <div className="truncate text-[10px] text-nss-muted">
+                          seq {event.sequence}
+                        </div>
+                      </td>
+                      <td className="max-w-56 px-2 py-1 text-nss-muted" title={routeLabel}>
+                        <div className="truncate text-nss-text">{routeLabel}</div>
+                        <div className="truncate text-[10px] text-nss-muted">
+                          {routeMeta || `${source} → ${target}`}
+                        </div>
+                      </td>
+                      <td className="px-2 py-1">
+                        <span
+                          className={`rounded-full border px-1.5 py-0.5 text-[10px] font-medium ${edgeFlowStatusClass(event.status)}`}
+                        >
+                          {edgeFlowStatusLabel(event.status)}
+                        </span>
+                      </td>
+                      <td className="px-2 py-1 text-right text-nss-text">
+                        {fmtMs(event.latencyMs)}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+          <div className="border-t border-nss-border px-2 py-1 text-[10px] text-nss-muted">
+            Showing the latest {visibleEvents.length}{' '}
+            {statusFilter === 'all' ? '' : `${edgeFlowStatusLabel(statusFilter)} `}
+            traversals at or before {fmtChartTime(currentSimMs)}.
+          </div>
+        </div>
+      ) : (
+        <div className="mt-3 text-xs text-nss-muted">
+          {statusFilter !== 'all'
+            ? `No ${edgeFlowStatusLabel(statusFilter)} traversals are visible at this point in the run.`
+            : mode === 'live'
+              ? 'Waiting for requests to start moving through the graph.'
+              : 'No retained request traversals exist at this replay point yet.'}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function RequestOutcomeLog({
+  output,
+  graphLookup
+}: {
+  output: SimulationOutput
+  graphLookup: EventGraphLookup
+}) {
+  const selectGraphElements = useStore((state) => state.selectGraphElements)
+  const [statusFilter, setStatusFilter] = useState<OutcomeStatusFilter>('all')
+  const [query, setQuery] = useState('')
+  const [page, setPage] = useState(1)
+  const [expandedRequestId, setExpandedRequestId] = useState<string | null>(null)
+
+  const outcomes = output.requestOutcomes
+  const statusCounts = useMemo(() => {
+    const counts: Record<OutcomeStatusFilter, number> = {
+      all: outcomes.length,
+      success: 0,
+      rejected: 0,
+      timeout: 0,
+      connection_reset: 0,
+      'in-flight': 0
+    }
+    for (const row of outcomes) {
+      counts[row.status] += 1
+    }
+    return counts
+  }, [outcomes])
+
+  // Chip filter, then free-text search over request id / node label / status.
+  const trimmedQuery = query.trim().toLowerCase()
+  const visibleRows = useMemo(() => {
+    const byStatus =
+      statusFilter === 'all' ? outcomes : outcomes.filter((row) => row.status === statusFilter)
+    if (trimmedQuery === '') return byStatus
+    return byStatus.filter((row) => {
+      const nodeLabel = row.nodeId ? (labelForNode(row.nodeId, graphLookup) ?? row.nodeId) : ''
+      const haystack =
+        `${row.requestId} ${nodeLabel} ${OUTCOME_STATUS_LABEL[row.status]}`.toLowerCase()
+      return haystack.includes(trimmedQuery)
+    })
+  }, [outcomes, statusFilter, trimmedQuery, graphLookup])
+
+  const pageCount = Math.max(1, Math.ceil(visibleRows.length / OUTCOME_PAGE_SIZE))
+  const clampedPage = Math.min(page, pageCount)
+  const pageStart = (clampedPage - 1) * OUTCOME_PAGE_SIZE
+  const pagedRows = visibleRows.slice(pageStart, pageStart + OUTCOME_PAGE_SIZE)
+
+  // Reset to the first page whenever the filter or search narrows the set.
+  useEffect(() => {
+    setPage(1)
+  }, [statusFilter, trimmedQuery])
+
+  // Lifecycle steps for the one expanded request, derived on demand from the
+  // canonical stream. Empty when the stream was truncated for a large run.
+  const expandedSteps = useMemo(() => {
+    if (expandedRequestId === null) return []
+    return output.eventStream
+      .filter((event) => event.requestId === expandedRequestId)
+      .sort((a, b) => a.sequence - b.sequence)
+  }, [expandedRequestId, output.eventStream])
+
+  // The same steps folded into per-node hops for the drill-down tree.
+  const expandedGroups = useMemo(
+    () => buildLifecycleGroups(expandedSteps, graphLookup),
+    [expandedSteps, graphLookup]
+  )
+
+  useEffect(() => {
+    if (
+      expandedRequestId !== null &&
+      !visibleRows.some((row) => row.requestId === expandedRequestId)
+    ) {
+      setExpandedRequestId(null)
+    }
+  }, [expandedRequestId, visibleRows])
+
+  const inFlightCount = statusCounts['in-flight']
+
+  const filters: OutcomeStatusFilter[] = ['all', ...OUTCOME_STATUS_ORDER]
+
+  return (
+    <div className={`${SURFACE_CARD} p-3`}>
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs font-semibold uppercase tracking-wider text-nss-muted">
+              Request Outcomes
+            </span>
+            <TooltipInfo
+              label="About the request outcome log"
+              content="One row per request, keyed on its final fate. Every generated request appears exactly once - successes, failures, and requests still in flight at the cutoff. Click a row to see its lifecycle steps."
+            />
+          </div>
+          <div className="text-[11px] text-nss-muted">
+            Final fate of every request this run. Click a row for its lifecycle.
+          </div>
+        </div>
+        <span className="text-[10px] text-nss-muted tabular-nums">
+          {visibleRows.length.toLocaleString()} of {outcomes.length.toLocaleString()}
+        </span>
+      </div>
+
+      {inFlightCount > 0 && (
+        <div className="mt-3 rounded-md border border-nss-muted/30 bg-nss-muted/10 px-2.5 py-1.5 text-[11px] leading-snug text-nss-muted">
+          {formatInFlightAtCutoffBanner(inFlightCount)}
+        </div>
+      )}
+
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        {filters.map((filter) => (
+          <button
+            key={filter}
+            type="button"
+            onClick={() => setStatusFilter(filter)}
+            className={`rounded-full border px-2 py-1 text-[10px] font-medium transition-colors ${outcomeFilterButtonClass(filter, statusFilter)}`}
+            aria-pressed={statusFilter === filter}
+          >
+            {statusCounts[filter].toLocaleString()}{' '}
+            {filter === 'all' ? 'All' : OUTCOME_STATUS_LABEL[filter]}
+          </button>
+        ))}
+      </div>
+
+      <div className="relative mt-2">
+        <Search
+          size={13}
+          className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-nss-muted"
+          aria-hidden="true"
+        />
+        <input
+          type="text"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search by request id, node, or status…"
+          aria-label="Search request outcomes"
+          className="w-full rounded-md border border-nss-border bg-nss-bg py-1.5 pl-8 pr-8 text-[11px] text-nss-text placeholder:text-nss-muted focus:border-nss-primary/50 focus:outline-none focus:ring-1 focus:ring-nss-primary/40"
+        />
+        {query !== '' && (
+          <button
+            type="button"
+            onClick={() => setQuery('')}
+            aria-label="Clear search"
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-nss-muted hover:text-nss-text"
+          >
+            <X size={13} />
+          </button>
+        )}
+      </div>
+
+      {pagedRows.length > 0 ? (
+        <div className="mt-3 overflow-hidden rounded-md border border-nss-border">
+          <div className="max-h-80 overflow-auto">
+            <table className="w-full text-[11px] tabular-nums">
+              <thead className="sticky top-0 border-b border-nss-border bg-nss-surface text-nss-muted">
+                <tr>
+                  <th className="px-2 py-1.5 text-left">Request</th>
+                  <th className="px-2 py-1.5 text-left">Terminal</th>
+                  <th className="px-2 py-1.5 text-left">Node</th>
+                  <th className="px-2 py-1.5 text-left">Status</th>
+                  <th className="px-2 py-1.5 text-right">Attempts</th>
+                  <th className="px-2 py-1.5 text-right">Latency</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pagedRows.map((row) => {
+                  const nodeLabel = row.nodeId
+                    ? (labelForNode(row.nodeId, graphLookup) ?? row.nodeId)
+                    : '-'
+                  const isExpanded = expandedRequestId === row.requestId
+
+                  return (
+                    <Fragment key={row.requestId}>
+                      <tr
+                        tabIndex={0}
+                        aria-expanded={isExpanded}
+                        onClick={() => {
+                          setExpandedRequestId(isExpanded ? null : row.requestId)
+                          if (row.nodeId) {
+                            selectGraphElements({ nodeId: row.nodeId })
+                          }
+                        }}
+                        onKeyDown={(keyboardEvent) => {
+                          if (keyboardEvent.key !== 'Enter' && keyboardEvent.key !== ' ') {
+                            return
+                          }
+                          keyboardEvent.preventDefault()
+                          setExpandedRequestId(isExpanded ? null : row.requestId)
+                          if (row.nodeId) {
+                            selectGraphElements({ nodeId: row.nodeId })
+                          }
+                        }}
+                        className={`cursor-pointer border-b border-nss-border outline-none hover:bg-nss-bg focus:bg-nss-bg ${
+                          isExpanded
+                            ? 'bg-nss-primary/10 ring-1 ring-inset ring-nss-primary/30'
+                            : ''
+                        }`}
+                      >
+                        <td className="px-2 py-1 text-nss-text">
+                          <div className="flex items-center gap-1 truncate">
+                            <span className="text-nss-muted">{isExpanded ? '▾' : '▸'}</span>
+                            <span className="truncate">{row.requestId}</span>
+                          </div>
+                        </td>
+                        <td className="px-2 py-1 text-nss-muted">
+                          {row.terminalAtMs === null ? '-' : fmtChartTime(row.terminalAtMs)}
+                        </td>
+                        <td className="max-w-40 px-2 py-1 text-nss-muted" title={nodeLabel}>
+                          <span className="block truncate">{nodeLabel}</span>
+                        </td>
+                        <td className="px-2 py-1">
+                          <span
+                            className={`rounded-full border px-1.5 py-0.5 text-[10px] font-medium ${outcomeStatusBadgeClass(row.status)}`}
+                          >
+                            {OUTCOME_STATUS_LABEL[row.status]}
+                          </span>
+                        </td>
+                        <td className="px-2 py-1 text-right text-nss-muted">
+                          {fmtAttempts(row.attempts)}
+                        </td>
+                        <td className="px-2 py-1 text-right text-nss-text">
+                          {fmtMs(row.latencyMs)}
+                        </td>
+                      </tr>
+                      {isExpanded && (
+                        <tr className="border-b border-nss-border bg-nss-bg/40">
+                          <td colSpan={6} className="px-3 py-2">
+                            {expandedGroups.length > 0 ? (
+                              <LifecycleTree
+                                requestId={row.requestId}
+                                totalLatencyMs={row.latencyMs}
+                                groups={expandedGroups}
+                              />
+                            ) : (
+                              <div className="text-[10px] text-nss-muted">
+                                Lifecycle steps for this request were not retained (the event stream
+                                was capped for this large run).
+                              </div>
+                            )}
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+          <div className="flex items-center justify-between gap-3 border-t border-nss-border px-2 py-1.5 text-[10px] text-nss-muted">
+            <span className="tabular-nums">
+              Showing {(pageStart + 1).toLocaleString()}–
+              {(pageStart + pagedRows.length).toLocaleString()} of{' '}
+              {visibleRows.length.toLocaleString()}
+            </span>
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                onClick={() => setPage((current) => Math.max(1, current - 1))}
+                disabled={clampedPage <= 1}
+                className="inline-flex items-center gap-0.5 rounded border border-nss-border px-1.5 py-0.5 text-nss-muted transition-colors hover:text-nss-text disabled:opacity-40 disabled:hover:text-nss-muted"
+              >
+                <ChevronLeft size={12} /> Prev
+              </button>
+              <span className="px-1 tabular-nums">
+                {clampedPage} / {pageCount}
+              </span>
+              <button
+                type="button"
+                onClick={() => setPage((current) => Math.min(pageCount, current + 1))}
+                disabled={clampedPage >= pageCount}
+                className="inline-flex items-center gap-0.5 rounded border border-nss-border px-1.5 py-0.5 text-nss-muted transition-colors hover:text-nss-text disabled:opacity-40 disabled:hover:text-nss-muted"
+              >
+                Next <ChevronRight size={12} />
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-3 text-xs text-nss-muted">
+          {outcomes.length === 0
+            ? 'No requests were generated in this run.'
+            : trimmedQuery !== ''
+              ? `No requests match “${query.trim()}”${statusFilter === 'all' ? '' : ` in ${OUTCOME_STATUS_LABEL[statusFilter as OutcomeStatus].toLowerCase()}`}.`
+              : `No ${statusFilter === 'all' ? '' : `${OUTCOME_STATUS_LABEL[statusFilter as OutcomeStatus].toLowerCase()} `}requests in this run.`}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function LiveMonitorPanel({
+  status,
+  progress,
+  eventsProcessed,
+  runStartedAtMs,
+  snapshot,
+  runContext,
+  graphLookup
+}: {
+  status: SimulationStatus
+  progress: number
+  eventsProcessed: number
+  runStartedAtMs: number | null
+  snapshot: TimeSeriesSnapshot | null
+  runContext: ScenarioRunContext
+  graphLookup: EventGraphLookup
+}) {
+  const edges = useStore((state) => state.edges)
+  const edgeFlowById = useStore((state) => state.edgeFlowById)
+  const [nowMs, setNowMs] = useState(() => Date.now())
+
+  useEffect(() => {
+    if (status !== 'running' && status !== 'paused') {
+      return
+    }
+
+    const intervalId = window.setInterval(() => setNowMs(Date.now()), 100)
+    return () => window.clearInterval(intervalId)
+  }, [status])
+
+  const elapsedWallMs = Math.max(0, runStartedAtMs === null ? 0 : nowMs - runStartedAtMs)
+  const currentSimMs =
+    snapshot?.timestamp ??
+    (runContext.global.simulationDuration > 0
+      ? (progress / 100) * runContext.global.simulationDuration
+      : 0)
+  const isWarmup = currentSimMs < runContext.global.warmupDuration
+  const phaseLabel = livePatternPhaseLabel(runContext.workload, currentSimMs)
+  const sourceEdgeIds = useMemo(
+    () => edges.filter((edge) => edge.source === runContext.sourceNodeId).map((edge) => edge.id),
+    [edges, runContext.sourceNodeId]
+  )
+
+  const sourceFlows = sourceEdgeIds
+    .map((edgeId) => edgeFlowById[edgeId])
+    .filter((flow): flow is NonNullable<(typeof edgeFlowById)[string]> => Boolean(flow))
+  const sourceEvents = sourceFlows.flatMap((flow) => flow.recent)
+  const allFlows = Object.values(edgeFlowById)
+
+  const arrivalWindowMs = Math.min(
+    4_000,
+    Math.max(1_200, Math.round(runContext.global.simulationDuration / 12))
+  )
+  const windowStartMs = Math.max(0, currentSimMs - arrivalWindowMs)
+  const arrivalBins = Array.from({ length: LIVE_PATTERN_BAR_COUNT }, () => 0)
+  const binSizeMs = arrivalWindowMs / LIVE_PATTERN_BAR_COUNT
+
+  for (const event of sourceEvents) {
+    if (event.startedAtMs < windowStartMs || event.startedAtMs > currentSimMs) continue
+    const index = Math.min(
+      LIVE_PATTERN_BAR_COUNT - 1,
+      Math.max(0, Math.floor((event.startedAtMs - windowStartMs) / Math.max(binSizeMs, 1)))
+    )
+    arrivalBins[index]++
+  }
+
+  const sourceEmitRate = sourceFlows.reduce((sum, flow) => sum + flow.attemptedPerSecond, 0)
+  const totalAttemptedPerSecond = allFlows.reduce((sum, flow) => sum + flow.attemptedPerSecond, 0)
+  const totalFailedPerSecond = allFlows.reduce((sum, flow) => sum + flow.failedPerSecond, 0)
+  const edgeFailureRatio =
+    totalAttemptedPerSecond > 0 ? totalFailedPerSecond / totalAttemptedPerSecond : 0
+
+  const liveNodes = Object.entries(snapshot?.node ?? {})
+  const totalInSystem = liveNodes.reduce((sum, [, node]) => sum + node.totalInSystem, 0)
+  const totalWorkers = liveNodes.reduce((sum, [, node]) => sum + node.activeWorkers, 0)
+  const hotQueueEntry = [...liveNodes].sort((a, b) => {
+    const queueDiff = b[1].queueLength - a[1].queueLength
+    if (queueDiff !== 0) return queueDiff
+    return b[1].totalInSystem - a[1].totalInSystem
+  })[0]
+  const hotQueueLabel = hotQueueEntry
+    ? `${labelForNode(hotQueueEntry[0], graphLookup) ?? hotQueueEntry[0]} · ${Math.round(hotQueueEntry[1].queueLength)}`
+    : '-'
+  const busiestNodes = [...liveNodes]
+    .sort((a, b) => {
+      const inSystemDiff = b[1].totalInSystem - a[1].totalInSystem
+      if (inSystemDiff !== 0) return inSystemDiff
+      const queueDiff = b[1].queueLength - a[1].queueLength
+      if (queueDiff !== 0) return queueDiff
+      // Stable tiebreak so interpolated near-ties don't swap rows every frame.
+      return a[0].localeCompare(b[0])
+    })
+    .filter(([, node]) => node.totalInSystem > 0 || node.queueLength > 0 || node.status !== 'idle')
+  const patternDetails = workloadPatternDetails(runContext.workload)
+  const phaseValue = `${isWarmup ? 'Warmup' : 'Steady state'}${phaseLabel ? ` · ${phaseLabel}` : ''}`
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <h3 className={SECTION_TITLE}>Live Monitor</h3>
+        <div className="text-xs text-nss-muted">
+          Runtime snapshot plus source-side arrivals. This stays compact on purpose.
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 text-sm xl:grid-cols-4">
+        <StatCard
+          label="Sim Clock"
+          value={`${fmtSeconds(currentSimMs)} / ${fmtSeconds(runContext.global.simulationDuration)}`}
+        />
+        <StatCard label="Elapsed" value={fmtSeconds(elapsedWallMs)} />
+        <StatCard label="Phase" value={phaseValue} highlight={isWarmup ? 'warn' : undefined} />
+        <StatCard label="Events" value={eventsProcessed.toLocaleString()} />
+      </div>
+
+      <div className={`${SURFACE_CARD} p-3 space-y-3`}>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <div className="text-xs text-nss-muted">Source workload</div>
+            <div className="text-sm font-medium text-nss-text">
+              {runContext.sourceLabel} · {runContext.workload.pattern} ·{' '}
+              {runContext.workload.baseRps.toFixed(1)} rps
+            </div>
+          </div>
+          {phaseLabel && (
+            <span className="rounded-full border border-nss-primary/20 bg-nss-primary/10 px-2 py-1 text-[11px] font-medium text-nss-primary">
+              {phaseLabel}
+            </span>
+          )}
+        </div>
+
+        <ArrivalPatternStrip bins={arrivalBins} active={status === 'running'} />
+
+        <div className="flex items-center justify-between gap-3 text-[11px] text-nss-muted">
+          <span>{fmtSeconds(arrivalWindowMs)} source arrival window</span>
+          <span>
+            {sourceEvents.length > 0
+              ? 'Same average rate, different spacing is what the pattern changes.'
+              : 'Waiting for source traffic.'}
+          </span>
+        </div>
+
+        {patternDetails.length > 0 && (
+          <div className="text-xs text-nss-muted">{patternDetails.join(' • ')}</div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 text-sm xl:grid-cols-4">
+        <StatCard label="Source Emit" value={fmtRps(sourceEmitRate)} />
+        <StatCard label="In System" value={totalInSystem.toLocaleString()} />
+        <StatCard
+          label="Edge Fail"
+          value={fmtPct(edgeFailureRatio)}
+          highlight={edgeFailureRatio > 0.05 ? 'crit' : edgeFailureRatio > 0 ? 'warn' : 'ok'}
+        />
+        <StatCard label="Hot Queue" value={hotQueueLabel} />
+      </div>
+
+      <TrafficEventLog currentSimMs={currentSimMs} graphLookup={graphLookup} mode="live" />
+
+      <BusiestNodesCard
+        busiestNodes={busiestNodes}
+        totalWorkers={totalWorkers}
+        graphLookup={graphLookup}
+        nodeCount={liveNodes.length}
+        emptyLabel="No components are carrying visible load yet."
+      />
+    </div>
+  )
+}
+
+// ─── Paced playback ───────────────────────────────────────────────────────────
+// Snapshots are sampled at a coarse cadence, so stepping frame-to-frame looks
+// choppy. Instead we run a wall-clock playhead over sim time and interpolate the
+// bracketing snapshots, so the clock, gauges, and bars move continuously.
+
+type SnapshotNodeState = TimeSeriesSnapshot['node'][string]
+
+function lerp(a: number, b: number, fraction: number): number {
+  return a + (b - a) * fraction
+}
+
+/** Interpolated topology state at an arbitrary sim time `t` (ms). */
+function snapshotAtTime(timeSeries: TimeSeriesSnapshot[], t: number): TimeSeriesSnapshot {
+  if (timeSeries.length === 0) return { timestamp: t, node: {} }
+  if (t <= timeSeries[0].timestamp) return timeSeries[0]
+  const last = timeSeries[timeSeries.length - 1]
+  if (t >= last.timestamp) return last
+
+  let lo = 0
+  let hi = timeSeries.length - 1
+  while (hi - lo > 1) {
+    const mid = (lo + hi) >> 1
+    if (timeSeries[mid].timestamp <= t) lo = mid
+    else hi = mid
+  }
+
+  const before = timeSeries[lo]
+  const after = timeSeries[hi]
+  const span = after.timestamp - before.timestamp
+  const fraction = span > 0 ? (t - before.timestamp) / span : 0
+
+  const node: TimeSeriesSnapshot['node'] = {}
+  const ids = new Set([...Object.keys(before.node), ...Object.keys(after.node)])
+  for (const id of ids) {
+    const a = before.node[id]
+    const b = after.node[id]
+    if (a && b) {
+      node[id] = {
+        queueLength: lerp(a.queueLength, b.queueLength, fraction),
+        activeWorkers: lerp(a.activeWorkers, b.activeWorkers, fraction),
+        totalInSystem: lerp(a.totalInSystem, b.totalInSystem, fraction),
+        utilization: lerp(a.utilization, b.utilization, fraction),
+        // Status is categorical — snap to the nearer sample rather than blend.
+        status: fraction < 0.5 ? a.status : b.status
+      } satisfies SnapshotNodeState
+    } else {
+      node[id] = (a ?? b) as SnapshotNodeState
+    }
+  }
+  return { timestamp: t, node }
+}
+
+// ─── Busiest nodes (animated, height-stable) ────────────────────────────────────
+// The card count varies as nodes cross the "carrying load" threshold, so a naive
+// list changes height and shoves the content below it up and down. We reserve a
+// fixed number of slots (so nothing below ever moves) and animate each card's
+// entry/exit, keeping departing cards mounted briefly so they fade out in place.
+
+type BusiestNodeEntry = [string, SnapshotNodeState]
+type NodeCardPhase = 'present' | 'exit'
+interface AnimatedNodeCard {
+  id: string
+  node: SnapshotNodeState
+  phase: NodeCardPhase
+}
+
+const BUSIEST_MAX_SLOTS = 4
+const BUSIEST_ROW_HEIGHT = 'h-[3.25rem]'
+const BUSIEST_EXIT_MS = 240
+
+function useAnimatedNodeList(entries: BusiestNodeEntry[]): AnimatedNodeCard[] {
+  const [cards, setCards] = useState<AnimatedNodeCard[]>(() =>
+    entries.map(([id, node]) => ({ id, node, phase: 'present' as NodeCardPhase }))
+  )
+  const timers = useRef(new Map<string, ReturnType<typeof setTimeout>>())
+
+  useEffect(() => {
+    const currentById = new Map(entries)
+    const currentIds = new Set(currentById.keys())
+
+    // A node that came back cancels its pending exit.
+    for (const id of currentIds) {
+      const timer = timers.current.get(id)
+      if (timer) {
+        clearTimeout(timer)
+        timers.current.delete(id)
+      }
+    }
+
+    setCards((prev) => {
+      const prevIds = new Set(prev.map((card) => card.id))
+      const next: AnimatedNodeCard[] = []
+      // Keep existing cards in place; refresh live ones, mark departed ones exiting.
+      for (const card of prev) {
+        const liveNode = currentById.get(card.id)
+        if (liveNode) {
+          next.push({ id: card.id, node: liveNode, phase: 'present' })
+        } else {
+          next.push({ ...card, phase: 'exit' })
+          if (!timers.current.has(card.id)) {
+            timers.current.set(
+              card.id,
+              setTimeout(() => {
+                timers.current.delete(card.id)
+                setCards((current) => current.filter((entry) => entry.id !== card.id))
+              }, BUSIEST_EXIT_MS)
+            )
+          }
+        }
+      }
+      // Append newly arrived cards.
+      for (const [id, node] of entries) {
+        if (!prevIds.has(id)) next.push({ id, node, phase: 'present' })
+      }
+      return next
+    })
+  }, [entries])
+
+  useEffect(() => {
+    const map = timers.current
+    return () => map.forEach((timer) => clearTimeout(timer))
+  }, [])
+
+  return cards
+}
+
+function BusiestNodesCard({
+  busiestNodes,
+  totalWorkers,
+  graphLookup,
+  nodeCount,
+  emptyLabel
+}: {
+  busiestNodes: BusiestNodeEntry[]
+  totalWorkers: number
+  graphLookup: EventGraphLookup
+  nodeCount: number
+  emptyLabel: string
+}) {
+  const slotCount = Math.min(BUSIEST_MAX_SLOTS, Math.max(1, nodeCount))
+  const shown = busiestNodes.slice(0, slotCount)
+  const overflow = busiestNodes.length - shown.length
+  const cards = useAnimatedNodeList(shown)
+  const isEmpty = cards.length === 0
+  // Reserve height for a full set of slots (row + gap) so nothing below ever
+  // moves; cards collapse into this space instead of resizing the section.
+  const reservedHeight = `${slotCount * 3.75}rem`
+
+  return (
+    <div className={`${SURFACE_CARD} p-3`}>
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-xs font-semibold uppercase tracking-wider text-nss-muted">
+          Busiest Nodes
+        </div>
+        <div className="text-[11px] text-nss-muted">
+          {overflow > 0 && <span className="text-nss-warning">+{overflow} more busy · </span>}
+          {Math.round(totalWorkers).toLocaleString()} active workers
+        </div>
+      </div>
+
+      <div className="relative mt-3" style={{ minHeight: reservedHeight }}>
+        {cards.map((card) => (
+          <div
+            key={card.id}
+            className={`flex ${BUSIEST_ROW_HEIGHT} mb-2 max-h-[3.25rem] items-center justify-between gap-3 overflow-hidden rounded-md border border-nss-border bg-nss-bg px-3 ${
+              card.phase === 'exit' ? 'nss-node-card-exit' : 'nss-node-card-enter'
+            }`}
+          >
+            <div className="min-w-0">
+              <div className="truncate text-sm text-nss-text">
+                {labelForNode(card.id, graphLookup) ?? card.id}
+              </div>
+              <div className="text-[11px] text-nss-muted tabular-nums">
+                q={Math.round(card.node.queueLength)} • in-system=
+                {Math.round(card.node.totalInSystem)} • util={fmtPct(card.node.utilization)}
+              </div>
+            </div>
+            <span
+              className={`shrink-0 rounded-full border px-2 py-1 text-[10px] font-medium capitalize ${liveNodeStatusClass(card.node.status)}`}
+            >
+              {card.node.status}
+            </span>
+          </div>
+        ))}
+        {isEmpty && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-center text-[11px] text-nss-muted">
+            {emptyLabel}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const PLAYBACK_SPEEDS = [0.5, 1, 2, 4] as const
+
+interface PacedPlayback {
+  playheadMs: number
+  isPlaying: boolean
+  speed: number
+  atEnd: boolean
+  setSpeed: (speed: number) => void
+  toggle: () => void
+  seek: (ms: number) => void
+  stepToFrame: (direction: -1 | 1) => void
+  jumpStart: () => void
+  jumpEnd: () => void
+}
+
+/**
+ * Wall-clock playhead over sim time. `speed` is sim-ms advanced per wall-ms, so
+ * speed 1 replays in real time. Advances via rAF for frame-rate-smooth motion.
+ */
+function usePacedPlayback(durationMs: number, frameTimes: number[]): PacedPlayback {
+  const [playheadMs, setPlayheadMs] = useState(0)
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [speed, setSpeed] = useState(1)
+  const lastWallRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!isPlaying || durationMs <= 0) return
+
+    let raf = 0
+    lastWallRef.current = null
+    const tick = (nowWall: number): void => {
+      const previous = lastWallRef.current ?? nowWall
+      const deltaWall = nowWall - previous
+      lastWallRef.current = nowWall
+      setPlayheadMs((current) => {
+        const next = current + deltaWall * speed
+        if (next >= durationMs) {
+          setIsPlaying(false)
+          return durationMs
+        }
+        return next
+      })
+      raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [isPlaying, durationMs, speed])
+
+  const atEnd = playheadMs >= durationMs
+
+  const toggle = useCallback(() => {
+    setIsPlaying((playing) => {
+      if (!playing && playheadMs >= durationMs) {
+        setPlayheadMs(0)
+      }
+      return !playing
+    })
+  }, [playheadMs, durationMs])
+
+  const seek = useCallback(
+    (ms: number) => {
+      setIsPlaying(false)
+      setPlayheadMs(Math.min(durationMs, Math.max(0, ms)))
+    },
+    [durationMs]
+  )
+
+  const stepToFrame = useCallback(
+    (direction: -1 | 1) => {
+      setIsPlaying(false)
+      setPlayheadMs((current) => {
+        if (direction === 1) {
+          const nextFrame = frameTimes.find((time) => time > current + 0.001)
+          return nextFrame ?? durationMs
+        }
+        let target = 0
+        for (const time of frameTimes) {
+          if (time < current - 0.001) target = time
+          else break
+        }
+        return target
+      })
+    },
+    [frameTimes, durationMs]
+  )
+
+  const jumpStart = useCallback(() => {
+    setIsPlaying(false)
+    setPlayheadMs(0)
+  }, [])
+
+  const jumpEnd = useCallback(() => {
+    setIsPlaying(false)
+    setPlayheadMs(durationMs)
+  }, [durationMs])
+
+  return {
+    playheadMs,
+    isPlaying,
+    speed,
+    atEnd,
+    setSpeed,
+    toggle,
+    seek,
+    stepToFrame,
+    jumpStart,
+    jumpEnd
+  }
+}
+
+function ReplayMonitorPanel({
+  output,
+  runContext,
+  graphLookup
+}: {
+  output: SimulationOutput
+  runContext: ScenarioRunContext | null
+  graphLookup: EventGraphLookup
+}) {
+  const durationMs = runContext?.global.simulationDuration ?? 0
+  const frameTimes = useMemo(
+    () => output.timeSeries.map((frame) => frame.timestamp),
+    [output.timeSeries]
+  )
+  const playback = usePacedPlayback(durationMs, frameTimes)
+
+  if (!runContext) {
+    return (
+      <div className={`${SURFACE_CARD} p-4 text-sm text-nss-muted`}>
+        Replay data is available, but the run context for this session is missing.
+      </div>
+    )
+  }
+
+  if (output.timeSeries.length === 0) {
+    return (
+      <div className={`${SURFACE_CARD} p-4 text-sm text-nss-muted`}>
+        No time-series snapshots were retained for this run.
+      </div>
+    )
+  }
+
+  const currentSimMs = playback.playheadMs
+  const snapshot = snapshotAtTime(output.timeSeries, currentSimMs)
+  const replayProgress = durationMs > 0 ? (currentSimMs / durationMs) * 100 : 0
+  const isWarmup = currentSimMs < runContext.global.warmupDuration
+  const phaseLabel = livePatternPhaseLabel(runContext.workload, currentSimMs)
+  const phaseValue = `${isWarmup ? 'Warmup' : 'Steady state'}${phaseLabel ? ` · ${phaseLabel}` : ''}`
+  const arrivalWindowMs = Math.min(
+    4_000,
+    Math.max(1_200, Math.round(runContext.global.simulationDuration / 12))
+  )
+  const arrivalBins = simulatedArrivalBins(
+    runContext.workload,
+    currentSimMs,
+    arrivalWindowMs,
+    LIVE_PATTERN_BAR_COUNT
+  )
+  const currentSourceRate =
+    workloadRateMultiplierAtMs(runContext.workload, currentSimMs) * runContext.workload.baseRps
+  const currentErrorRate = errorRateAtTime(output, currentSimMs)
+  const liveNodes = Object.entries(snapshot.node)
+  const totalInSystem = liveNodes.reduce((sum, [, node]) => sum + node.totalInSystem, 0)
+  const totalWorkers = liveNodes.reduce((sum, [, node]) => sum + node.activeWorkers, 0)
+  const hotQueueEntry = [...liveNodes].sort((a, b) => {
+    const queueDiff = b[1].queueLength - a[1].queueLength
+    if (queueDiff !== 0) return queueDiff
+    return b[1].totalInSystem - a[1].totalInSystem
+  })[0]
+  const hotQueueLabel = hotQueueEntry
+    ? `${labelForNode(hotQueueEntry[0], graphLookup) ?? hotQueueEntry[0]} · ${Math.round(hotQueueEntry[1].queueLength)}`
+    : '-'
+  const busiestNodes = [...liveNodes]
+    .sort((a, b) => {
+      const inSystemDiff = b[1].totalInSystem - a[1].totalInSystem
+      if (inSystemDiff !== 0) return inSystemDiff
+      const queueDiff = b[1].queueLength - a[1].queueLength
+      if (queueDiff !== 0) return queueDiff
+      // Stable tiebreak so interpolated near-ties don't swap rows every frame.
+      return a[0].localeCompare(b[0])
+    })
+    .filter(([, node]) => node.totalInSystem > 0 || node.queueLength > 0 || node.status !== 'idle')
+  const buttonClass =
+    'h-7 w-7 inline-flex items-center justify-center rounded border border-nss-border text-nss-muted hover:text-nss-text hover:bg-nss-surface transition-colors disabled:opacity-40 disabled:hover:bg-transparent'
+  const patternDetails = workloadPatternDetails(runContext.workload)
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className={SECTION_TITLE}>Replay Monitor</h3>
+          <div className="text-xs text-nss-muted">
+            Scrub saved snapshots to replay the run state over simulation time.
+          </div>
+        </div>
+        <span className="text-[10px] text-nss-muted tabular-nums">
+          {fmtChartTime(currentSimMs)} · {playback.speed}×
+        </span>
+      </div>
+
+      <div className={`${SURFACE_CARD} p-3 space-y-3`}>
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            onClick={playback.jumpStart}
+            disabled={currentSimMs <= 0}
+            className={buttonClass}
+            title="Jump to start"
+            aria-label="Jump to start"
+          >
+            <ChevronsLeft size={14} />
+          </button>
+          <button
+            type="button"
+            onClick={() => playback.stepToFrame(-1)}
+            disabled={currentSimMs <= 0}
+            className={buttonClass}
+            title="Step back one snapshot"
+            aria-label="Step back"
+          >
+            <ChevronLeft size={14} />
+          </button>
+          <button
+            type="button"
+            onClick={playback.toggle}
+            disabled={durationMs <= 0}
+            className={buttonClass}
+            title={playback.isPlaying ? 'Pause' : 'Play'}
+            aria-label={playback.isPlaying ? 'Pause' : 'Play'}
+          >
+            {playback.isPlaying ? <Pause size={14} /> : <Play size={14} />}
+          </button>
+          <input
+            type="range"
+            min={0}
+            max={Math.max(1, durationMs)}
+            step={Math.max(1, durationMs / 1000)}
+            value={currentSimMs}
+            onChange={(event) => playback.seek(Number(event.target.value))}
+            className="nss-range min-w-0 flex-1"
+            style={{ '--range-progress': `${replayProgress}%` } as CSSProperties}
+            aria-label="Replay time"
+          />
+          <button
+            type="button"
+            onClick={() => playback.stepToFrame(1)}
+            disabled={playback.atEnd}
+            className={buttonClass}
+            title="Step forward one snapshot"
+            aria-label="Step forward"
+          >
+            <ChevronRight size={14} />
+          </button>
+          <button
+            type="button"
+            onClick={playback.jumpEnd}
+            disabled={playback.atEnd}
+            className={buttonClass}
+            title="Jump to end"
+            aria-label="Jump to end"
+          >
+            <ChevronsRight size={14} />
+          </button>
+          <div className="ml-1 flex items-center gap-0.5">
+            {PLAYBACK_SPEEDS.map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => playback.setSpeed(option)}
+                className={`rounded px-1.5 py-1 text-[10px] font-medium tabular-nums transition-colors ${
+                  playback.speed === option
+                    ? 'bg-nss-primary/15 text-nss-primary'
+                    : 'text-nss-muted hover:text-nss-text'
+                }`}
+                aria-pressed={playback.speed === option}
+                title={`${option}× speed`}
+              >
+                {option}×
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="text-[11px] text-nss-muted">
+          Playback eases between sampled snapshots over sim time. Drag to scrub; the step buttons
+          jump to a sampled frame.
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 text-sm xl:grid-cols-4">
+        <StatCard
+          label="Sim Clock"
+          value={`${fmtSeconds(currentSimMs)} / ${fmtSeconds(runContext.global.simulationDuration)}`}
+        />
+        <StatCard label="Snapshot" value={fmtChartTime(currentSimMs)} />
+        <StatCard label="Phase" value={phaseValue} highlight={isWarmup ? 'warn' : undefined} />
+        <StatCard label="Warmup Ends" value={fmtSeconds(runContext.global.warmupDuration)} />
+      </div>
+
+      <div className={`${SURFACE_CARD} p-3 space-y-3`}>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <div className="text-xs text-nss-muted">Source workload</div>
+            <div className="text-sm font-medium text-nss-text">
+              {runContext.sourceLabel} · {runContext.workload.pattern} ·{' '}
+              {runContext.workload.baseRps.toFixed(1)} rps
+            </div>
+          </div>
+          {phaseLabel && (
+            <span className="rounded-full border border-nss-primary/20 bg-nss-primary/10 px-2 py-1 text-[11px] font-medium text-nss-primary">
+              {phaseLabel}
+            </span>
+          )}
+        </div>
+
+        <ArrivalPatternStrip bins={arrivalBins} active={playback.isPlaying} />
+
+        <div className="flex items-center justify-between gap-3 text-[11px] text-nss-muted">
+          <span>{fmtSeconds(arrivalWindowMs)} arrival window</span>
+          <span>Slide or press play to walk the run again.</span>
+        </div>
+
+        {patternDetails.length > 0 && (
+          <div className="text-xs text-nss-muted">{patternDetails.join(' • ')}</div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 text-sm xl:grid-cols-4">
+        <StatCard label="Est. Source Emit" value={fmtRps(currentSourceRate)} />
+        <StatCard label="In System" value={Math.round(totalInSystem).toLocaleString()} />
+        <StatCard
+          label="Window Fail"
+          value={currentErrorRate === null ? '-' : fmtPct(currentErrorRate)}
+          highlight={
+            currentErrorRate === null
+              ? undefined
+              : currentErrorRate > 0.05
+                ? 'crit'
+                : currentErrorRate > 0
+                  ? 'warn'
+                  : 'ok'
+          }
+        />
+        <StatCard label="Hot Queue" value={hotQueueLabel} />
+      </div>
+
+      <RequestOutcomeLog output={output} graphLookup={graphLookup} />
+
+      <BusiestNodesCard
+        busiestNodes={busiestNodes}
+        totalWorkers={totalWorkers}
+        graphLookup={graphLookup}
+        nodeCount={liveNodes.length}
+        emptyLabel="No components were carrying visible load at this snapshot."
+      />
     </div>
   )
 }
@@ -349,11 +1973,41 @@ function StatCard({
         ? 'text-nss-warning'
         : 'text-nss-text'
 
-  return (
-    <div className={`${SURFACE_CARD} p-2`} title={tooltip}>
+  const card = (triggerProps?: HTMLAttributes<HTMLDivElement>) => (
+    <div className={`${SURFACE_CARD} p-2`} tabIndex={tooltip ? 0 : undefined} {...triggerProps}>
       <div className="text-xs text-nss-muted">{label}</div>
       <div className={`font-medium tabular-nums text-sm ${colour}`}>{value}</div>
     </div>
+  )
+
+  if (!tooltip) {
+    return card()
+  }
+
+  return <HoverTooltip content={tooltip}>{(triggerProps) => card(triggerProps)}</HoverTooltip>
+}
+
+function MetricHeaderCell({
+  label,
+  tooltip,
+  className = 'text-right pb-1 pr-2'
+}: {
+  label: string
+  tooltip: string
+  className?: string
+}) {
+  return (
+    <th className={className}>
+      <span className="inline-flex items-center justify-end gap-1">
+        <span>{label}</span>
+        <TooltipInfo
+          label={`Explain ${label}`}
+          content={tooltip}
+          width={280}
+          className="h-3 w-3 text-[8px]"
+        />
+      </span>
+    </th>
   )
 }
 
@@ -448,7 +2102,7 @@ function SummaryPanel({ output }: { output: SimulationOutput }) {
       ]
     >
   ).filter(([, metrics]) => metrics.count > 0)
-  const throughputDisplay = summary.postWarmupTotalRequests > 0 ? fmtRps(summary.throughput) : '—'
+  const throughputDisplay = summary.postWarmupTotalRequests > 0 ? fmtRps(summary.throughput) : '-'
   const totalInFlightAtCutoff = output.conservationCheck.reduce(
     (sum, result) => sum + result.inFlight,
     0
@@ -474,42 +2128,40 @@ function SummaryPanel({ output }: { output: SimulationOutput }) {
         <StatCard
           label="Requests (post-warmup)"
           value={summary.postWarmupTotalRequests.toLocaleString()}
-          tooltip="Total requests that entered the system after warmup ended. Warmup samples are excluded so transient startup behavior doesn't skew the metrics."
+          tooltip={RESULTS_SUMMARY_TOOLTIPS.requestsPostWarmup}
         />
         <StatCard
           label="Successful"
           value={summary.postWarmupSuccessfulRequests.toLocaleString()}
-          tooltip="Requests that both entered after warmup and eventually completed successfully."
+          tooltip={RESULTS_SUMMARY_TOOLTIPS.successful}
         />
         <StatCard
           label="Throughput"
           value={throughputDisplay}
-          tooltip="Requests completed per second, averaged over the post-warmup window. If this exceeds your configured Base RPS, something (retries, fan-out, misconfigured source) is amplifying traffic."
+          tooltip={RESULTS_SUMMARY_TOOLTIPS.throughput}
         />
         <StatCard
           label="Error Rate"
           value={fmtPct(summary.errorRate)}
           highlight={errorHighlight}
-          tooltip="Fraction of post-warmup requests that failed. This includes instant rejects, timeout walls, and connection resets."
+          tooltip={RESULTS_SUMMARY_TOOLTIPS.errorRate}
         />
         <StatCard
           label="In Flight at Cutoff"
           value={totalInFlightAtCutoff.toLocaleString()}
           highlight={totalInFlightAtCutoff > 0 ? 'warn' : 'ok'}
-          tooltip="Requests that had entered at least one node after warmup, but had not yet completed, timed out, or been rejected when the simulation stopped."
+          tooltip={RESULTS_SUMMARY_TOOLTIPS.inFlightAtCutoff}
         />
         <StatCard
           label="Offered Arrival CV"
           value={fmtCv(summary.offeredArrivalCV)}
-          tooltip="Coefficient of variation of source-generated inter-arrival gaps after warmup. 0 means perfectly even; ≈1 is Poisson."
+          tooltip={RESULTS_SUMMARY_TOOLTIPS.offeredArrivalCv}
         />
       </div>
 
       {totalInFlightAtCutoff > 0 && (
         <div className="rounded-md border border-nss-warning/20 bg-nss-warning/10 px-3 py-2 text-xs text-nss-warning">
-          {totalInFlightAtCutoff.toLocaleString()} request
-          {totalInFlightAtCutoff === 1 ? '' : 's'} were still in flight when the simulation hit its
-          duration limit. They are not counted as completed or failed.
+          {formatInFlightAtCutoffBanner(totalInFlightAtCutoff)}
         </div>
       )}
 
@@ -520,19 +2172,24 @@ function SummaryPanel({ output }: { output: SimulationOutput }) {
         errorRate={summary.latencyWindowErrorRate}
       >
         <div className="flex items-baseline justify-between gap-3">
-          <span
-            className="text-[10px] text-nss-muted"
-            title="Percentiles don't compose — E2E p99 ≠ sum of per-hop p99s. Use per-node mean (W) for additive decomposition."
-          >
-            ⓘ percentiles do not sum across hops
-          </span>
+          <HoverTooltip content={RESULTS_CONTEXTUAL_TOOLTIPS.percentilesDoNotCompose} width={320}>
+            {(triggerProps) => (
+              <span className="text-[10px] text-nss-muted" tabIndex={0} {...triggerProps}>
+                ⓘ percentiles do not sum across hops
+              </span>
+            )}
+          </HoverTooltip>
         </div>
         <div className="grid grid-cols-5 gap-1 text-xs text-center">
           {(['p50', 'p90', 'p95', 'p99', 'max'] as const).map((k) => (
-            <div key={k} className={`${SURFACE_CARD} p-1.5`} title={E2E_PERCENTILE_TOOLTIPS[k]}>
-              <div className="text-nss-muted">{k}</div>
-              <div className="font-medium tabular-nums text-nss-text">{fmtMs(l[k])}</div>
-            </div>
+            <HoverTooltip key={k} content={RESULTS_E2E_PERCENTILE_TOOLTIPS[k]} width={280}>
+              {(triggerProps) => (
+                <div className={`${SURFACE_CARD} p-1.5`} tabIndex={0} {...triggerProps}>
+                  <div className="text-nss-muted">{k}</div>
+                  <div className="font-medium tabular-nums text-nss-text">{fmtMs(l[k])}</div>
+                </div>
+              )}
+            </HoverTooltip>
           ))}
         </div>
       </LatencyPopulationSection>
@@ -607,23 +2264,30 @@ function CollapsibleCheck({
         ? 'text-nss-warning'
         : 'text-nss-success'
   const icon = level === 'healthy' ? '✓' : level === 'warnings' ? '⚠' : '✕'
+  const button = (triggerProps?: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button
+      type="button"
+      onClick={() => setOpen((o) => !o)}
+      aria-expanded={open}
+      aria-controls={contentId}
+      className="w-full flex items-center justify-between px-3 py-2 bg-nss-surface hover:bg-nss-bg text-left transition-colors"
+      {...triggerProps}
+    >
+      <span className="flex items-center gap-2 text-xs font-medium text-nss-text">
+        <span className={iconCls}>{icon}</span>
+        {title}
+      </span>
+      <span className="text-nss-muted text-[10px]">{open ? '▲' : '▼'}</span>
+    </button>
+  )
 
   return (
     <div className="border border-nss-border rounded-md overflow-hidden">
-      <button
-        type="button"
-        onClick={() => setOpen((o) => !o)}
-        aria-expanded={open}
-        aria-controls={contentId}
-        title={tooltip}
-        className="w-full flex items-center justify-between px-3 py-2 bg-nss-surface hover:bg-nss-bg text-left transition-colors"
-      >
-        <span className="flex items-center gap-2 text-xs font-medium text-nss-text">
-          <span className={iconCls}>{icon}</span>
-          {title}
-        </span>
-        <span className="text-nss-muted text-[10px]">{open ? '▲' : '▼'}</span>
-      </button>
+      {tooltip ? (
+        <HoverTooltip content={tooltip}>{(triggerProps) => button(triggerProps)}</HoverTooltip>
+      ) : (
+        button()
+      )}
       {open && (
         <div id={contentId} className="px-3 py-2 bg-nss-panel space-y-1">
           {children}
@@ -646,6 +2310,12 @@ const CONDITION_CLASSES: Record<'ok' | 'warn' | 'crit', string> = {
   crit: 'text-nss-danger border-nss-danger/30 bg-nss-danger/10'
 }
 
+const CAPACITY_CLASSES: Record<CapacityStatus['level'], string> = {
+  headroom: 'text-nss-success border-nss-success/30 bg-nss-success/10',
+  tight: 'text-nss-warning border-nss-warning/25 bg-nss-warning/10',
+  saturated: 'text-nss-warning border-nss-warning/40 bg-nss-warning/15'
+}
+
 function dominantCause(tte: NodeMetric['timeToErrorByCause']): ErrorCauseKey | null {
   return dominantTimeToErrorCause(tte)
 }
@@ -656,31 +2326,14 @@ function dominantCause(tte: NodeMetric['timeToErrorByCause']): ErrorCauseKey | n
  * passes) never renders as healthy, and the dominant failure cause separates
  * "overloaded" (queue_full) from "dead" (node_failed) from "silent" (timeout).
  */
-function nodeCondition(m: NodeMetric): { label: string; level: 'ok' | 'warn' | 'crit' } {
-  const hasWindowSamples = m.successLatencySamples + m.timeToErrorSamples > 0
-  if (m.postWarmupArrived === 0 && !hasWindowSamples) return { label: 'Idle', level: 'ok' }
-  const served = m.successLatencySamples > 0
-  const dominant = dominantCause(m.timeToErrorByCause)
-
-  if (!served && m.latencyWindowErrorRate > 0.5) {
-    if (dominant === 'timeout') return { label: 'Silent (timing out)', level: 'crit' }
-    return { label: 'Down', level: 'crit' }
-  }
-  if (m.latencyWindowErrorRate > 0.05) {
-    switch (dominant) {
-      case 'node_failed':
-        return { label: 'Failing', level: 'crit' }
-      case 'queue_full':
-        return { label: 'Overloaded', level: 'warn' }
-      case 'timeout':
-        return { label: 'Timing out', level: 'warn' }
-      case 'network_error':
-        return { label: 'Network errors', level: 'warn' }
-      default:
-        return { label: 'Degraded', level: 'warn' }
-    }
-  }
-  return { label: 'Healthy', level: 'ok' }
+function nodeCondition(m: NodeMetric): ReliabilityStatus {
+  return deriveReliabilityStatus({
+    postWarmupArrived: m.postWarmupArrived,
+    successLatencySamples: m.successLatencySamples,
+    timeToErrorSamples: m.timeToErrorSamples,
+    latencyWindowErrorRate: m.latencyWindowErrorRate,
+    timeToErrorByCause: m.timeToErrorByCause
+  })
 }
 
 /**
@@ -689,22 +2342,48 @@ function nodeCondition(m: NodeMetric): { label: string; level: 'ok' | 'warn' | '
  * wrong claim. The card never puts an approving mark next to a latency when the
  * node is down: the survivor-bias 8ms is only over requests that succeeded.
  */
-function NodeConditionCard({ nodeId, m }: { nodeId: string; m: NodeMetric }) {
-  const condition = nodeCondition(m)
+function NodeConditionCard({
+  nodeId,
+  m,
+  workers
+}: {
+  nodeId: string
+  m: NodeMetric
+  workers?: number
+}) {
+  const reliability = nodeCondition(m)
+  const capacity = deriveCapacityStatus({
+    utilization: m.utilization,
+    utilizationUnit: 'ratio',
+    queueDepth: m.avgQueueLength,
+    workers
+  })
   const served = m.successLatencySamples
   const lowSample = served > 0 && served < LOW_SAMPLE_FLOOR
   const p95 = m.latencyNodeLocal.p95
-  const dominant = dominantCause(m.timeToErrorByCause)
 
   return (
     <div className={`${SURFACE_CARD} p-2.5 space-y-2`}>
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex items-start justify-between gap-3">
         <span className="text-xs font-medium text-nss-text truncate">{m.nodeLabel ?? nodeId}</span>
-        <span
-          className={`text-[10px] font-semibold px-1.5 py-0.5 rounded border ${CONDITION_CLASSES[condition.level]}`}
-        >
-          {condition.label}
-        </span>
+        <div className="grid gap-1 text-right">
+          <div className="flex items-center justify-end gap-1.5">
+            <span className="text-[10px] text-nss-muted uppercase tracking-wide">Reliability</span>
+            <span
+              className={`text-[10px] font-semibold px-1.5 py-0.5 rounded border ${CONDITION_CLASSES[reliability.tone]}`}
+            >
+              {reliability.label}
+            </span>
+          </div>
+          <div className="flex items-center justify-end gap-1.5">
+            <span className="text-[10px] text-nss-muted uppercase tracking-wide">Capacity</span>
+            <span
+              className={`text-[10px] font-semibold px-1.5 py-0.5 rounded border ${CAPACITY_CLASSES[capacity.level]}`}
+            >
+              {capacity.label}
+            </span>
+          </div>
+        </div>
       </div>
 
       <div className="flex items-baseline justify-between gap-2">
@@ -734,19 +2413,43 @@ function NodeConditionCard({ nodeId, m }: { nodeId: string; m: NodeMetric }) {
           {fmtPct(m.latencyWindowErrorRate)}
         </span>
       </div>
-      <div className="text-[10px] text-nss-muted">
-        {dominant ? `mostly ${ERROR_CAUSE_LABELS[dominant]}` : 'no failures at this node'}
-        {' · same window as latency'}
+      <div className="text-[10px] text-nss-muted">{reliability.detail}</div>
+
+      <div className="flex items-baseline justify-between gap-2 border-t border-nss-border pt-1.5">
+        <span className="text-[10px] text-nss-muted uppercase tracking-wide">capacity</span>
+        <span
+          className={`text-sm font-medium tabular-nums ${
+            capacity.level === 'headroom' ? 'text-nss-success' : 'text-nss-warning'
+          }`}
+        >
+          {fmtPct(m.utilization)}
+        </span>
       </div>
+      <div className="text-[10px] text-nss-muted">{capacity.detail}</div>
     </div>
   )
 }
 
-function conditionRank(level: 'ok' | 'warn' | 'crit'): number {
-  return level === 'crit' ? 2 : level === 'warn' ? 1 : 0
+function conditionRank(condition: ReliabilityStatus): number {
+  return reliabilityRank(condition.level) * 10 + toneRank(condition.tone)
 }
 
 function NodeConditionCards({ output }: { output: SimulationOutput }) {
+  const nodes = useStore((state) => state.nodes)
+  const workersByNodeId = useMemo(() => {
+    const byId = new Map<string, number>()
+
+    for (const node of nodes) {
+      const workers = (node.data as { sim?: { queue?: { workers?: unknown } } } | undefined)?.sim
+        ?.queue?.workers
+      if (typeof workers === 'number' && Number.isFinite(workers) && workers > 0) {
+        byId.set(node.id, workers)
+      }
+    }
+
+    return byId
+  }, [nodes])
+
   const active = Object.entries(output.perNode)
     .filter(
       ([, m]) => m.postWarmupArrived > 0 || m.successLatencySamples > 0 || m.timeToErrorSamples > 0
@@ -754,8 +2457,19 @@ function NodeConditionCards({ output }: { output: SimulationOutput }) {
     .sort(([, a], [, b]) => {
       const aCondition = nodeCondition(a)
       const bCondition = nodeCondition(b)
+      const aCapacity = deriveCapacityStatus({
+        utilization: a.utilization,
+        utilizationUnit: 'ratio',
+        queueDepth: a.avgQueueLength
+      })
+      const bCapacity = deriveCapacityStatus({
+        utilization: b.utilization,
+        utilizationUnit: 'ratio',
+        queueDepth: b.avgQueueLength
+      })
       return (
-        conditionRank(bCondition.level) - conditionRank(aCondition.level) ||
+        conditionRank(bCondition) - conditionRank(aCondition) ||
+        capacityRank(bCapacity.level) - capacityRank(aCapacity.level) ||
         b.latencyWindowErrorRate - a.latencyWindowErrorRate ||
         b.timeToErrorSamples - a.timeToErrorSamples ||
         b.successLatencySamples - a.successLatencySamples
@@ -767,7 +2481,12 @@ function NodeConditionCards({ output }: { output: SimulationOutput }) {
       <h3 className={SECTION_TITLE}>Node Health</h3>
       <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
         {active.map(([nodeId, m]) => (
-          <NodeConditionCard key={nodeId} nodeId={nodeId} m={m} />
+          <NodeConditionCard
+            key={nodeId}
+            nodeId={nodeId}
+            m={m}
+            workers={workersByNodeId.get(nodeId)}
+          />
         ))}
       </div>
     </div>
@@ -833,7 +2552,7 @@ function BottleneckVerdicts({
               <div className="text-xs text-nss-text">
                 <span className="font-medium">{latencyLabel}</span>{' '}
                 <span className="text-nss-muted">
-                  — {fmtMs(latTop.meanMs)} ({fmtPct(latTop.shareOfEndToEnd)} of end-to-end,{' '}
+                  - {fmtMs(latTop.meanMs)} ({fmtPct(latTop.shareOfEndToEnd)} of end-to-end,{' '}
                   {latTop.kind})
                 </span>
               </div>
@@ -856,14 +2575,14 @@ function BottleneckVerdicts({
               <div className="text-xs text-nss-text">
                 <span className="font-medium">{failureLabel}</span>{' '}
                 <span className="text-nss-muted">
-                  — {failTop.total.toLocaleString()} killed (
+                  - {failTop.total.toLocaleString()} killed (
                   {ERROR_CAUSE_LABELS[failTop.dominantCause]}, {fmtPct(failTop.shareOfFailures)} of
                   failures)
                 </span>
               </div>
             </button>
           ) : (
-            <div className="text-xs text-nss-success">No failures — nothing to locate.</div>
+            <div className="text-xs text-nss-success">No failures - nothing to locate.</div>
           )}
         </div>
       </div>
@@ -937,6 +2656,15 @@ function StatusTimelineStrip({ output }: { output: SimulationOutput }) {
 
 type ChartPoint = { xMs: number; y: number | null }
 type ChartSeries = { label: string; color: string; points: ChartPoint[] }
+type HoveredChartPoint = {
+  key: string
+  label: string
+  value: string
+  timeLabel: string
+  leftPercent: number
+  topPercent: number
+  placement: 'above' | 'below'
+}
 
 function edgeCondition(m: EdgeMetric): { label: string; level: 'ok' | 'warn' | 'crit' } {
   const total = m.successLatencySamples + m.timeToErrorSamples
@@ -1048,6 +2776,11 @@ function linePath(
     .join(' ')
 }
 
+function fmtChartTime(ms: number): string {
+  const seconds = ms / 1000
+  return `t=${seconds.toFixed(Number.isInteger(seconds) ? 0 : 1)}s`
+}
+
 function TimelineChart({
   title,
   subtitle,
@@ -1055,7 +2788,9 @@ function TimelineChart({
   warmupDurationMs,
   statusWindows,
   series,
-  yFormatter
+  yFormatter,
+  xAxisLabel = 'simulation time (seconds)',
+  yAxisLabel
 }: {
   title: string
   subtitle: string
@@ -1064,13 +2799,16 @@ function TimelineChart({
   statusWindows: StatusWindow[]
   series: ChartSeries[]
   yFormatter: (value: number | null) => string
+  xAxisLabel?: string
+  yAxisLabel: string
 }) {
   const width = 640
   const height = 180
-  const margin = { top: 12, right: 12, bottom: 24, left: 36 }
+  const margin = { top: 12, right: 12, bottom: 24, left: 44 }
   const plotWidth = width - margin.left - margin.right
   const plotHeight = height - margin.top - margin.bottom
   const duration = Math.max(1, totalDurationMs)
+  const [hoveredPoint, setHoveredPoint] = useState<HoveredChartPoint | null>(null)
   const values = series.flatMap((item) =>
     item.points.map((point) => point.y).filter((value): value is number => value !== null)
   )
@@ -1085,6 +2823,9 @@ function TimelineChart({
         <div>
           <div className="text-xs font-medium text-nss-text">{title}</div>
           <div className="text-[10px] text-nss-muted">{subtitle}</div>
+          <div className="mt-1 text-[10px] text-nss-muted">
+            x-axis: {xAxisLabel} · y-axis: {yAxisLabel}
+          </div>
         </div>
         <div className="text-[10px] text-nss-muted tabular-nums">
           max {yFormatter(values.length > 0 ? yMax : null)}
@@ -1096,79 +2837,152 @@ function TimelineChart({
           No windowed samples for this chart.
         </div>
       ) : (
-        <svg viewBox={`0 0 ${width} ${height}`} className="w-full h-44 rounded bg-nss-panel">
-          <rect x={0} y={0} width={width} height={height} rx={8} fill="transparent" />
-          {warmupDurationMs > 0 && (
-            <rect
-              x={margin.left}
-              y={margin.top}
-              width={(Math.min(duration, warmupDurationMs) / duration) * plotWidth}
-              height={plotHeight}
-              fill="rgba(148, 163, 184, 0.12)"
-            />
-          )}
-          {statusWindows.map((window, index) => (
-            <rect
-              key={`${window.componentId}-${window.startMs}-${index}`}
-              x={xAt(window.startMs)}
-              y={margin.top}
-              width={Math.max(2, xAt(window.endMs) - xAt(window.startMs))}
-              height={plotHeight}
-              fill="rgba(239, 68, 68, 0.16)"
-            />
-          ))}
-          {[0.25, 0.5, 0.75, 1].map((fraction) => (
-            <line
-              key={fraction}
-              x1={margin.left}
-              x2={width - margin.right}
-              y1={margin.top + plotHeight - plotHeight * fraction}
-              y2={margin.top + plotHeight - plotHeight * fraction}
-              stroke="rgba(148, 163, 184, 0.18)"
-              strokeWidth={1}
-            />
-          ))}
-          {series.map((item) => {
-            const path = linePath(item.points, xAt, yAt)
-            return (
-              <g key={item.label}>
-                {path && (
-                  <path
-                    d={path}
-                    fill="none"
-                    stroke={item.color}
-                    strokeWidth={2}
-                    strokeLinejoin="round"
-                    strokeLinecap="round"
-                  />
-                )}
-                {item.points
-                  .filter((point) => point.y !== null)
-                  .map((point, index) => (
-                    <circle
-                      key={`${item.label}-${index}`}
-                      cx={xAt(point.xMs)}
-                      cy={yAt(point.y as number)}
-                      r={2.4}
-                      fill={item.color}
+        <div className="relative" onMouseLeave={() => setHoveredPoint(null)}>
+          <svg viewBox={`0 0 ${width} ${height}`} className="w-full h-44 rounded bg-nss-panel">
+            <rect x={0} y={0} width={width} height={height} rx={8} fill="transparent" />
+            {warmupDurationMs > 0 && (
+              <rect
+                x={margin.left}
+                y={margin.top}
+                width={(Math.min(duration, warmupDurationMs) / duration) * plotWidth}
+                height={plotHeight}
+                fill="rgba(148, 163, 184, 0.12)"
+              />
+            )}
+            {statusWindows.map((window, index) => (
+              <rect
+                key={`${window.componentId}-${window.startMs}-${index}`}
+                x={xAt(window.startMs)}
+                y={margin.top}
+                width={Math.max(2, xAt(window.endMs) - xAt(window.startMs))}
+                height={plotHeight}
+                fill="rgba(239, 68, 68, 0.16)"
+              />
+            ))}
+            {[0.25, 0.5, 0.75, 1].map((fraction) => (
+              <line
+                key={fraction}
+                x1={margin.left}
+                x2={width - margin.right}
+                y1={margin.top + plotHeight - plotHeight * fraction}
+                y2={margin.top + plotHeight - plotHeight * fraction}
+                stroke="rgba(148, 163, 184, 0.18)"
+                strokeWidth={1}
+              />
+            ))}
+            <text
+              x={14}
+              y={margin.top + plotHeight / 2}
+              textAnchor="middle"
+              fill="rgba(148, 163, 184, 0.8)"
+              fontSize="9"
+              transform={`rotate(-90 14 ${margin.top + plotHeight / 2})`}
+            >
+              {yAxisLabel}
+            </text>
+            {series.map((item) => {
+              const path = linePath(item.points, xAt, yAt)
+              return (
+                <g key={item.label}>
+                  {path && (
+                    <path
+                      d={path}
+                      fill="none"
+                      stroke={item.color}
+                      strokeWidth={2}
+                      strokeLinejoin="round"
+                      strokeLinecap="round"
                     />
-                  ))}
-              </g>
-            )
-          })}
-          <text x={margin.left} y={height - 6} fill="rgba(148, 163, 184, 0.8)" fontSize="10">
-            t=0
-          </text>
-          <text
-            x={width - margin.right}
-            y={height - 6}
-            textAnchor="end"
-            fill="rgba(148, 163, 184, 0.8)"
-            fontSize="10"
-          >
-            t={(duration / 1000).toFixed(0)}s
-          </text>
-        </svg>
+                  )}
+                  {item.points
+                    .filter((point) => point.y !== null)
+                    .map((point, index) => {
+                      const value = point.y as number
+                      const cx = xAt(point.xMs)
+                      const cy = yAt(value)
+                      const key = `${item.label}-${index}-${point.xMs}`
+                      const isHovered = hoveredPoint?.key === key
+
+                      return (
+                        <g key={key}>
+                          {isHovered && (
+                            <circle
+                              cx={cx}
+                              cy={cy}
+                              r={5.5}
+                              fill="transparent"
+                              stroke={item.color}
+                              strokeWidth={1.5}
+                              opacity={0.85}
+                            />
+                          )}
+                          <circle cx={cx} cy={cy} r={2.4} fill={item.color} />
+                          <circle
+                            cx={cx}
+                            cy={cy}
+                            r={8}
+                            fill="transparent"
+                            onMouseEnter={() =>
+                              setHoveredPoint({
+                                key,
+                                label: item.label,
+                                value: yFormatter(value),
+                                timeLabel: fmtChartTime(point.xMs),
+                                leftPercent: (cx / width) * 100,
+                                topPercent: (cy / height) * 100,
+                                placement: cy < margin.top + 34 ? 'below' : 'above'
+                              })
+                            }
+                          />
+                        </g>
+                      )
+                    })}
+                </g>
+              )
+            })}
+            <text x={margin.left} y={height - 6} fill="rgba(148, 163, 184, 0.8)" fontSize="10">
+              t=0
+            </text>
+            <text
+              x={width / 2}
+              y={height - 6}
+              textAnchor="middle"
+              fill="rgba(148, 163, 184, 0.8)"
+              fontSize="10"
+            >
+              {xAxisLabel}
+            </text>
+            <text
+              x={width - margin.right}
+              y={height - 6}
+              textAnchor="end"
+              fill="rgba(148, 163, 184, 0.8)"
+              fontSize="10"
+            >
+              t={(duration / 1000).toFixed(0)}s
+            </text>
+          </svg>
+
+          {hoveredPoint && (
+            <div
+              className="pointer-events-none absolute z-10 w-44 -translate-x-1/2 rounded-md border border-nss-border bg-nss-surface px-2.5 py-2 shadow-xl"
+              style={{
+                left: `${hoveredPoint.leftPercent}%`,
+                top: `${hoveredPoint.topPercent}%`,
+                transform:
+                  hoveredPoint.placement === 'above'
+                    ? 'translate(-50%, calc(-100% - 10px))'
+                    : 'translate(-50%, 10px)'
+              }}
+            >
+              <div className="text-[10px] font-semibold uppercase tracking-wide text-nss-muted">
+                {hoveredPoint.label}
+              </div>
+              <div className="mt-1 text-xs font-medium text-nss-text">{hoveredPoint.value}</div>
+              <div className="mt-1 text-[10px] text-nss-muted">{hoveredPoint.timeLabel}</div>
+            </div>
+          )}
+        </div>
       )}
 
       <div className="flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-nss-muted">
@@ -1202,6 +3016,7 @@ function SystemWindowCharts({ output }: { output: SimulationOutput }) {
           totalDurationMs={output.simulationDuration}
           warmupDurationMs={output.warmupDuration}
           statusWindows={output.statusTimeline}
+          yAxisLabel="end-to-end p95 latency (ms)"
           series={[
             {
               label: 'p95 latency',
@@ -1217,6 +3032,7 @@ function SystemWindowCharts({ output }: { output: SimulationOutput }) {
           totalDurationMs={output.simulationDuration}
           warmupDurationMs={output.warmupDuration}
           statusWindows={output.statusTimeline}
+          yAxisLabel="error rate (% of terminals)"
           series={[
             {
               label: 'error rate',
@@ -1341,8 +3157,19 @@ function ComponentSelectorPanel({
     .sort(([, a], [, b]) => {
       const aCondition = nodeCondition(a)
       const bCondition = nodeCondition(b)
+      const aCapacity = deriveCapacityStatus({
+        utilization: a.utilization,
+        utilizationUnit: 'ratio',
+        queueDepth: a.avgQueueLength
+      })
+      const bCapacity = deriveCapacityStatus({
+        utilization: b.utilization,
+        utilizationUnit: 'ratio',
+        queueDepth: b.avgQueueLength
+      })
       return (
-        conditionRank(bCondition.level) - conditionRank(aCondition.level) ||
+        conditionRank(bCondition) - conditionRank(aCondition) ||
+        capacityRank(bCapacity.level) - capacityRank(aCapacity.level) ||
         b.latencyWindowErrorRate - a.latencyWindowErrorRate
       )
     })
@@ -1352,7 +3179,7 @@ function ComponentSelectorPanel({
       const aCondition = edgeCondition(a)
       const bCondition = edgeCondition(b)
       return (
-        conditionRank(bCondition.level) - conditionRank(aCondition.level) ||
+        toneRank(bCondition.level) - toneRank(aCondition.level) ||
         b.latencyWindowErrorRate - a.latencyWindowErrorRate
       )
     })
@@ -1364,6 +3191,11 @@ function ComponentSelectorPanel({
         {nodeEntries.map(([nodeId, metric]) => {
           const condition = nodeCondition(metric)
           const isSelected = selected?.kind === 'node' && selected.id === nodeId
+          const capacity = deriveCapacityStatus({
+            utilization: metric.utilization,
+            utilizationUnit: 'ratio',
+            queueDepth: metric.avgQueueLength
+          })
           return (
             <button
               key={`node-${nodeId}`}
@@ -1380,10 +3212,12 @@ function ComponentSelectorPanel({
                   <div className="truncate text-xs font-medium text-nss-text">
                     {metric.nodeLabel ?? nodeId}
                   </div>
-                  <div className="text-[10px] text-nss-muted">node-local scope</div>
+                  <div className="text-[10px] text-nss-muted">
+                    node-local scope · capacity {capacity.label.toLowerCase()}
+                  </div>
                 </div>
                 <span
-                  className={`text-[10px] font-semibold px-1.5 py-0.5 rounded border ${CONDITION_CLASSES[condition.level]}`}
+                  className={`text-[10px] font-semibold px-1.5 py-0.5 rounded border ${CONDITION_CLASSES[condition.tone]}`}
                 >
                   {condition.label}
                 </span>
@@ -1506,7 +3340,7 @@ function ComponentDrilldown({
                 </div>
               </div>
               <span
-                className={`text-[10px] font-semibold px-2 py-0.5 rounded border ${CONDITION_CLASSES[condition.level]}`}
+                className={`text-[10px] font-semibold px-2 py-0.5 rounded border ${CONDITION_CLASSES[condition.tone]}`}
               >
                 {condition.label}
               </span>
@@ -1530,7 +3364,7 @@ function ComponentDrilldown({
               <StatCard
                 label="Offered CV"
                 value={fmtCv(output.summary.offeredArrivalCV)}
-                tooltip="Source-generated inter-arrival CV after warmup. Compare against this node's arrival CV to see how much variance the network added."
+                tooltip={RESULTS_CONTEXTUAL_TOOLTIPS.offeredCvVsArrivalCv}
               />
               <StatCard
                 label="Arrival CV"
@@ -1542,7 +3376,7 @@ function ComponentDrilldown({
                     ? 'warn'
                     : undefined
                 }
-                tooltip="Delivered inter-arrival CV at this node after warmup. 0 = perfectly even; ≈1 = Poisson."
+                tooltip={RESULTS_CONTEXTUAL_TOOLTIPS.arrivalCvNode}
               />
             </div>
 
@@ -1559,6 +3393,7 @@ function ComponentDrilldown({
                 totalDurationMs={output.simulationDuration}
                 warmupDurationMs={output.warmupDuration}
                 statusWindows={statusWindows}
+                yAxisLabel="node-local p95 latency (ms)"
                 series={[
                   {
                     label: 'p95 latency',
@@ -1574,6 +3409,7 @@ function ComponentDrilldown({
                 totalDurationMs={output.simulationDuration}
                 warmupDurationMs={output.warmupDuration}
                 statusWindows={statusWindows}
+                yAxisLabel="error rate (% of terminals)"
                 series={[
                   {
                     label: 'error rate',
@@ -1592,6 +3428,7 @@ function ComponentDrilldown({
                 totalDurationMs={output.simulationDuration}
                 warmupDurationMs={output.warmupDuration}
                 statusWindows={statusWindows}
+                yAxisLabel="queue length (requests)"
                 series={[
                   {
                     label: 'queue length',
@@ -1607,6 +3444,7 @@ function ComponentDrilldown({
                 totalDurationMs={output.simulationDuration}
                 warmupDurationMs={output.warmupDuration}
                 statusWindows={statusWindows}
+                yAxisLabel="utilization (% busy)"
                 series={[
                   {
                     label: 'utilization',
@@ -1749,6 +3587,7 @@ function ComponentDrilldown({
               totalDurationMs={output.simulationDuration}
               warmupDurationMs={output.warmupDuration}
               statusWindows={statusWindows}
+              yAxisLabel="edge transit p95 latency (ms)"
               series={[
                 {
                   label: 'p95 latency',
@@ -1764,6 +3603,7 @@ function ComponentDrilldown({
               totalDurationMs={output.simulationDuration}
               warmupDurationMs={output.warmupDuration}
               statusWindows={statusWindows}
+              yAxisLabel="error rate (% of terminals)"
               series={[
                 {
                   label: 'error rate',
@@ -1891,11 +3731,11 @@ function SimulationHealth({ output }: { output: SimulationOutput }) {
       <CollapsibleCheck
         title={
           sloLevel === 'healthy'
-            ? 'SLO — No breaches'
-            : `SLO — ${output.sloBreaches.length} breach${output.sloBreaches.length !== 1 ? 'es' : ''}`
+            ? 'SLO -No breaches'
+            : `SLO -${output.sloBreaches.length} breach${output.sloBreaches.length !== 1 ? 'es' : ''}`
         }
         level={sloLevel}
-        tooltip={HEALTH_CHECK_TOOLTIPS.slo}
+        tooltip={RESULTS_HEALTH_CHECK_TOOLTIPS.slo}
       >
         {sloLevel === 'healthy' ? (
           <p className="text-xs text-nss-muted">All configured SLO targets met.</p>
@@ -1918,7 +3758,7 @@ function SimulationHealth({ output }: { output: SimulationOutput }) {
                   {b.severity === 'critical' ? 'CRIT' : 'WARN'}
                 </span>
                 <span>
-                  {b.nodeLabel} — {metricStr}
+                  {b.nodeLabel} - {metricStr}
                 </span>
               </div>
             )
@@ -1930,11 +3770,11 @@ function SimulationHealth({ output }: { output: SimulationOutput }) {
       <CollapsibleCheck
         title={
           errorLevel === 'healthy'
-            ? 'Error Rate — None'
-            : `Error Rate — ${fmtPct(output.summary.errorRate)} (${output.summary.postWarmupFailedRequests.toLocaleString()} errors)`
+            ? 'Error Rate -None'
+            : `Error Rate -${fmtPct(output.summary.errorRate)} (${output.summary.postWarmupFailedRequests.toLocaleString()} errors)`
         }
         level={errorLevel}
-        tooltip={HEALTH_CHECK_TOOLTIPS.errorRate}
+        tooltip={RESULTS_HEALTH_CHECK_TOOLTIPS.errorRate}
       >
         {errorLevel === 'healthy' ? (
           <p className="text-xs text-nss-muted">
@@ -1984,11 +3824,11 @@ function SimulationHealth({ output }: { output: SimulationOutput }) {
       <CollapsibleCheck
         title={
           llLevel === 'healthy'
-            ? "Little's Law — Within tolerance"
-            : `Little's Law — ${llViolations.length} violation${llViolations.length !== 1 ? 's' : ''} (error > 10%)`
+            ? "Little's Law -Within tolerance"
+            : `Little's Law -${llViolations.length} violation${llViolations.length !== 1 ? 's' : ''} (error > 10%)`
         }
         level={llLevel}
-        tooltip={HEALTH_CHECK_TOOLTIPS.littlesLaw}
+        tooltip={RESULTS_HEALTH_CHECK_TOOLTIPS.littlesLaw}
       >
         {llLevel === 'healthy' ? (
           <p className="text-xs text-nss-muted">L = λW verified for all nodes (error ≤ 10%).</p>
@@ -2014,12 +3854,12 @@ function SimulationHealth({ output }: { output: SimulationOutput }) {
         title={
           conservationLevel === 'healthy'
             ? totalInFlightAtCutoff > 0
-              ? `Conservation — Balanced (${totalInFlightAtCutoff} in-flight at cutoff)`
-              : 'Conservation — Balanced'
-            : `Conservation — ${imbalanced.length} node${imbalanced.length !== 1 ? 's' : ''} with in-flight requests`
+              ? `Conservation -Balanced (${totalInFlightAtCutoff} in-flight at cutoff)`
+              : 'Conservation -Balanced'
+            : `Conservation -${imbalanced.length} node${imbalanced.length !== 1 ? 's' : ''} with in-flight requests`
         }
         level={conservationLevel}
-        tooltip={HEALTH_CHECK_TOOLTIPS.conservation}
+        tooltip={RESULTS_HEALTH_CHECK_TOOLTIPS.conservation}
       >
         {conservationLevel === 'healthy' ? (
           totalInFlightAtCutoff === 0 ? (
@@ -2057,9 +3897,9 @@ function SimulationHealth({ output }: { output: SimulationOutput }) {
 
       {/* Warmup */}
       <CollapsibleCheck
-        title={warmupLevel === 'healthy' ? 'Warmup — Adequate' : 'Warmup — May be too short'}
+        title={warmupLevel === 'healthy' ? 'Warmup -Adequate' : 'Warmup -May be too short'}
         level={warmupLevel}
-        tooltip={HEALTH_CHECK_TOOLTIPS.warmup}
+        tooltip={RESULTS_HEALTH_CHECK_TOOLTIPS.warmup}
       >
         <p
           className={`text-xs ${warmupLevel === 'healthy' ? 'text-nss-muted' : 'text-nss-warning'}`}
@@ -2102,54 +3942,38 @@ function PerNodeTable({ output }: { output: SimulationOutput }) {
           <thead>
             <tr className="text-nss-muted border-b border-nss-border">
               <th className="text-left pb-1 pr-2">Node</th>
-              <th className="text-right pb-1 pr-2" title={PER_NODE_COLUMN_TOOLTIPS.arrived}>
-                Arrived
-              </th>
-              <th className="text-right pb-1 pr-2" title={PER_NODE_COLUMN_TOOLTIPS.done}>
-                Done
-              </th>
-              <th className="text-right pb-1 pr-2" title={PER_NODE_COLUMN_TOOLTIPS.reject}>
-                Reject
-              </th>
-              <th className="text-right pb-1 pr-2" title={PER_NODE_COLUMN_TOOLTIPS.timedOut}>
-                T.O.
-              </th>
-              <th className="text-right pb-1 pr-2" title={PER_NODE_COLUMN_TOOLTIPS.reset}>
-                Reset
-              </th>
-              <th className="text-right pb-1 pr-2" title={PER_NODE_COLUMN_TOOLTIPS.inFlight}>
-                In Flight
-              </th>
-              <th className="text-right pb-1 pr-2" title={PER_NODE_COLUMN_TOOLTIPS.avgQueue}>
-                Avg Q
-              </th>
-              <th className="text-right pb-1 pr-2" title={PER_NODE_COLUMN_TOOLTIPS.util}>
-                Util
-              </th>
-              <th className="text-right pb-1 pr-2" title={PER_NODE_COLUMN_TOOLTIPS.errorRate}>
-                Err %
-              </th>
-              <th className="text-right pb-1 pr-2" title={PER_NODE_COLUMN_TOOLTIPS.arrivalCV}>
-                Arr CV
-              </th>
-              <th className="text-right pb-1 pr-2" title={PER_NODE_COLUMN_TOOLTIPS.p50}>
-                p50
-              </th>
-              <th className="text-right pb-1 pr-2" title={PER_NODE_COLUMN_TOOLTIPS.p95}>
-                p95
-              </th>
-              <th className="text-right pb-1 pr-2" title={PER_NODE_COLUMN_TOOLTIPS.p99}>
-                p99
-              </th>
-              <th className="text-right pb-1 pr-2" title={PER_NODE_COLUMN_TOOLTIPS.lambda}>
-                λ
-              </th>
-              <th className="text-right pb-1 pr-2" title={PER_NODE_COLUMN_TOOLTIPS.w}>
-                W
-              </th>
-              <th className="text-right pb-1" title={PER_NODE_COLUMN_TOOLTIPS.l}>
-                L
-              </th>
+              <MetricHeaderCell
+                label="Arrived"
+                tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.arrived}
+              />
+              <MetricHeaderCell label="Done" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.done} />
+              <MetricHeaderCell label="Reject" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.reject} />
+              <MetricHeaderCell label="T.O." tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.timedOut} />
+              <MetricHeaderCell label="Reset" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.reset} />
+              <MetricHeaderCell
+                label="In Flight"
+                tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.inFlight}
+              />
+              <MetricHeaderCell label="Avg Q" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.avgQueue} />
+              <MetricHeaderCell label="Util" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.util} />
+              <MetricHeaderCell
+                label="Err %"
+                tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.errorRate}
+              />
+              <MetricHeaderCell
+                label="Arr CV"
+                tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.arrivalCV}
+              />
+              <MetricHeaderCell label="p50" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.p50} />
+              <MetricHeaderCell label="p95" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.p95} />
+              <MetricHeaderCell label="p99" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.p99} />
+              <MetricHeaderCell label="λ" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.lambda} />
+              <MetricHeaderCell label="W" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.w} />
+              <MetricHeaderCell
+                label="L"
+                tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.l}
+                className="text-right pb-1"
+              />
             </tr>
           </thead>
           <tbody>
@@ -2219,16 +4043,16 @@ function PerNodeTable({ output }: { output: SimulationOutput }) {
                   <td className="text-right pr-2 text-nss-text">{fmtMs(m.latencyP95)}</td>
                   <td className="text-right pr-2 text-nss-text">{fmtMs(m.latencyP99)}</td>
                   <td className="text-right pr-2 text-nss-muted">
-                    {ll ? fmtLambda(ll.lambda) : '—'}
+                    {ll ? fmtLambda(ll.lambda) : '-'}
                   </td>
-                  <td className="text-right pr-2 text-nss-muted">{ll ? fmtW(ll.wSeconds) : '—'}</td>
+                  <td className="text-right pr-2 text-nss-muted">{ll ? fmtW(ll.wSeconds) : '-'}</td>
                   <td
                     className={`text-right ${llViolation ? 'text-nss-warning font-medium' : 'text-nss-muted'}`}
                     title={
                       llViolation ? `Little's Law: expected ${fmtL(ll!.expectedL)}` : undefined
                     }
                   >
-                    {ll ? fmtL(ll.observedL) : '—'}
+                    {ll ? fmtL(ll.observedL) : '-'}
                     {llViolation && <span className="ml-0.5">⚠</span>}
                   </td>
                 </tr>
@@ -2245,7 +4069,7 @@ function PerNodeTable({ output }: { output: SimulationOutput }) {
             onClick={() => setShowInactive((s) => !s)}
             className="text-[10px] text-nss-muted hover:text-nss-text transition-colors"
           >
-            {showInactive ? '▲' : '▼'} Inactive nodes ({inactiveEntries.length}) — post-warmup
+            {showInactive ? '▲' : '▼'} Inactive nodes ({inactiveEntries.length}) - post-warmup
           </button>
           {showInactive && (
             <table className="w-full text-xs tabular-nums mt-1 opacity-50">
@@ -2262,372 +4086,6 @@ function PerNodeTable({ output }: { output: SimulationOutput }) {
             </table>
           )}
         </div>
-      )}
-    </div>
-  )
-}
-
-// ─── Replay Preview ──────────────────────────────────────────────────────────
-
-function ReplayPreview({
-  output,
-  graphLookup
-}: {
-  output: SimulationOutput
-  graphLookup: EventGraphLookup
-}) {
-  const retainedEventCount = output.eventStream.length
-  const totalEventCount = totalReplayEventCount(output)
-  const isTruncated = retainedEventCount < totalEventCount
-  const [sequence, setSequence] = useState(0)
-  const maxSequence = Math.max(0, retainedEventCount - 1)
-
-  useEffect(() => {
-    setSequence((current) => clampSequence(current, maxSequence))
-  }, [maxSequence])
-
-  const event = output.eventStream[clampSequence(sequence, maxSequence)]
-  const debugEvent = useMemo(() => (event ? projectToDebugEvent(event) : null), [event])
-
-  if (!debugEvent) {
-    return null
-  }
-
-  const currentEdge = edgeDisplay(debugEvent, graphLookup)
-  const replayProgress =
-    maxSequence > 0 ? Math.round((clampSequence(sequence, maxSequence) / maxSequence) * 100) : 0
-
-  const buttonClass =
-    'h-7 w-7 inline-flex items-center justify-center rounded border border-nss-border text-nss-muted hover:text-nss-text hover:bg-nss-surface transition-colors disabled:opacity-40 disabled:hover:bg-transparent'
-
-  return (
-    <div className="space-y-2">
-      <div className="flex items-center justify-between gap-3">
-        <h3 className={SECTION_TITLE}>Replay Preview</h3>
-        <span className="text-[10px] text-nss-muted tabular-nums">
-          {sequence + 1} / {retainedEventCount.toLocaleString()}
-        </span>
-      </div>
-
-      <div className={`${SURFACE_CARD} p-3 space-y-3`}>
-        <div className="flex items-center gap-1.5">
-          <button
-            type="button"
-            onClick={() => setSequence(0)}
-            disabled={sequence === 0}
-            className={buttonClass}
-            title="Jump to start"
-          >
-            <ChevronsLeft size={14} />
-          </button>
-          <button
-            type="button"
-            onClick={() => setSequence((current) => clampSequence(current - 1, maxSequence))}
-            disabled={sequence === 0}
-            className={buttonClass}
-            title="Previous event"
-          >
-            <ChevronLeft size={14} />
-          </button>
-          <input
-            type="range"
-            min={0}
-            max={maxSequence}
-            value={sequence}
-            onChange={(event) => setSequence(Number(event.target.value))}
-            className="nss-range min-w-0 flex-1"
-            style={{ '--range-progress': `${replayProgress}%` } as CSSProperties}
-            aria-label="Replay sequence"
-          />
-          <button
-            type="button"
-            onClick={() => setSequence((current) => clampSequence(current + 1, maxSequence))}
-            disabled={sequence === maxSequence}
-            className={buttonClass}
-            title="Next event"
-          >
-            <ChevronRight size={14} />
-          </button>
-          <button
-            type="button"
-            onClick={() => setSequence(maxSequence)}
-            disabled={sequence === maxSequence}
-            className={buttonClass}
-            title="Jump to end"
-          >
-            <ChevronsRight size={14} />
-          </button>
-        </div>
-
-        {isTruncated && (
-          <div className="rounded-md border border-nss-warning/20 bg-nss-warning/10 px-2 py-1 text-[10px] text-nss-warning">
-            Showing the first {retainedEventCount.toLocaleString()} replay events out of{' '}
-            {totalEventCount.toLocaleString()} recorded for this run.
-          </div>
-        )}
-
-        <div className="grid grid-cols-2 gap-2 text-xs">
-          <StatCard label="Sequence" value={debugEvent.sequence.toLocaleString()} />
-          <StatCard label="Time" value={fmtEventTime(debugEvent.timestampMs)} />
-          <StatCard label="Type" value={debugEvent.type} />
-          <StatCard label="Status" value={debugEvent.status} />
-          <StatCard label="Request" value={debugEvent.requestId ?? '—'} />
-          <StatCard label="Node" value={nodeDisplayName(debugEvent, graphLookup)} />
-          <StatCard label="Edge" value={currentEdge.primary} />
-          <StatCard label="Route" value={routeDisplayName(debugEvent, graphLookup)} />
-        </div>
-
-        {(debugEvent.reasonCode || debugEvent.nodeSnapshot) && (
-          <div className="grid grid-cols-2 gap-2 text-xs">
-            {debugEvent.reasonCode && <StatCard label="Reason" value={debugEvent.reasonCode} />}
-            {debugEvent.nodeSnapshot && (
-              <StatCard
-                label="Node State"
-                value={`${debugEvent.nodeSnapshot.activeWorkers} active / ${debugEvent.nodeSnapshot.queueLength} queued`}
-              />
-            )}
-          </div>
-        )}
-      </div>
-    </div>
-  )
-}
-
-function EventLog({
-  output,
-  graphLookup
-}: {
-  output: SimulationOutput
-  graphLookup: EventGraphLookup
-}) {
-  const [isOpen, setIsOpen] = useState(true)
-  const [query, setQuery] = useState('')
-  const [page, setPage] = useState(0)
-  const [activeSequence, setActiveSequence] = useState<number | null>(null)
-  const selectGraphElements = useStore((state) => state.selectGraphElements)
-  const retainedEventCount = output.eventStream.length
-  const totalEventCount = totalReplayEventCount(output)
-  const isTruncated = retainedEventCount < totalEventCount
-  const debugEvents = useMemo(
-    () => (isOpen ? output.eventStream.map((event) => projectToDebugEvent(event)) : []),
-    [isOpen, output.eventStream]
-  )
-  const visibleEvents = useMemo(
-    () => debugEvents.filter((event) => eventMatchesQuery(event, query, graphLookup)),
-    [debugEvents, query, graphLookup]
-  )
-  const summary = useMemo(
-    () =>
-      visibleEvents.reduce(
-        (acc, event) => {
-          acc[event.status] = (acc[event.status] ?? 0) + 1
-          return acc
-        },
-        {} as Partial<Record<DebugEvent['status'], number>>
-      ),
-    [visibleEvents]
-  )
-  const pageCount = Math.max(1, Math.ceil(visibleEvents.length / EVENT_LOG_PAGE_SIZE))
-  const clampedPage = Math.min(page, pageCount - 1)
-  const pageStart = clampedPage * EVENT_LOG_PAGE_SIZE
-  const rows = visibleEvents.slice(pageStart, pageStart + EVENT_LOG_PAGE_SIZE)
-  const displayStart = visibleEvents.length === 0 ? 0 : pageStart + 1
-  const displayEnd = pageStart + rows.length
-
-  useEffect(() => {
-    setPage(0)
-  }, [query, retainedEventCount])
-
-  function selectEventTarget(event: DebugEvent): void {
-    if (!event.nodeId && !event.edgeId) {
-      return
-    }
-
-    setActiveSequence(event.sequence)
-    selectGraphElements({ nodeId: event.nodeId, edgeId: event.edgeId })
-  }
-
-  function handleRowKeyDown(
-    keyboardEvent: KeyboardEvent<HTMLTableRowElement>,
-    event: DebugEvent
-  ): void {
-    if (keyboardEvent.key !== 'Enter' && keyboardEvent.key !== ' ') {
-      return
-    }
-
-    keyboardEvent.preventDefault()
-    selectEventTarget(event)
-  }
-
-  if (retainedEventCount === 0) {
-    return null
-  }
-
-  return (
-    <div className="space-y-2">
-      <button
-        type="button"
-        onClick={() => setIsOpen((open) => !open)}
-        className="w-full flex items-center justify-between gap-3 text-left"
-        aria-expanded={isOpen}
-      >
-        <span className={SECTION_TITLE}>Event Log</span>
-        <div className="flex items-center gap-2">
-          <span className="text-[10px] text-nss-muted tabular-nums">
-            {isTruncated
-              ? `${retainedEventCount.toLocaleString()} / ${totalEventCount.toLocaleString()} replay events`
-              : `${totalEventCount.toLocaleString()} replay events`}
-          </span>
-          <span className="text-nss-muted text-[10px]">{isOpen ? '▲' : '▼'}</span>
-        </div>
-      </button>
-
-      {!isOpen && (
-        <div className={`${SURFACE_CARD} px-3 py-2 text-xs text-nss-muted`}>
-          {isTruncated
-            ? `Open to inspect the retained replay window (${retainedEventCount.toLocaleString()} of ${totalEventCount.toLocaleString()} events).`
-            : 'Open to inspect canonical events and filter by request, node, edge, status, or type.'}
-        </div>
-      )}
-
-      {isOpen && (
-        <>
-          {isTruncated && (
-            <div className="rounded-md border border-nss-warning/20 bg-nss-warning/10 px-3 py-2 text-xs text-nss-warning">
-              Large runs are capped to keep the renderer responsive. This table shows the first{' '}
-              {retainedEventCount.toLocaleString()} replay events out of{' '}
-              {totalEventCount.toLocaleString()} total canonical events.
-            </div>
-          )}
-
-          <div className="flex flex-wrap gap-1 text-[10px]">
-            {(['rejected', 'timeout', 'success', 'info'] as const).map((status) => (
-              <span
-                key={status}
-                className={`px-1.5 py-0.5 rounded border ${eventStatusClass(status)}`}
-              >
-                {summary[status] ?? 0} {status}
-              </span>
-            ))}
-          </div>
-
-          <input
-            value={query}
-            onChange={(event) => {
-              setQuery(event.target.value)
-              setPage(0)
-            }}
-            placeholder="type:request-forwarded OR status:rejected"
-            className="w-full h-8 px-2 rounded-md bg-nss-surface border border-nss-border text-xs text-nss-text placeholder:text-nss-muted outline-none focus:border-nss-primary"
-          />
-
-          <div className={`${SURFACE_CARD} overflow-hidden`}>
-            <div className="max-h-80 overflow-auto">
-              <table className="w-full text-[11px] tabular-nums">
-                <thead className="sticky top-0 bg-nss-surface text-nss-muted border-b border-nss-border">
-                  <tr>
-                    <th className="text-right py-1.5 px-2">Seq</th>
-                    <th className="text-right py-1.5 px-2">Time</th>
-                    <th className="text-left py-1.5 px-2">Type</th>
-                    <th className="text-left py-1.5 px-2">Request</th>
-                    <th className="text-left py-1.5 px-2">Node</th>
-                    <th className="text-left py-1.5 px-2">Edge / Route</th>
-                    <th className="text-left py-1.5 px-2">Status</th>
-                    <th className="text-left py-1.5 px-2">Reason</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {rows.map((event) => {
-                    const edge = edgeDisplay(event, graphLookup)
-                    const isActive = activeSequence === event.sequence
-                    const isSelectable = Boolean(event.nodeId || event.edgeId)
-                    return (
-                      <tr
-                        key={event.sequence}
-                        tabIndex={isSelectable ? 0 : undefined}
-                        aria-selected={isActive}
-                        onClick={() => selectEventTarget(event)}
-                        onKeyDown={(keyboardEvent) => handleRowKeyDown(keyboardEvent, event)}
-                        className={`border-b border-nss-border outline-none ${
-                          isSelectable ? 'cursor-pointer hover:bg-nss-bg focus:bg-nss-bg' : ''
-                        } ${
-                          isActive ? 'bg-nss-primary/10 ring-1 ring-inset ring-nss-primary/30' : ''
-                        }`}
-                      >
-                        <td className="text-right py-1 px-2 text-nss-muted">{event.sequence}</td>
-                        <td className="text-right py-1 px-2 text-nss-muted">
-                          {fmtEventTime(event.timestampMs)}
-                        </td>
-                        <td className="py-1 px-2 text-nss-text whitespace-nowrap">{event.type}</td>
-                        <td className="py-1 px-2 text-nss-muted">{event.requestId ?? '—'}</td>
-                        <td className="py-1 px-2 text-nss-muted max-w-32" title={event.nodeId}>
-                          <div className="truncate text-nss-text">
-                            {nodeDisplayName(event, graphLookup)}
-                          </div>
-                          {labelForNode(event.nodeId, graphLookup) && event.nodeId && (
-                            <div className="truncate text-[10px] text-nss-muted">
-                              {event.nodeId}
-                            </div>
-                          )}
-                        </td>
-                        <td className="py-1 px-2 text-nss-muted max-w-48" title={edge.title}>
-                          <div className="truncate text-nss-text">{edge.primary}</div>
-                          {edge.secondary && (
-                            <div className="truncate text-[10px] text-nss-muted">
-                              {edge.secondary}
-                            </div>
-                          )}
-                        </td>
-                        <td className="py-1 px-2">
-                          <span
-                            className={`px-1.5 py-0.5 rounded border ${eventStatusClass(event.status)}`}
-                          >
-                            {event.status}
-                          </span>
-                        </td>
-                        <td className="py-1 px-2 text-nss-muted">{event.reasonCode ?? '—'}</td>
-                      </tr>
-                    )
-                  })}
-                </tbody>
-              </table>
-            </div>
-            {visibleEvents.length > 0 && (
-              <div className="px-2 py-1 border-t border-nss-border flex items-center justify-between gap-2 text-[10px] text-nss-muted">
-                <span>
-                  Showing {displayStart.toLocaleString()}-{displayEnd.toLocaleString()} of{' '}
-                  {visibleEvents.length.toLocaleString()}
-                </span>
-                <div className="flex items-center gap-1">
-                  <button
-                    type="button"
-                    onClick={() => setPage((current) => Math.max(0, current - 1))}
-                    disabled={clampedPage === 0}
-                    className="px-2 py-0.5 rounded border border-nss-border text-nss-muted hover:text-nss-text hover:bg-nss-bg disabled:opacity-40 disabled:hover:bg-transparent"
-                  >
-                    Prev
-                  </button>
-                  <span className="tabular-nums px-1">
-                    {clampedPage + 1} / {pageCount}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => setPage((current) => Math.min(pageCount - 1, current + 1))}
-                    disabled={clampedPage >= pageCount - 1}
-                    className="px-2 py-0.5 rounded border border-nss-border text-nss-muted hover:text-nss-text hover:bg-nss-bg disabled:opacity-40 disabled:hover:bg-transparent"
-                  >
-                    Next
-                  </button>
-                </div>
-              </div>
-            )}
-            {visibleEvents.length === 0 && (
-              <div className="px-3 py-4 text-xs text-nss-muted text-center">
-                No events match this filter.
-              </div>
-            )}
-          </div>
-        </>
       )}
     </div>
   )
@@ -2681,6 +4139,8 @@ export function ResultsTray({
   stopped,
   progress,
   eventsProcessed,
+  runStartedAtMs,
+  snapshot,
   results,
   error,
   runContext,
@@ -2724,6 +4184,12 @@ export function ResultsTray({
   }, [results])
 
   useEffect(() => {
+    if (!results && (status === 'running' || status === 'paused') && activeTab !== 'traffic') {
+      setActiveTab('traffic')
+    }
+  }, [activeTab, results, status])
+
+  useEffect(() => {
     if (!results) {
       return
     }
@@ -2737,6 +4203,7 @@ export function ResultsTray({
   const retainedReplayEventCount = results ? results.eventStream.length : 0
   const totalCapturedReplayEvents = results ? totalReplayEventCount(results) : 0
   const replayEventsTruncated = retainedReplayEventCount < totalCapturedReplayEvents
+  const visibleTabs = results !== null ? RESULTS_TABS : []
   const progressLabel =
     stopped && status === 'paused'
       ? `Stopping at ${progress.toFixed(1)}% complete...`
@@ -2783,16 +4250,31 @@ export function ResultsTray({
         </div>
       )}
 
-      {/* Results */}
+      {!results && runContext && (status === 'running' || status === 'paused') && (
+        <div className="flex-1 overflow-y-auto px-4 py-3">
+          <LiveMonitorPanel
+            status={status}
+            progress={progress}
+            eventsProcessed={eventsProcessed}
+            runStartedAtMs={runStartedAtMs}
+            snapshot={snapshot}
+            runContext={runContext}
+            graphLookup={graphLookup}
+          />
+        </div>
+      )}
+
       {results && (
         <>
-          <div className="shrink-0 px-4 py-2 border-b border-nss-border overflow-x-auto">
-            <div className="flex items-center gap-2 min-w-max">
-              {RESULTS_TABS.map((tab) => (
-                <TabButton key={tab.id} tab={tab} activeTab={activeTab} onSelect={setActiveTab} />
-              ))}
+          {visibleTabs.length > 0 && (
+            <div className="shrink-0 overflow-x-auto border-b border-nss-border px-4 py-2">
+              <div className="flex min-w-max items-center gap-2">
+                {visibleTabs.map((tab) => (
+                  <TabButton key={tab.id} tab={tab} activeTab={activeTab} onSelect={setActiveTab} />
+                ))}
+              </div>
             </div>
-          </div>
+          )}
 
           <div className="flex-1 overflow-y-auto px-4 py-3 space-y-5">
             {stopped && (
@@ -2834,14 +4316,14 @@ export function ResultsTray({
             )}
 
             {activeTab === 'traffic' && (
-              <>
-                <ReplayPreview output={results} graphLookup={graphLookup} />
-                <EventLog output={results} graphLookup={graphLookup} />
-              </>
+              <ReplayMonitorPanel
+                output={results}
+                runContext={runContext}
+                graphLookup={graphLookup}
+              />
             )}
 
-            {/* Footer — debug info */}
-            <div className="text-[10px] text-nss-muted pb-2 flex flex-wrap gap-x-3 gap-y-1">
+            <div className="flex flex-wrap gap-x-3 gap-y-1 pb-2 text-[10px] text-nss-muted">
               <span>Seed: {results.seed}</span>
               <span>Reproducible: {results.reproducible ? 'yes' : 'no'}</span>
               <span>{eventsProcessed.toLocaleString()} events processed</span>

--- a/src/renderer/src/components/simulation/ResultsTray.tsx
+++ b/src/renderer/src/components/simulation/ResultsTray.tsx
@@ -48,7 +48,7 @@ function fmtMs(ms: number | null): string {
   // `null` means no successful samples in this population/window — show N/A, never a fake 0.
   if (ms === null) return 'N/A'
   if (ms === 0) return '—'
-  if (ms < 1) return `${(ms * 1000).toFixed(0)}µs`
+  if (ms < 1) return `${ms.toFixed(3)}ms`
   if (ms < 1000) return `${ms.toFixed(2)}ms`
   return `${(ms / 1000).toFixed(2)}s`
 }

--- a/src/renderer/src/components/simulation/SimulationControls.tsx
+++ b/src/renderer/src/components/simulation/SimulationControls.tsx
@@ -444,7 +444,7 @@ export function SimulationControls({
 
           <label className="flex items-center justify-between mb-2 cursor-pointer">
             <span className="text-[10px] font-semibold uppercase tracking-widest text-nss-muted">
-              Chaos — inject a failure
+              Chaos - inject a failure
             </span>
             <input
               type="checkbox"

--- a/src/renderer/src/components/ui/EdgePropertiesPanel.tsx
+++ b/src/renderer/src/components/ui/EdgePropertiesPanel.tsx
@@ -1,4 +1,7 @@
+import { Waypoints } from 'lucide-react'
 import { EdgeSimulationData } from '@renderer/types/ui'
+import { TooltipInfo } from '@renderer/components/ui/Tooltip'
+import { EDGE_PROPERTY_HELP, type EdgeHelpEntry, inferCanvasEdgeMode } from '@renderer/config/edgeSemantics'
 import type { CanvasNodeDataV2 } from '../../../../engine/catalog/nodeSpecTypes'
 import { getEdgeConstraints } from '../../../../engine/defaults/edgeConstraints'
 import { inferEdgeDefaults } from '../../../../engine/defaults/edgeDefaults'
@@ -35,8 +38,33 @@ const EDGE_MODE_OPTIONS: NonNullable<EdgeSimulationData['mode']>[] = [
   'conditional'
 ]
 
+const FIELD_LABEL_CLASS = 'text-[11px] text-nss-muted font-medium'
 function logNormalJitterCv(sigma: number): number {
   return Math.sqrt(Math.max(0, Math.exp(sigma * sigma) - 1))
+}
+
+function EdgeTooltipContent({ entry }: { entry: EdgeHelpEntry }) {
+  return (
+    <div className="space-y-1 text-[11px] leading-relaxed">
+      <p className="font-semibold text-nss-text">{entry.title}</p>
+      <p className="text-nss-text/80">{entry.summary}</p>
+      <p className="text-nss-muted">{entry.simulationEffect}</p>
+      {entry.note ? <p className="text-nss-muted">{entry.note}</p> : null}
+    </div>
+  )
+}
+
+function FieldLabel({ label, help }: { label: string; help: EdgeHelpEntry }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <label className={FIELD_LABEL_CLASS}>{label}</label>
+      <TooltipInfo
+        label={`${label} help`}
+        width={320}
+        content={<EdgeTooltipContent entry={help} />}
+      />
+    </div>
+  )
 }
 
 export const EdgePropertiesPanel = ({
@@ -52,7 +80,10 @@ export const EdgePropertiesPanel = ({
     targetNodeData?.componentType
   )
   const selectedProtocol = value.protocol ?? defaults.protocol
-  const selectedMode = value.mode ?? 'synchronous'
+  const selectedMode = inferCanvasEdgeMode(
+    { mode: value.mode, protocol: selectedProtocol },
+    targetNodeData
+  )
   const selectedCondition = value.condition ?? ''
   const selectedLatencyDistributionType =
     value.latencyDistributionType ?? (value.latencyValue !== undefined ? 'constant' : 'log-normal')
@@ -71,25 +102,43 @@ export const EdgePropertiesPanel = ({
     selectedLatencyDistributionType === 'constant'
       ? `Constant transit: ${selectedLatencyValue.toFixed(2)}ms on every hop. Use this for a clean, no-jitter edge.`
       : `Log-normal transit: median hop ≈ ${Math.exp(selectedLatencyMu).toFixed(2)}ms, jitter CV ≈ ${jitterCv.toFixed(2)}. Mu is log-space; sigma controls spread.`
+  const selectedPathType = value.pathType ?? defaults.pathType
+  const sourceLabel = sourceNodeData?.label
+  const targetLabel = targetNodeData?.label
 
   return (
-    <div className="absolute top-4 right-4 z-10 w-72 p-4 rounded shadow-xl border border-nss-border bg-nss-panel transition-colors duration-200">
-      <div className="flex justify-between items-center mb-3">
-        <h3 className="text-sm font-bold text-nss-text uppercase tracking-wider">
-          Edge Properties
-        </h3>
-        <button
-          onClick={onClose}
-          className="text-nss-muted hover:text-nss-text transition-colors"
-          aria-label="Close panel"
-        >
-          ✕
-        </button>
+    <div className="h-full w-full bg-nss-panel border-l border-nss-border flex flex-col text-nss-text font-sans">
+      <div className="p-5 border-b border-nss-border bg-nss-panel">
+        <div className="flex items-center gap-4">
+          <div className="shrink-0 flex items-center justify-center rounded-lg p-2 shadow-sm bg-nss-primary/10 text-nss-primary">
+            <Waypoints size={24} />
+          </div>
+
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center justify-between gap-2">
+              <h2 className="min-w-0 font-semibold text-sm leading-tight truncate text-nss-text">
+                Edge Properties
+              </h2>
+              <button
+                onClick={onClose}
+                className="shrink-0 text-nss-muted hover:text-nss-text transition-colors"
+                aria-label="Close panel"
+              >
+                ✕
+              </button>
+            </div>
+            {(sourceLabel || targetLabel) && (
+              <p className="mt-1 truncate text-[10px] uppercase tracking-wide text-nss-muted">
+                {sourceLabel || 'Source'} → {targetLabel || 'Target'}
+              </p>
+            )}
+          </div>
+        </div>
       </div>
 
-      <div className="space-y-3">
+      <div className="flex-1 overflow-y-auto custom-scrollbar p-5 space-y-3">
         <div className="space-y-1">
-          <label className="text-[11px] text-nss-muted font-medium">Label</label>
+          <FieldLabel label="Label" help={EDGE_PROPERTY_HELP.label} />
           <input
             type="text"
             value={value.label ?? ''}
@@ -101,7 +150,7 @@ export const EdgePropertiesPanel = ({
 
         <div className="grid grid-cols-2 gap-2">
           <div className="space-y-1">
-            <label className="text-[11px] text-nss-muted font-medium">Protocol</label>
+            <FieldLabel label="Protocol" help={EDGE_PROPERTY_HELP.protocol} />
             <select
               value={selectedProtocol}
               onChange={(e) =>
@@ -128,7 +177,7 @@ export const EdgePropertiesPanel = ({
           </div>
 
           <div className="space-y-1">
-            <label className="text-[11px] text-nss-muted font-medium">Mode</label>
+            <FieldLabel label="Mode" help={EDGE_PROPERTY_HELP.mode} />
             <select
               value={selectedMode}
               onChange={(e) => onChange({ mode: e.target.value as EdgeSimulationData['mode'] })}
@@ -155,9 +204,9 @@ export const EdgePropertiesPanel = ({
 
         <div className="grid grid-cols-2 gap-2">
           <div className="space-y-1">
-            <label className="text-[11px] text-nss-muted font-medium">Path Type</label>
+            <FieldLabel label="Path Type" help={EDGE_PROPERTY_HELP.pathType} />
             <select
-              value={value.pathType ?? defaults.pathType}
+              value={selectedPathType}
               onChange={(e) =>
                 onChange({ pathType: e.target.value as EdgeSimulationData['pathType'] })
               }
@@ -171,20 +220,19 @@ export const EdgePropertiesPanel = ({
             </select>
           </div>
           <div className="space-y-1">
-            <label className="text-[11px] text-nss-muted font-medium">Condition</label>
+            <FieldLabel label="Condition" help={EDGE_PROPERTY_HELP.condition} />
             <input
               type="text"
               value={selectedCondition}
               onChange={(e) => onChange({ condition: e.target.value })}
               placeholder='request.metadata.origin == "eu-west"'
-              disabled={selectedMode !== 'conditional'}
-              className={`${CONTROL_CLASS} disabled:opacity-50`}
+              className={CONTROL_CLASS}
             />
           </div>
         </div>
 
         <div className="space-y-1">
-          <label className="text-[11px] text-nss-muted font-medium">Latency Model</label>
+          <FieldLabel label="Latency Model" help={EDGE_PROPERTY_HELP.latencyModel} />
           <select
             value={selectedLatencyDistributionType}
             onChange={(e) =>
@@ -205,7 +253,7 @@ export const EdgePropertiesPanel = ({
 
         {selectedLatencyDistributionType === 'constant' ? (
           <div className="space-y-1">
-            <label className="text-[11px] text-nss-muted font-medium">Latency (ms)</label>
+            <FieldLabel label="Latency (ms)" help={EDGE_PROPERTY_HELP.latencyValue} />
             <input
               type="number"
               min={0}
@@ -218,9 +266,7 @@ export const EdgePropertiesPanel = ({
         ) : (
           <div className="grid grid-cols-2 gap-2">
             <div className="space-y-1">
-              <label className="text-[11px] text-nss-muted font-medium">
-                Latency Mu (log-space)
-              </label>
+              <FieldLabel label="Latency Mu (log-space)" help={EDGE_PROPERTY_HELP.latencyMu} />
               <input
                 type="number"
                 step={0.01}
@@ -230,7 +276,7 @@ export const EdgePropertiesPanel = ({
               />
             </div>
             <div className="space-y-1">
-              <label className="text-[11px] text-nss-muted font-medium">Jitter Sigma</label>
+              <FieldLabel label="Jitter Sigma" help={EDGE_PROPERTY_HELP.latencySigma} />
               <input
                 type="number"
                 min={0.01}
@@ -245,7 +291,7 @@ export const EdgePropertiesPanel = ({
 
         <div className="grid grid-cols-2 gap-2">
           <div className="space-y-1">
-            <label className="text-[11px] text-nss-muted font-medium">Bandwidth (Mbps)</label>
+            <FieldLabel label="Bandwidth (Mbps)" help={EDGE_PROPERTY_HELP.bandwidth} />
             <input
               type="number"
               min={1}
@@ -256,7 +302,7 @@ export const EdgePropertiesPanel = ({
             />
           </div>
           <div className="space-y-1">
-            <label className="text-[11px] text-nss-muted font-medium">Max Concurrent</label>
+            <FieldLabel label="Max Concurrent" help={EDGE_PROPERTY_HELP.maxConcurrentRequests} />
             <input
               type="number"
               min={1}
@@ -270,7 +316,7 @@ export const EdgePropertiesPanel = ({
 
         <div className="grid grid-cols-2 gap-2">
           <div className="space-y-1">
-            <label className="text-[11px] text-nss-muted font-medium">Packet Loss (%)</label>
+            <FieldLabel label="Packet Loss (%)" help={EDGE_PROPERTY_HELP.packetLossRate} />
             <input
               type="number"
               min={0}
@@ -282,7 +328,7 @@ export const EdgePropertiesPanel = ({
             />
           </div>
           <div className="space-y-1">
-            <label className="text-[11px] text-nss-muted font-medium">Edge Error (%)</label>
+            <FieldLabel label="Edge Error (%)" help={EDGE_PROPERTY_HELP.errorRate} />
             <input
               type="number"
               min={0}
@@ -296,9 +342,9 @@ export const EdgePropertiesPanel = ({
         </div>
 
         <div className="rounded border border-nss-border bg-nss-surface px-2 py-2 text-[10px] leading-relaxed text-nss-muted">
-          <div>{latencySummary}</div>
-          <div className="mt-1">{constraints.reliabilityText}</div>
+          {latencySummary}
         </div>
+
       </div>
     </div>
   )

--- a/src/renderer/src/components/ui/EdgePropertiesPanel.tsx
+++ b/src/renderer/src/components/ui/EdgePropertiesPanel.tsx
@@ -1,7 +1,11 @@
 import { Waypoints } from 'lucide-react'
 import { EdgeSimulationData } from '@renderer/types/ui'
 import { TooltipInfo } from '@renderer/components/ui/Tooltip'
-import { EDGE_PROPERTY_HELP, type EdgeHelpEntry, inferCanvasEdgeMode } from '@renderer/config/edgeSemantics'
+import {
+  EDGE_PROPERTY_HELP,
+  type EdgeHelpEntry,
+  inferCanvasEdgeMode
+} from '@renderer/config/edgeSemantics'
 import type { CanvasNodeDataV2 } from '../../../../engine/catalog/nodeSpecTypes'
 import { getEdgeConstraints } from '../../../../engine/defaults/edgeConstraints'
 import { inferEdgeDefaults } from '../../../../engine/defaults/edgeDefaults'
@@ -344,7 +348,6 @@ export const EdgePropertiesPanel = ({
         <div className="rounded border border-nss-border bg-nss-surface px-2 py-2 text-[10px] leading-relaxed text-nss-muted">
           {latencySummary}
         </div>
-
       </div>
     </div>
   )

--- a/src/renderer/src/components/ui/Input.tsx
+++ b/src/renderer/src/components/ui/Input.tsx
@@ -8,7 +8,7 @@ export const Input = ({
   <div className="relative group">
     <input
       className={clsx(
-        'w-full bg-nss-input-bg border border-nss-border hover:border-nss-muted/50 focus:border-nss-primary rounded px-3 py-2 text-sm text-nss-text outline-none transition-colors font-mono placeholder:text-nss-placeholder',
+        'w-full bg-nss-input-bg border border-nss-border hover:border-nss-muted/50 focus:border-nss-primary rounded px-3 py-2 text-sm text-nss-text outline-none transition-colors placeholder:text-nss-placeholder',
         className
       )}
       {...props}

--- a/src/renderer/src/components/ui/RoutingVisualizationToast.tsx
+++ b/src/renderer/src/components/ui/RoutingVisualizationToast.tsx
@@ -42,8 +42,8 @@ export function RoutingVisualizationToast({ state, onClose }: RoutingVisualizati
           <span className="font-semibold text-nss-text">{state.sourceLabel}</span>.
         </p>
         <p className="text-nss-muted">
-          Node id: <span className="font-mono text-nss-text">{state.sourceNodeId}</span>. Close this
-          banner to return to the normal packet view.
+          Node id: <span className="text-nss-text">{state.sourceNodeId}</span>. Close this banner to
+          return to the normal packet view.
         </p>
       </div>
     </div>

--- a/src/renderer/src/components/ui/Slider.tsx
+++ b/src/renderer/src/components/ui/Slider.tsx
@@ -40,7 +40,7 @@ export const Slider = ({
           onChange={handleInputChange}
           style={{ width: dynamicWidth }}
           className="
-            text-center text-xs font-mono 
+            text-center text-xs tabular-nums
             bg-nss-primary/10 text-nss-primary 
             border border-nss-primary/20 rounded px-1 py-0.5
             focus:outline-none focus:border-nss-primary focus:ring-1 focus:ring-nss-primary/50

--- a/src/renderer/src/components/ui/Tooltip.tsx
+++ b/src/renderer/src/components/ui/Tooltip.tsx
@@ -1,5 +1,5 @@
-import type { MouseEvent, ReactNode } from 'react'
-import { useEffect, useRef, useState } from 'react'
+import type { FocusEvent, MouseEvent, ReactNode } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
 import { clsx } from 'clsx'
 
 interface TooltipPosition {
@@ -12,6 +12,9 @@ export interface TooltipTriggerProps {
   onMouseLeave: () => void
   onMouseDown: () => void
   onDragStart: () => void
+  onFocus: (event: FocusEvent<HTMLElement>) => void
+  onBlur: () => void
+  'aria-describedby'?: string
 }
 
 interface HoverTooltipProps {
@@ -34,6 +37,7 @@ export function HoverTooltip({
   className
 }: HoverTooltipProps) {
   const [position, setPosition] = useState<TooltipPosition | null>(null)
+  const tooltipId = useId()
   const showTimer = useRef<ReturnType<typeof window.setTimeout> | null>(null)
 
   const clearShowTimer = () => {
@@ -48,10 +52,10 @@ export function HoverTooltip({
     setPosition(null)
   }
 
-  const scheduleShow = (event: MouseEvent<HTMLElement>) => {
+  const scheduleShowFromElement = (element: HTMLElement) => {
     clearShowTimer()
 
-    const rect = event.currentTarget.getBoundingClientRect()
+    const rect = element.getBoundingClientRect()
     const nextLeft = Math.min(rect.right + offset, window.innerWidth - width - offset)
     const nextTop = Math.min(rect.top - 4, window.innerHeight - estimatedHeight)
     const nextPosition = {
@@ -65,6 +69,14 @@ export function HoverTooltip({
     }, delayMs)
   }
 
+  const scheduleShow = (event: MouseEvent<HTMLElement>) => {
+    scheduleShowFromElement(event.currentTarget)
+  }
+
+  const scheduleShowOnFocus = (event: FocusEvent<HTMLElement>) => {
+    scheduleShowFromElement(event.currentTarget)
+  }
+
   useEffect(() => clearShowTimer, [])
 
   return (
@@ -73,11 +85,15 @@ export function HoverTooltip({
         onMouseEnter: scheduleShow,
         onMouseLeave: hide,
         onMouseDown: hide,
-        onDragStart: hide
+        onDragStart: hide,
+        onFocus: scheduleShowOnFocus,
+        onBlur: hide,
+        'aria-describedby': position ? tooltipId : undefined
       })}
 
       {position && (
         <div
+          id={tooltipId}
           role="tooltip"
           style={{ top: position.top, left: position.left, width }}
           className={clsx(
@@ -89,5 +105,32 @@ export function HoverTooltip({
         </div>
       )}
     </>
+  )
+}
+
+interface TooltipInfoProps {
+  label: string
+  content: ReactNode
+  width?: number
+  className?: string
+}
+
+export function TooltipInfo({ label, content, width = 260, className }: TooltipInfoProps) {
+  return (
+    <HoverTooltip content={content} width={width}>
+      {(triggerProps) => (
+        <button
+          type="button"
+          aria-label={label}
+          className={clsx(
+            'inline-flex h-3.5 w-3.5 items-center justify-center rounded-full border border-nss-border text-[9px] font-semibold leading-none text-nss-muted transition-colors hover:text-nss-text focus:outline-none focus:ring-2 focus:ring-nss-primary/50 focus:ring-offset-1 focus:ring-offset-nss-surface',
+            className
+          )}
+          {...triggerProps}
+        >
+          i
+        </button>
+      )}
+    </HoverTooltip>
   )
 }

--- a/src/renderer/src/config/canvasLegendConfig.ts
+++ b/src/renderer/src/config/canvasLegendConfig.ts
@@ -1,0 +1,42 @@
+export interface CanvasLegendItem {
+  label: string
+  swatchClassName: string
+  shape: 'dot' | 'square'
+}
+
+export interface CanvasLegendSection {
+  title: string
+  items: CanvasLegendItem[]
+}
+
+export const CANVAS_RUNTIME_LEGEND_SECTIONS: CanvasLegendSection[] = [
+  {
+    title: 'Reliability',
+    items: [
+      { label: 'Healthy', swatchClassName: 'bg-nss-success', shape: 'dot' },
+      { label: 'Degraded', swatchClassName: 'bg-nss-warning', shape: 'dot' },
+      { label: 'Failing', swatchClassName: 'bg-nss-danger', shape: 'dot' },
+      { label: 'Idle', swatchClassName: 'bg-nss-muted', shape: 'dot' }
+    ]
+  },
+  {
+    title: 'Capacity',
+    items: [
+      { label: 'Headroom', swatchClassName: 'bg-nss-success', shape: 'square' },
+      { label: 'Steady', swatchClassName: 'bg-nss-primary', shape: 'square' },
+      { label: 'Tight', swatchClassName: 'bg-nss-warning', shape: 'square' },
+      { label: 'Saturated', swatchClassName: 'bg-orange-400', shape: 'square' }
+    ]
+  },
+  {
+    title: 'Path',
+    items: [
+      { label: 'Moving requests', swatchClassName: 'bg-nss-success', shape: 'dot' },
+      { label: 'Elevated failures', swatchClassName: 'bg-nss-warning', shape: 'dot' },
+      { label: 'Hard failures', swatchClassName: 'bg-nss-danger', shape: 'dot' }
+    ]
+  }
+]
+
+export const CANVAS_PRE_RUN_LEGEND_NOTE =
+  'Run a simulation to populate reliability, capacity, and path indicators.'

--- a/src/renderer/src/config/edgeSemantics.test.ts
+++ b/src/renderer/src/config/edgeSemantics.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import type { CanvasNodeDataV2 } from '../../../engine/catalog/nodeSpecTypes'
+import { inferCanvasEdgeMode, isPathTypeDrivingLatency } from './edgeSemantics'
+
+describe('inferCanvasEdgeMode', () => {
+  it('preserves an explicit mode override', () => {
+    expect(inferCanvasEdgeMode({ mode: 'conditional', protocol: 'https' })).toBe('conditional')
+  })
+
+  it('infers streaming for websocket-style targets', () => {
+    expect(
+      inferCanvasEdgeMode(
+        { protocol: 'websocket' },
+        { componentType: 'websockets-gateway' } as CanvasNodeDataV2
+      )
+    ).toBe('streaming')
+  })
+
+  it('infers asynchronous for async-boundary targets when mode is unset', () => {
+    expect(
+      inferCanvasEdgeMode(
+        { protocol: 'amqp' },
+        { componentType: 'queue', templateId: 'queue' } as CanvasNodeDataV2
+      )
+    ).toBe('asynchronous')
+  })
+
+  it('falls back to synchronous for ordinary request-response edges', () => {
+    expect(
+      inferCanvasEdgeMode(
+        { protocol: 'grpc' },
+        { componentType: 'microservice', templateId: 'microservice' } as CanvasNodeDataV2
+      )
+    ).toBe('synchronous')
+  })
+})
+
+describe('isPathTypeDrivingLatency', () => {
+  it('treats implicit log-normal latency as path-type derived', () => {
+    expect(isPathTypeDrivingLatency({})).toBe(true)
+    expect(isPathTypeDrivingLatency({ latencyDistributionType: 'log-normal' })).toBe(true)
+  })
+
+  it('treats constant latency as an explicit override', () => {
+    expect(
+      isPathTypeDrivingLatency({
+        latencyDistributionType: 'constant',
+        latencyValue: 4.5
+      })
+    ).toBe(false)
+  })
+
+  it('treats explicit log-normal parameters as an override', () => {
+    expect(
+      isPathTypeDrivingLatency({
+        latencyDistributionType: 'log-normal',
+        latencyMu: 1.2,
+        latencySigma: 0.4
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/config/edgeSemantics.test.ts
+++ b/src/renderer/src/config/edgeSemantics.test.ts
@@ -9,28 +9,27 @@ describe('inferCanvasEdgeMode', () => {
 
   it('infers streaming for websocket-style targets', () => {
     expect(
-      inferCanvasEdgeMode(
-        { protocol: 'websocket' },
-        { componentType: 'websockets-gateway' } as CanvasNodeDataV2
-      )
+      inferCanvasEdgeMode({ protocol: 'websocket' }, {
+        componentType: 'websockets-gateway'
+      } as CanvasNodeDataV2)
     ).toBe('streaming')
   })
 
   it('infers asynchronous for async-boundary targets when mode is unset', () => {
     expect(
-      inferCanvasEdgeMode(
-        { protocol: 'amqp' },
-        { componentType: 'queue', templateId: 'queue' } as CanvasNodeDataV2
-      )
+      inferCanvasEdgeMode({ protocol: 'amqp' }, {
+        componentType: 'queue',
+        templateId: 'queue'
+      } as CanvasNodeDataV2)
     ).toBe('asynchronous')
   })
 
   it('falls back to synchronous for ordinary request-response edges', () => {
     expect(
-      inferCanvasEdgeMode(
-        { protocol: 'grpc' },
-        { componentType: 'microservice', templateId: 'microservice' } as CanvasNodeDataV2
-      )
+      inferCanvasEdgeMode({ protocol: 'grpc' }, {
+        componentType: 'microservice',
+        templateId: 'microservice'
+      } as CanvasNodeDataV2)
     ).toBe('synchronous')
   })
 })

--- a/src/renderer/src/config/edgeSemantics.ts
+++ b/src/renderer/src/config/edgeSemantics.ts
@@ -1,0 +1,266 @@
+import { getComponentSpec } from '../../../engine/catalog/componentSpecs'
+import { getPaletteTemplate } from '../../../engine/catalog/paletteTemplates'
+import type { CanvasNodeDataV2 } from '../../../engine/catalog/nodeSpecTypes'
+import type { EdgeDefinition } from '../../../engine/core/types'
+import type { EdgeSimulationData } from '@renderer/types/ui'
+
+export type EdgeModeValue = EdgeDefinition['mode']
+export type EdgeProtocolValue = EdgeDefinition['protocol']
+export type EdgePathTypeValue = EdgeDefinition['latency']['pathType']
+
+export interface EdgeHelpEntry {
+  title: string
+  summary: string
+  simulationEffect: string
+  note?: string
+}
+
+export interface EdgeModePresentation extends EdgeHelpEntry {
+  shortLabel: string
+  strokeDasharray: string
+  badgeClassName: string
+}
+
+export const EDGE_MODE_PRESENTATION: Record<EdgeModeValue, EdgeModePresentation> = {
+  synchronous: {
+    title: 'Synchronous',
+    shortLabel: 'SYNC',
+    summary: 'Caller sends work and waits for the downstream hop to finish.',
+    simulationEffect:
+      'Competes with other non-async edges; the router picks one route per hop.',
+    strokeDasharray: 'none',
+    badgeClassName: 'border-nss-border bg-nss-surface text-nss-muted'
+  },
+  asynchronous: {
+    title: 'Asynchronous',
+    shortLabel: 'ASYNC',
+    summary: 'Fire-and-forget delivery to downstream async boundaries such as queues or brokers.',
+    simulationEffect:
+      'Every matching async edge is selected, so requests fan out in parallel.',
+    strokeDasharray: '12 7',
+    badgeClassName: 'border-nss-success/30 bg-nss-success/10 text-nss-success'
+  },
+  streaming: {
+    title: 'Streaming',
+    shortLabel: 'STREAM',
+    summary: 'Represents a long-lived channel such as WebSocket or bidirectional RPC.',
+    simulationEffect:
+      'Competes like a synchronous edge for route selection, but amortizes protocol overhead to model a persistent channel.',
+    note:
+      'Useful for teaching stream topology today; full session state and multiplexed message behavior are still not modeled.',
+    strokeDasharray: '4 6',
+    badgeClassName: 'border-nss-primary/30 bg-nss-primary/10 text-nss-primary'
+  },
+  conditional: {
+    title: 'Conditional',
+    shortLabel: 'IF',
+    summary: 'Route is only eligible when its condition matches the request payload or metadata.',
+    simulationEffect:
+      'Competes like a synchronous edge, but only after the condition gate passes.',
+    strokeDasharray: '14 6 2 6',
+    badgeClassName: 'border-nss-warning/30 bg-nss-warning/10 text-nss-warning'
+  }
+}
+
+export const EDGE_PROPERTY_HELP = {
+  label: {
+    title: 'Label',
+    summary: 'Short display name shown on the canvas, inspector, validation, and results panels.',
+    simulationEffect: 'No runtime effect. This is documentation for humans.'
+  },
+  protocol: {
+    title: 'Protocol',
+    summary: 'Transport used on the edge: HTTP, gRPC, TCP, UDP, WebSocket, AMQP, or Kafka.',
+    simulationEffect:
+      'Changes protocol overhead, retransmission behavior, and whether connection-limit rejection applies.'
+  },
+  mode: {
+    title: 'Mode',
+    summary: 'How the edge participates in routing: wait, fan out, stream, or branch by condition.',
+    simulationEffect:
+      'Controls whether one route is chosen, all async routes are chosen, or a condition must match first.'
+  },
+  pathType: {
+    title: 'Path Type',
+    summary: 'Physical distance and network locality: same rack, same DC, cross-zone, cross-region, or internet.',
+    simulationEffect:
+      'Only drives runtime latency when the edge is still using the path-type-derived log-normal profile.',
+    note:
+      'If you switch to constant latency or set explicit mu/sigma, path type becomes descriptive metadata.'
+  },
+  condition: {
+    title: 'Condition',
+    summary: 'Predicate that filters traffic by request type or request metadata.',
+    simulationEffect:
+      'A non-empty condition gates the edge even outside conditional mode; conditional mode simply makes it required.',
+    note:
+      'Supported forms today are request.type and request.metadata.<field> with ==, ===, !=, or !==.'
+  },
+  latencyModel: {
+    title: 'Latency Model',
+    summary: 'Choose either a jittered log-normal hop delay or a fixed constant delay.',
+    simulationEffect:
+      'This directly changes the sampled transit time for every request on the edge.'
+  },
+  latencyValue: {
+    title: 'Latency (ms)',
+    summary: 'Fixed one-way delay added to every hop when constant latency is selected.',
+    simulationEffect:
+      'Every request pays exactly this transit delay before transmission and protocol overhead.'
+  },
+  latencyMu: {
+    title: 'Latency Mu (log-space)',
+    summary: 'Natural-log median of the base latency distribution before transmission and protocol overhead.',
+    simulationEffect:
+      'Higher mu shifts the whole latency distribution upward and increases the typical hop time.'
+  },
+  latencySigma: {
+    title: 'Jitter Sigma',
+    summary: 'Spread of the log-normal latency distribution.',
+    simulationEffect:
+      'Higher sigma increases jitter and tail latency without necessarily changing the median.'
+  },
+  bandwidth: {
+    title: 'Bandwidth (Mbps)',
+    summary: 'Link throughput used to convert request size into transmission time.',
+    simulationEffect:
+      'Adds transmission delay as request.sizeBytes / (bandwidth * 125). Large payloads slow down more on narrow links.'
+  },
+  maxConcurrentRequests: {
+    title: 'Max Concurrent',
+    summary: 'How many transfers the edge can carry at once before it behaves like a saturated connection pool.',
+    simulationEffect:
+      'Near the cap, latency inflates; at or above the cap, reliable protocols reject new transfers with connection_refused.'
+  },
+  packetLossRate: {
+    title: 'Packet Loss (%)',
+    summary: 'Probability that packets are dropped while traversing the edge.',
+    simulationEffect:
+      'UDP loss becomes a timeout/drop. Reliable protocols simulate retransmission by adding extra delay instead of immediate failure.'
+  },
+  errorRate: {
+    title: 'Edge Error (%)',
+    summary: 'Probability that the link itself rejects the request independent of packet loss.',
+    simulationEffect:
+      'Produces an immediate edge-level failure before the request arrives at the target node.'
+  }
+} satisfies Record<string, EdgeHelpEntry>
+
+export const EDGE_PROTOCOL_HELP: Record<EdgeProtocolValue, EdgeHelpEntry> = {
+  https: {
+    title: 'HTTPS',
+    summary: 'Secure request-response traffic typical for internet-facing APIs.',
+    simulationEffect: 'Moderate protocol overhead with reliable retransmission semantics.'
+  },
+  grpc: {
+    title: 'gRPC',
+    summary: 'Binary RPC over reliable transport, common inside service meshes.',
+    simulationEffect: 'Low fixed overhead with reliable retransmission semantics.'
+  },
+  tcp: {
+    title: 'TCP',
+    summary: 'Raw reliable transport used by databases, caches, and lower-level services.',
+    simulationEffect: 'No extra protocol overhead beyond transport, but connection limits still apply.'
+  },
+  udp: {
+    title: 'UDP',
+    summary: 'Connectionless transport used when speed matters more than guaranteed delivery.',
+    simulationEffect:
+      'No retransmission and no connection-limit rejection, so packet loss becomes a direct timeout/drop signal.'
+  },
+  websocket: {
+    title: 'WebSocket',
+    summary: 'Long-lived bidirectional channel for live updates and interactive sessions.',
+    simulationEffect:
+      'Low fixed overhead with reliable delivery; best paired with streaming mode for clear topology intent.'
+  },
+  amqp: {
+    title: 'AMQP',
+    summary: 'Broker-style messaging protocol used for queues and work distribution.',
+    simulationEffect: 'Higher fixed overhead with reliable delivery semantics and broker-style async routing.'
+  },
+  kafka: {
+    title: 'Kafka',
+    summary: 'Durable streaming/broker protocol used for event logs and stream processing.',
+    simulationEffect: 'Higher fixed overhead with reliable delivery semantics and async fan-out topologies.'
+  }
+}
+
+export const EDGE_PATH_TYPE_HELP: Record<EdgePathTypeValue, EdgeHelpEntry> = {
+  'same-rack': {
+    title: 'Same Rack',
+    summary: 'Shortest, fastest local path between tightly colocated components.',
+    simulationEffect: 'Lowest inferred latency and highest default bandwidth.'
+  },
+  'same-dc': {
+    title: 'Same DC',
+    summary: 'Local datacenter traffic between nearby but not identical racks.',
+    simulationEffect: 'Low inferred latency with high default bandwidth.'
+  },
+  'cross-zone': {
+    title: 'Cross Zone',
+    summary: 'Traffic crossing failure domains inside one region.',
+    simulationEffect: 'Higher inferred latency and lower default bandwidth than same-DC links.'
+  },
+  'cross-region': {
+    title: 'Cross Region',
+    summary: 'Traffic crossing regional boundaries over long-haul links.',
+    simulationEffect: 'High inferred latency and reduced default bandwidth.'
+  },
+  internet: {
+    title: 'Internet',
+    summary: 'Public-network or external-service traffic with the widest latency spread.',
+    simulationEffect: 'Highest inferred latency variance and the lowest default bandwidth.'
+  }
+}
+
+function hasFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+export function getEdgeModePresentation(
+  mode: EdgeSimulationData['mode'] | EdgeDefinition['mode'] | undefined
+): EdgeModePresentation {
+  return EDGE_MODE_PRESENTATION[mode ?? 'synchronous']
+}
+
+export function inferCanvasEdgeMode(
+  edgeData: Pick<EdgeSimulationData, 'mode' | 'protocol'> | undefined,
+  targetNodeData?: CanvasNodeDataV2
+): EdgeModeValue {
+  if (edgeData?.mode) {
+    return edgeData.mode
+  }
+
+  if (edgeData?.protocol === 'websocket' || targetNodeData?.componentType === 'websockets-gateway') {
+    return 'streaming'
+  }
+
+  const targetTemplate = getPaletteTemplate(targetNodeData?.templateId)
+  const targetSpec = getComponentSpec(targetNodeData?.componentType)
+  return targetTemplate?.asyncBoundary || targetSpec?.asyncBoundary ? 'asynchronous' : 'synchronous'
+}
+
+export function isPathTypeDrivingLatency(
+  edgeData: Pick<
+    EdgeSimulationData,
+    'latencyDistributionType' | 'latencyValue' | 'latencyMu' | 'latencySigma'
+  >
+): boolean {
+  const distributionType =
+    edgeData.latencyDistributionType === 'constant'
+      ? 'constant'
+      : edgeData.latencyDistributionType === 'log-normal'
+        ? 'log-normal'
+        : hasFiniteNumber(edgeData.latencyValue) &&
+            !hasFiniteNumber(edgeData.latencyMu) &&
+            !hasFiniteNumber(edgeData.latencySigma)
+          ? 'constant'
+          : 'log-normal'
+
+  return (
+    distributionType === 'log-normal' &&
+    !hasFiniteNumber(edgeData.latencyMu) &&
+    !hasFiniteNumber(edgeData.latencySigma)
+  )
+}

--- a/src/renderer/src/config/edgeSemantics.ts
+++ b/src/renderer/src/config/edgeSemantics.ts
@@ -26,8 +26,7 @@ export const EDGE_MODE_PRESENTATION: Record<EdgeModeValue, EdgeModePresentation>
     title: 'Synchronous',
     shortLabel: 'SYNC',
     summary: 'Caller sends work and waits for the downstream hop to finish.',
-    simulationEffect:
-      'Competes with other non-async edges; the router picks one route per hop.',
+    simulationEffect: 'Competes with other non-async edges; the router picks one route per hop.',
     strokeDasharray: 'none',
     badgeClassName: 'border-nss-border bg-nss-surface text-nss-muted'
   },
@@ -35,8 +34,7 @@ export const EDGE_MODE_PRESENTATION: Record<EdgeModeValue, EdgeModePresentation>
     title: 'Asynchronous',
     shortLabel: 'ASYNC',
     summary: 'Fire-and-forget delivery to downstream async boundaries such as queues or brokers.',
-    simulationEffect:
-      'Every matching async edge is selected, so requests fan out in parallel.',
+    simulationEffect: 'Every matching async edge is selected, so requests fan out in parallel.',
     strokeDasharray: '12 7',
     badgeClassName: 'border-nss-success/30 bg-nss-success/10 text-nss-success'
   },
@@ -46,8 +44,7 @@ export const EDGE_MODE_PRESENTATION: Record<EdgeModeValue, EdgeModePresentation>
     summary: 'Represents a long-lived channel such as WebSocket or bidirectional RPC.',
     simulationEffect:
       'Competes like a synchronous edge for route selection, but amortizes protocol overhead to model a persistent channel.',
-    note:
-      'Useful for teaching stream topology today; full session state and multiplexed message behavior are still not modeled.',
+    note: 'Useful for teaching stream topology today; full session state and multiplexed message behavior are still not modeled.',
     strokeDasharray: '4 6',
     badgeClassName: 'border-nss-primary/30 bg-nss-primary/10 text-nss-primary'
   },
@@ -55,8 +52,7 @@ export const EDGE_MODE_PRESENTATION: Record<EdgeModeValue, EdgeModePresentation>
     title: 'Conditional',
     shortLabel: 'IF',
     summary: 'Route is only eligible when its condition matches the request payload or metadata.',
-    simulationEffect:
-      'Competes like a synchronous edge, but only after the condition gate passes.',
+    simulationEffect: 'Competes like a synchronous edge, but only after the condition gate passes.',
     strokeDasharray: '14 6 2 6',
     badgeClassName: 'border-nss-warning/30 bg-nss-warning/10 text-nss-warning'
   }
@@ -82,19 +78,18 @@ export const EDGE_PROPERTY_HELP = {
   },
   pathType: {
     title: 'Path Type',
-    summary: 'Physical distance and network locality: same rack, same DC, cross-zone, cross-region, or internet.',
+    summary:
+      'Physical distance and network locality: same rack, same DC, cross-zone, cross-region, or internet.',
     simulationEffect:
       'Only drives runtime latency when the edge is still using the path-type-derived log-normal profile.',
-    note:
-      'If you switch to constant latency or set explicit mu/sigma, path type becomes descriptive metadata.'
+    note: 'If you switch to constant latency or set explicit mu/sigma, path type becomes descriptive metadata.'
   },
   condition: {
     title: 'Condition',
     summary: 'Predicate that filters traffic by request type or request metadata.',
     simulationEffect:
       'A non-empty condition gates the edge even outside conditional mode; conditional mode simply makes it required.',
-    note:
-      'Supported forms today are request.type and request.metadata.<field> with ==, ===, !=, or !==.'
+    note: 'Supported forms today are request.type and request.metadata.<field> with ==, ===, !=, or !==.'
   },
   latencyModel: {
     title: 'Latency Model',
@@ -110,7 +105,8 @@ export const EDGE_PROPERTY_HELP = {
   },
   latencyMu: {
     title: 'Latency Mu (log-space)',
-    summary: 'Natural-log median of the base latency distribution before transmission and protocol overhead.',
+    summary:
+      'Natural-log median of the base latency distribution before transmission and protocol overhead.',
     simulationEffect:
       'Higher mu shifts the whole latency distribution upward and increases the typical hop time.'
   },
@@ -128,7 +124,8 @@ export const EDGE_PROPERTY_HELP = {
   },
   maxConcurrentRequests: {
     title: 'Max Concurrent',
-    summary: 'How many transfers the edge can carry at once before it behaves like a saturated connection pool.',
+    summary:
+      'How many transfers the edge can carry at once before it behaves like a saturated connection pool.',
     simulationEffect:
       'Near the cap, latency inflates; at or above the cap, reliable protocols reject new transfers with connection_refused.'
   },
@@ -160,7 +157,8 @@ export const EDGE_PROTOCOL_HELP: Record<EdgeProtocolValue, EdgeHelpEntry> = {
   tcp: {
     title: 'TCP',
     summary: 'Raw reliable transport used by databases, caches, and lower-level services.',
-    simulationEffect: 'No extra protocol overhead beyond transport, but connection limits still apply.'
+    simulationEffect:
+      'No extra protocol overhead beyond transport, but connection limits still apply.'
   },
   udp: {
     title: 'UDP',
@@ -177,12 +175,14 @@ export const EDGE_PROTOCOL_HELP: Record<EdgeProtocolValue, EdgeHelpEntry> = {
   amqp: {
     title: 'AMQP',
     summary: 'Broker-style messaging protocol used for queues and work distribution.',
-    simulationEffect: 'Higher fixed overhead with reliable delivery semantics and broker-style async routing.'
+    simulationEffect:
+      'Higher fixed overhead with reliable delivery semantics and broker-style async routing.'
   },
   kafka: {
     title: 'Kafka',
     summary: 'Durable streaming/broker protocol used for event logs and stream processing.',
-    simulationEffect: 'Higher fixed overhead with reliable delivery semantics and async fan-out topologies.'
+    simulationEffect:
+      'Higher fixed overhead with reliable delivery semantics and async fan-out topologies.'
   }
 }
 
@@ -232,7 +232,10 @@ export function inferCanvasEdgeMode(
     return edgeData.mode
   }
 
-  if (edgeData?.protocol === 'websocket' || targetNodeData?.componentType === 'websockets-gateway') {
+  if (
+    edgeData?.protocol === 'websocket' ||
+    targetNodeData?.componentType === 'websockets-gateway'
+  ) {
     return 'streaming'
   }
 

--- a/src/renderer/src/config/metricLensConfig.ts
+++ b/src/renderer/src/config/metricLensConfig.ts
@@ -1,0 +1,35 @@
+import type { MetricLens, PreRunMetricLens, RuntimeMetricLens } from '@renderer/types/ui'
+
+export type MetricLensOption<T extends MetricLens = MetricLens> = {
+  id: T
+  label: string
+}
+
+export const PRE_RUN_LENSES: Array<MetricLensOption<PreRunMetricLens>> = [
+  { id: 'concurrency', label: 'Concurrency' },
+  { id: 'queueCapacity', label: 'Queue Capacity' },
+  { id: 'timeout', label: 'Timeout' }
+]
+
+export const RUNTIME_LENSES: Array<MetricLensOption<RuntimeMetricLens>> = [
+  { id: 'traffic', label: 'Traffic' },
+  { id: 'saturation', label: 'Saturation' },
+  { id: 'latency', label: 'Latency' },
+  { id: 'errors', label: 'Errors' },
+  { id: 'throughput', label: 'Throughput' }
+]
+
+const METRIC_LENS_LABELS: Record<MetricLens, string> = {
+  concurrency: 'Concurrency',
+  queueCapacity: 'Queue Capacity',
+  timeout: 'Timeout',
+  traffic: 'Traffic',
+  saturation: 'Saturation',
+  latency: 'Latency',
+  errors: 'Errors',
+  throughput: 'Throughput'
+}
+
+export function getMetricLensLabel(lens: MetricLens): string {
+  return METRIC_LENS_LABELS[lens]
+}

--- a/src/renderer/src/config/sampleScenarios.ts
+++ b/src/renderer/src/config/sampleScenarios.ts
@@ -1,4 +1,6 @@
 import directClientServerRaw from '../../../engine/__samples__/direct-client-server.json?raw'
+import directClientServerCleanRaw from '../../../engine/__samples__/direct-client-server-clean.json?raw'
+import directClientServerJitterRaw from '../../../engine/__samples__/direct-client-server-jitter.json?raw'
 import monolithStackRaw from '../../../engine/__samples__/traditional-single-instance-stack.json?raw'
 import proxyEdgeRaw from '../../../engine/__samples__/proxy-edge.json?raw'
 import l7ScaleOutRaw from '../../../engine/__samples__/horizontal-compute-scaling-l7.json?raw'
@@ -33,6 +35,28 @@ export const SAMPLE_SCENARIOS: SampleScenario[] = [
     simulatorValue: 'Show how quickly one node gets overwhelmed by high RPS or concurrency.',
     difficulty: 'starter',
     raw: directClientServerRaw
+  },
+  {
+    id: 'direct-client-server-clean',
+    name: 'Even Arrivals (D/D/1)',
+    subtitle: 'Constant edge, no jitter',
+    diagram: 'Client App --(constant edge)--> API Server',
+    primaryUseCase: 'A constant source over a constant-latency edge: perfectly even arrivals.',
+    simulatorValue:
+      'The clean baseline — one worker near capacity never queues, so there are zero rejects. Pair it with "Jittered Arrivals" to see what variance adds.',
+    difficulty: 'starter',
+    raw: directClientServerCleanRaw
+  },
+  {
+    id: 'direct-client-server-jitter',
+    name: 'Jittered Arrivals',
+    subtitle: 'Log-normal edge adds variance',
+    diagram: 'Client App --(jittery edge)--> API Server',
+    primaryUseCase: 'The same server, but the edge varies each hop so arrivals bunch.',
+    simulatorValue:
+      'Identical to the clean baseline except the edge is log-normal — now capacity_exceeded rejects appear below nominal capacity. Compare offered vs arrival CV to see why.',
+    difficulty: 'starter',
+    raw: directClientServerJitterRaw
   },
   {
     id: 'traditional-single-instance-stack',

--- a/src/renderer/src/config/sampleScenarios.ts
+++ b/src/renderer/src/config/sampleScenarios.ts
@@ -43,7 +43,7 @@ export const SAMPLE_SCENARIOS: SampleScenario[] = [
     diagram: 'Client App --(constant edge)--> API Server',
     primaryUseCase: 'A constant source over a constant-latency edge: perfectly even arrivals.',
     simulatorValue:
-      'The clean baseline — one worker near capacity never queues, so there are zero rejects. Pair it with "Jittered Arrivals" to see what variance adds.',
+      'The clean baseline - one worker near capacity never queues, so there are zero rejects. Pair it with "Jittered Arrivals" to see what variance adds.',
     difficulty: 'starter',
     raw: directClientServerCleanRaw
   },
@@ -54,7 +54,7 @@ export const SAMPLE_SCENARIOS: SampleScenario[] = [
     diagram: 'Client App --(jittery edge)--> API Server',
     primaryUseCase: 'The same server, but the edge varies each hop so arrivals bunch.',
     simulatorValue:
-      'Identical to the clean baseline except the edge is log-normal — now capacity_exceeded rejects appear below nominal capacity. Compare offered vs arrival CV to see why.',
+      'Identical to the clean baseline except the edge is log-normal - now capacity_exceeded rejects appear below nominal capacity. Compare offered vs arrival CV to see why.',
     difficulty: 'starter',
     raw: directClientServerJitterRaw
   },

--- a/src/renderer/src/config/tooltipCatalog.ts
+++ b/src/renderer/src/config/tooltipCatalog.ts
@@ -1,0 +1,93 @@
+import type { MetricLens } from '@renderer/types/ui'
+
+export const METRIC_LENS_TOOLTIPS: Record<MetricLens, string> = {
+  concurrency: 'Shows how much work each node can process at once before queueing begins.',
+  queueCapacity: 'Shows how much work each node can buffer once concurrency is exhausted.',
+  timeout: 'Shows the timeout budget configured on each node before requests fail.',
+  traffic: 'Highlights request flow and fail rate across nodes and edges.',
+  saturation: 'Highlights utilization headroom and queue pressure.',
+  latency: 'Highlights response time so slow hops stand out.',
+  errors: 'Highlights failure rate and dominant failure cause.',
+  throughput: 'Highlights requests per second across nodes and edges.'
+}
+
+export const RESULTS_SUMMARY_TOOLTIPS = {
+  requestsPostWarmup:
+    "Total requests that entered the system after warmup ended. Warmup samples are excluded so transient startup behavior doesn't skew the metrics.",
+  successful: 'Requests that both entered after warmup and eventually completed successfully.',
+  throughput:
+    'Requests completed per second, averaged over the post-warmup window. If this exceeds your configured Base RPS, something is amplifying traffic.',
+  errorRate:
+    'Fraction of post-warmup requests that failed. This includes instant rejects, timeout walls, and connection resets.',
+  inFlightAtCutoff:
+    'Requests that had entered at least one node after warmup, but had not yet completed, timed out, or been rejected when the simulation stopped.',
+  offeredArrivalCv:
+    'Coefficient of variation of source-generated inter-arrival gaps after warmup. 0 means perfectly even; about 1 is Poisson.'
+} as const
+
+export const RESULTS_E2E_PERCENTILE_TOOLTIPS: Record<
+  'p50' | 'p90' | 'p95' | 'p99' | 'max',
+  string
+> = {
+  p50: 'Median end-to-end latency. Half of requests were faster than this, half slower.',
+  p90: '90th percentile. 10% of requests were slower than this value.',
+  p95: '95th percentile. Typical SLO target for latency-sensitive services.',
+  p99: '99th percentile tail latency. 1% of requests were slower. Most user-facing SLOs live here.',
+  max: 'Slowest observed request. Useful for spotting outliers, not as a reliable tail metric.'
+}
+
+export const RESULTS_HEALTH_CHECK_TOOLTIPS = {
+  slo: "Compares each node's measured p99 latency and availability against the SLO targets configured on the node.",
+  errorRate:
+    'Breakdown of rejected, timed-out, and connection-reset requests by node. Rejections happen when the queue is full, timeouts happen when the caller waits too long, and resets happen when in-flight work is explicitly dropped.',
+  littlesLaw:
+    "Little's Law (L = λ·W) is a queueing-theory identity that must hold in steady state. Violations usually indicate either measurement noise at low utilization, or that the simulation never reached steady state. At very low L, relative errors can be large while absolute differences are sub-request.",
+  conservation:
+    'Verifies that for every node: arrived = processed + rejected + timed out + connection reset + in-flight at cutoff. Small non-zero in-flight counts are expected when the run ends with requests still being processed.',
+  warmup:
+    "Checks that warmup duration is at least 10× the max observed p99. If it isn't, post-warmup metrics may still be contaminated by startup transients."
+} as const
+
+export const RESULTS_PER_NODE_COLUMN_TOOLTIPS = {
+  arrived: 'Requests that reached this node during the post-warmup window.',
+  done: 'Requests this node finished processing before the simulation cutoff in the post-warmup window.',
+  reject: "Requests turned away because the node's queue was full.",
+  timedOut: "Requests that exceeded this node's processing timeout.",
+  reset:
+    'Requests explicitly terminated with connection_reset while queued, in service, or released from a hung recovery path.',
+  errorRate:
+    'Rejected + timed out + connection reset, divided by post-warmup arrivals at this node. Read the latency columns with this value, never by themselves.',
+  arrivalCV:
+    'Coefficient of variation of inter-arrival gaps at this node. 0 = perfectly even; about 1 = Poisson. If this exceeds the offered CV, upstream jitter or contention bunched requests before this node.',
+  inFlight:
+    'Requests that had arrived at this node but were still queued or processing when the simulation ended.',
+  avgQueue: 'Time-averaged queue depth. Requests waiting, not yet being processed.',
+  util: 'Fraction of workers busy on average. Near 100% means the node is saturated.',
+  p50: 'Median service + queue time at this node only. Does not include network or link latency.',
+  p95: '95th percentile per-hop latency at this node.',
+  p99: '99th percentile per-hop latency at this node. Per-hop p99s do not sum to end-to-end p99.',
+  lambda: 'Arrival rate (λ, requests per second) during the post-warmup window.',
+  w: 'Mean time a request spends at this node (W, service + queue). End-to-end latency is roughly the sum of W across the path.',
+  l: "Average number of requests concurrently at this node (L). By Little's Law, L = λ·W."
+} as const
+
+export const RUNTIME_NODE_METRIC_TOOLTIPS = {
+  completedReceived:
+    'Requests this node completed out of requests that reached it in the post-warmup window.',
+  rejectedTimedOut:
+    'Requests dropped because the queue filled, or requests that waited longer than the timeout.'
+} as const
+
+export const RESULTS_CONTEXTUAL_TOOLTIPS = {
+  percentilesDoNotCompose:
+    "Percentiles don't compose. End-to-end p99 is not the sum of per-hop p99s. Use per-node mean (W) for additive decomposition.",
+  offeredCvVsArrivalCv:
+    "Source-generated inter-arrival CV after warmup. Compare against this node's arrival CV to see how much variance the network added.",
+  arrivalCvNode:
+    'Delivered inter-arrival CV at this node after warmup. 0 means perfectly even; about 1 is Poisson.'
+} as const
+
+export function formatInFlightAtCutoffBanner(count: number): string {
+  const noun = count === 1 ? 'request was' : 'requests were'
+  return `${count.toLocaleString()} ${noun} still in flight when the simulation hit its duration limit. They are not counted as completed or failed.`
+}

--- a/src/renderer/src/hooks/useSimulation.ts
+++ b/src/renderer/src/hooks/useSimulation.ts
@@ -12,6 +12,7 @@ export interface SimulationState {
   status: SimulationStatus
   progress: number // 0–100
   eventsProcessed: number
+  runStartedAtMs: number | null
   snapshot: TimeSeriesSnapshot | null
   results: SimulationOutput | null
   stopped: boolean
@@ -33,6 +34,7 @@ const INITIAL_STATE: SimulationState = {
   status: 'idle',
   progress: 0,
   eventsProcessed: 0,
+  runStartedAtMs: null,
   snapshot: null,
   results: null,
   stopped: false,
@@ -136,6 +138,7 @@ export function useSimulation(): SimulationState & SimulationControls {
       status: 'running',
       progress: 0,
       eventsProcessed: 0,
+      runStartedAtMs: Date.now(),
       snapshot: null,
       results: null,
       stopped: false,

--- a/src/renderer/src/hooks/useTopologySerializer.ts
+++ b/src/renderer/src/hooks/useTopologySerializer.ts
@@ -12,6 +12,7 @@ import { getComponentSpec } from '../../../engine/catalog/componentSpecs'
 import { getPaletteTemplate } from '../../../engine/catalog/paletteTemplates'
 import type { CanvasNodeDataV2 } from '../../../engine/catalog/nodeSpecTypes'
 import { getPathTypeLatencyProfile, inferEdgeDefaults } from '../../../engine/defaults/edgeDefaults'
+import { inferCanvasEdgeMode } from '@renderer/config/edgeSemantics'
 import useStore from '../store/useStore'
 import type { ScenarioRunContext, ScenarioState } from '@renderer/types/ui'
 import { normalizeScenarioState } from '@renderer/types/ui'
@@ -186,9 +187,13 @@ function serializeEdge(
     pathLatencyProfile
   )
 
-  const mode =
-    asEdgeMode(edgeData.mode) ??
-    (targetTemplate?.asyncBoundary || targetSpec?.asyncBoundary ? 'asynchronous' : 'synchronous')
+  const mode = inferCanvasEdgeMode(
+    {
+      mode: asEdgeMode(edgeData.mode) ?? undefined,
+      protocol: asProtocol(edgeData.protocol) ?? undefined
+    },
+    targetData
+  )
 
   return {
     id: id || `${source}->${target}`,

--- a/src/renderer/src/hooks/useTopologySerializer.ts
+++ b/src/renderer/src/hooks/useTopologySerializer.ts
@@ -9,7 +9,6 @@ import type {
   WorkloadProfile
 } from '../../../engine/core/types'
 import { getComponentSpec } from '../../../engine/catalog/componentSpecs'
-import { getPaletteTemplate } from '../../../engine/catalog/paletteTemplates'
 import type { CanvasNodeDataV2 } from '../../../engine/catalog/nodeSpecTypes'
 import { getPathTypeLatencyProfile, inferEdgeDefaults } from '../../../engine/defaults/edgeDefaults'
 import { inferCanvasEdgeMode } from '@renderer/config/edgeSemantics'
@@ -176,8 +175,6 @@ function serializeEdge(
 
   const targetData = dataByNodeId.get(target)
   const sourceData = dataByNodeId.get(source)
-  const targetTemplate = getPaletteTemplate(targetData?.templateId)
-  const targetSpec = getComponentSpec(targetData?.componentType)
   const edgeData = (rfEdge.data ?? {}) as EdgeRuntimeData
   const inferredDefaults = inferEdgeDefaults(sourceData, targetData)
   const pathType = asPathType(edgeData.pathType) ?? inferredDefaults.pathType

--- a/src/renderer/src/store/useStore.ts
+++ b/src/renderer/src/store/useStore.ts
@@ -69,6 +69,7 @@ export interface EdgeFlowRunConfig {
 
 const EDGE_FLOW_WINDOW_MS = 6_000
 const EDGE_FLOW_MAX_EVENTS = 25_000
+const EDGE_FLOW_HISTORY_MAX_EVENTS = 100_000
 const EDGE_FLOW_PLAYBACK_SPEED = 10
 
 const EMPTY_EDGE_FLOW_STATE: EdgeFlowState = {
@@ -138,6 +139,7 @@ type RFState = {
   simulationMetricsByNode: Record<string, NodeSimulationMetrics>
   metricLens: MetricLens
   edgeFlowById: Record<string, EdgeFlowState>
+  edgeFlowHistory: EdgeFlowRenderEvent[]
   edgeFlowPlayback: { wallStartMs: number; simStartMs: number } | null
   edgeFlowStatus: EdgeFlowStatus
   edgeFlowRunConfig: EdgeFlowRunConfig | null
@@ -183,6 +185,7 @@ const useStore = create<RFState>((set, get) => ({
   simulationMetricsByNode: {},
   metricLens: 'concurrency',
   edgeFlowById: {},
+  edgeFlowHistory: [],
   edgeFlowPlayback: null,
   edgeFlowStatus: 'idle',
   edgeFlowRunConfig: null,
@@ -321,19 +324,19 @@ const useStore = create<RFState>((set, get) => ({
       simStartMs: event.startedAtMs
     }
     const edgeFlowById = get().edgeFlowById
+    const edgeFlowHistory = get().edgeFlowHistory
     const previous = edgeFlowById[event.edgeId] ?? EMPTY_EDGE_FLOW_STATE
     const displayAtMs =
       playback.wallStartMs + (event.startedAtMs - playback.simStartMs) / EDGE_FLOW_PLAYBACK_SPEED
-    const recent = [
-      ...previous.recent,
-      {
-        ...event,
-        receivedAtMs: now,
-        displayAtMs
-      }
-    ]
+    const renderedEvent: EdgeFlowRenderEvent = {
+      ...event,
+      receivedAtMs: now,
+      displayAtMs
+    }
+    const recent = [...previous.recent, renderedEvent]
       .filter((item) => displayAtMs - item.displayAtMs <= EDGE_FLOW_WINDOW_MS * 2)
       .slice(-EDGE_FLOW_MAX_EVENTS)
+    const nextHistory = [...edgeFlowHistory, renderedEvent].slice(-EDGE_FLOW_HISTORY_MAX_EVENTS)
     const warmupDurationMs = get().edgeFlowRunConfig?.warmupDurationMs ?? 0
     const isPostWarmupEvent = event.completedAtMs >= warmupDurationMs
     const isPostWarmupSuccess = event.status === 'success' && isPostWarmupEvent
@@ -363,6 +366,7 @@ const useStore = create<RFState>((set, get) => ({
     set({
       edgeFlowStatus: 'running',
       edgeFlowPlayback: playback,
+      edgeFlowHistory: nextHistory,
       edgeFlowById: {
         ...edgeFlowById,
         [event.edgeId]: {
@@ -398,6 +402,7 @@ const useStore = create<RFState>((set, get) => ({
   clearEdgeFlow: () => {
     set({
       edgeFlowById: {},
+      edgeFlowHistory: [],
       edgeFlowPlayback: null,
       edgeFlowStatus: 'idle',
       edgeFlowRunConfig: null

--- a/src/renderer/src/utils/failureRatePresentation.ts
+++ b/src/renderer/src/utils/failureRatePresentation.ts
@@ -1,4 +1,10 @@
-export type FailureRateLevel = 'ok' | 'warn' | 'crit'
+import type { FailureRateLevel } from '@renderer/utils/nodeHealthThresholds'
+
+export type { FailureRateLevel } from '@renderer/utils/nodeHealthThresholds'
+export {
+  failureRateLevelFromPercent,
+  failureRateLevelFromRatio
+} from '@renderer/utils/nodeHealthThresholds'
 
 export function roundedFailurePercent(value?: number): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return 0
@@ -15,18 +21,6 @@ export function formatFailurePercentLabel(value?: number): string {
   }
 
   return `${value.toFixed(1)}%`
-}
-
-export function failureRateLevelFromPercent(value?: number): FailureRateLevel {
-  const rounded = roundedFailurePercent(value)
-  if (rounded > 5) return 'crit'
-  if (rounded > 1) return 'warn'
-  return 'ok'
-}
-
-export function failureRateLevelFromRatio(value?: number): FailureRateLevel {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return 'ok'
-  return failureRateLevelFromPercent(value * 100)
 }
 
 export function failureRateTextClass(level: FailureRateLevel): string {

--- a/src/renderer/src/utils/nodeHealthThresholds.ts
+++ b/src/renderer/src/utils/nodeHealthThresholds.ts
@@ -1,0 +1,256 @@
+import type { TimeToErrorSummary } from '../../../engine/metrics'
+import type { ErrorCause } from '../../../engine/metrics/windowedLatencyAggregator'
+import { ERROR_CAUSE_LABELS, dominantTimeToErrorCause } from './errorCausePresentation'
+
+export type FailureRateLevel = 'ok' | 'warn' | 'crit'
+export type NodeStatusTone = 'ok' | 'warn' | 'crit'
+export type NodeCapacityLevel = 'headroom' | 'tight' | 'saturated'
+export type NodeReliabilityLevel = 'idle' | 'healthy' | 'degraded' | 'failing' | 'silent' | 'down'
+
+export const NODE_HEALTH_THRESHOLDS = {
+  reliability: {
+    failureWarnPercent: 1,
+    failureCritPercent: 5,
+    noSuccessTerminalCritRatio: 0.5
+  },
+  capacity: {
+    tightUtilizationPercent: 75,
+    saturatedUtilizationPercent: 90,
+    queueObservedThreshold: 1
+  }
+} as const
+
+function clampLowerBound(value: number): number {
+  return Math.max(0, value)
+}
+
+export function roundedFailurePercent(value?: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 0
+  return Math.round(clampLowerBound(value) * 10) / 10
+}
+
+export function failureRateLevelFromPercent(value?: number): FailureRateLevel {
+  const rounded = roundedFailurePercent(value)
+  if (rounded > NODE_HEALTH_THRESHOLDS.reliability.failureCritPercent) return 'crit'
+  if (rounded > NODE_HEALTH_THRESHOLDS.reliability.failureWarnPercent) return 'warn'
+  return 'ok'
+}
+
+export function failureRateLevelFromRatio(value?: number): FailureRateLevel {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 'ok'
+  return failureRateLevelFromPercent(value * 100)
+}
+
+export function utilizationPercent(value: number, unit: 'ratio' | 'percent'): number {
+  if (!Number.isFinite(value)) return 0
+  return clampLowerBound(unit === 'ratio' ? value * 100 : value)
+}
+
+export function toneRank(tone: NodeStatusTone): number {
+  if (tone === 'crit') return 2
+  if (tone === 'warn') return 1
+  return 0
+}
+
+export interface CapacityStatus {
+  level: NodeCapacityLevel
+  tone: NodeStatusTone
+  label: 'Headroom' | 'Tight' | 'Saturated'
+  utilizationPercent: number
+  detail: string
+}
+
+export function deriveCapacityStatus({
+  utilization,
+  queueDepth = 0,
+  workers,
+  utilizationUnit
+}: {
+  utilization: number
+  queueDepth?: number
+  workers?: number
+  utilizationUnit: 'ratio' | 'percent'
+}): CapacityStatus {
+  const percent = utilizationPercent(utilization, utilizationUnit)
+  const normalizedQueueDepth = Number.isFinite(queueDepth) ? Math.max(0, queueDepth) : 0
+  const workerText =
+    typeof workers === 'number' && Number.isFinite(workers) && workers > 0
+      ? `${workers} worker${workers === 1 ? '' : 's'}`
+      : null
+
+  if (percent >= NODE_HEALTH_THRESHOLDS.capacity.saturatedUtilizationPercent) {
+    return {
+      level: 'saturated',
+      tone: 'warn',
+      label: 'Saturated',
+      utilizationPercent: percent,
+      detail: workerText
+        ? `${workerText} at ${percent.toFixed(1)}% utilization - no headroom for spikes.`
+        : `${percent.toFixed(1)}% utilized - no headroom for spikes.`
+    }
+  }
+
+  if (
+    percent >= NODE_HEALTH_THRESHOLDS.capacity.tightUtilizationPercent ||
+    normalizedQueueDepth >= NODE_HEALTH_THRESHOLDS.capacity.queueObservedThreshold
+  ) {
+    return {
+      level: 'tight',
+      tone: 'warn',
+      label: 'Tight',
+      utilizationPercent: percent,
+      detail:
+        percent >= NODE_HEALTH_THRESHOLDS.capacity.tightUtilizationPercent
+          ? workerText
+            ? `${workerText} at ${percent.toFixed(1)}% utilization - limited headroom for spikes.`
+            : `${percent.toFixed(1)}% utilized - limited headroom for spikes.`
+          : `Avg queue ${normalizedQueueDepth.toFixed(1)} observed at ${percent.toFixed(1)}% utilization - burstiness is consuming slack.`
+    }
+  }
+
+  return {
+    level: 'headroom',
+    tone: 'ok',
+    label: 'Headroom',
+    utilizationPercent: percent,
+    detail: workerText
+      ? `${workerText} at ${percent.toFixed(1)}% utilization - comfortable headroom.`
+      : `${percent.toFixed(1)}% utilized - comfortable headroom.`
+  }
+}
+
+export function capacityRank(level: NodeCapacityLevel): number {
+  if (level === 'saturated') return 2
+  if (level === 'tight') return 1
+  return 0
+}
+
+export interface ReliabilityStatus {
+  level: NodeReliabilityLevel
+  tone: NodeStatusTone
+  label: 'Idle' | 'Healthy' | 'Degraded' | 'Failing' | 'Silent' | 'Down'
+  dominantCause: ErrorCause | null
+  detail: string
+}
+
+export function deriveReliabilityStatus({
+  postWarmupArrived,
+  successLatencySamples,
+  timeToErrorSamples,
+  latencyWindowErrorRate,
+  timeToErrorByCause
+}: {
+  postWarmupArrived: number
+  successLatencySamples: number
+  timeToErrorSamples: number
+  latencyWindowErrorRate: number
+  timeToErrorByCause?: Partial<TimeToErrorSummary> | null
+}): ReliabilityStatus {
+  const hasWindowSamples = successLatencySamples + timeToErrorSamples > 0
+  const served = successLatencySamples > 0
+  const dominantCause = dominantTimeToErrorCause(timeToErrorByCause)
+
+  if (postWarmupArrived === 0 && !hasWindowSamples) {
+    return {
+      level: 'idle',
+      tone: 'ok',
+      label: 'Idle',
+      dominantCause,
+      detail: 'No post-warmup traffic reached this node.'
+    }
+  }
+
+  if (
+    !served &&
+    latencyWindowErrorRate > NODE_HEALTH_THRESHOLDS.reliability.noSuccessTerminalCritRatio
+  ) {
+    if (dominantCause === 'timeout') {
+      return {
+        level: 'silent',
+        tone: 'crit',
+        label: 'Silent',
+        dominantCause,
+        detail: 'No successful passes; requests are timing out here.'
+      }
+    }
+
+    return {
+      level: 'down',
+      tone: 'crit',
+      label: 'Down',
+      dominantCause,
+      detail: 'No successful passes; requests are failing at this node.'
+    }
+  }
+
+  if (latencyWindowErrorRate > NODE_HEALTH_THRESHOLDS.reliability.failureCritPercent / 100) {
+    if (dominantCause === 'node_failed') {
+      return {
+        level: 'failing',
+        tone: 'crit',
+        label: 'Failing',
+        dominantCause,
+        detail: 'Requests are being terminated by node failure at this node.'
+      }
+    }
+
+    return {
+      level: 'degraded',
+      tone: 'warn',
+      label: 'Degraded',
+      dominantCause,
+      detail: dominantCause
+        ? `Requests are failing here, mostly ${ERROR_CAUSE_LABELS[dominantCause]}.`
+        : 'Requests are failing here in this window.'
+    }
+  }
+
+  return {
+    level: 'healthy',
+    tone: 'ok',
+    label: 'Healthy',
+    dominantCause,
+    detail: dominantCause
+      ? `Requests are succeeding here; no failures terminated at this node in this window.`
+      : 'Requests are succeeding at this node in this window.'
+  }
+}
+
+export function reliabilityRank(level: NodeReliabilityLevel): number {
+  switch (level) {
+    case 'down':
+    case 'silent':
+      return 4
+    case 'failing':
+      return 3
+    case 'degraded':
+      return 2
+    case 'healthy':
+      return 1
+    case 'idle':
+    default:
+      return 0
+  }
+}
+
+export function deriveCombinedRuntimeTone({
+  utilization,
+  queueDepth = 0,
+  errorRatePercent = 0
+}: {
+  utilization: number
+  queueDepth?: number
+  errorRatePercent?: number
+}): NodeStatusTone {
+  const failureTone = failureRateLevelFromPercent(errorRatePercent)
+  const capacity = deriveCapacityStatus({
+    utilization,
+    queueDepth,
+    utilizationUnit: 'percent'
+  })
+
+  if (failureTone === 'crit') return 'crit'
+  if (capacity.level === 'saturated') return 'crit'
+  if (failureTone === 'warn' || capacity.level === 'tight') return 'warn'
+  return 'ok'
+}

--- a/src/renderer/src/utils/routingStrategyGraph.ts
+++ b/src/renderer/src/utils/routingStrategyGraph.ts
@@ -1,8 +1,6 @@
 import type { Edge, Node } from 'reactflow'
-import type { EdgeDefinition } from '../../../engine/core/types'
-import { getComponentSpec } from '../../../engine/catalog/componentSpecs'
-import { getPaletteTemplate } from '../../../engine/catalog/paletteTemplates'
 import type { AnyNodeData, NodeSimulationMetrics } from '@renderer/types/ui'
+import { inferCanvasEdgeMode } from '@renderer/config/edgeSemantics'
 import type { RoutingVisualizationTarget } from './routingStrategyVisualization'
 
 type EdgeDataRecord = Record<string, unknown>
@@ -31,19 +29,6 @@ function readString(...values: unknown[]): string | undefined {
   return undefined
 }
 
-function asEdgeMode(value: unknown): EdgeDefinition['mode'] | undefined {
-  if (
-    value === 'synchronous' ||
-    value === 'asynchronous' ||
-    value === 'streaming' ||
-    value === 'conditional'
-  ) {
-    return value
-  }
-
-  return undefined
-}
-
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value))
 }
@@ -57,15 +42,6 @@ function edgeLabel(edge: Edge, fallback: string): string {
   return typeof edge.label === 'string' && edge.label.trim().length > 0
     ? edge.label.trim()
     : fallback
-}
-
-function inferEdgeMode(edgeData: EdgeDataRecord, targetData: AnyNodeData | undefined) {
-  const explicitMode = asEdgeMode(edgeData.mode)
-  if (explicitMode) return explicitMode
-
-  const targetTemplate = getPaletteTemplate(targetData?.templateId)
-  const targetSpec = getComponentSpec(targetData?.componentType)
-  return targetTemplate?.asyncBoundary || targetSpec?.asyncBoundary ? 'asynchronous' : 'synchronous'
 }
 
 function edgeSuccessRatio(edgeData: EdgeDataRecord): number {
@@ -170,7 +146,28 @@ export function buildRoutingVisualizationTargets({
         inFlight: metricInFlight(targetMetrics),
         healthy: isTargetHealthy(targetData, targetMetrics, edgeData),
         condition: readString(edgeData.condition),
-        mode: inferEdgeMode(edgeData, targetData),
+        mode: inferCanvasEdgeMode(
+          {
+            mode:
+              edgeData.mode === 'synchronous' ||
+              edgeData.mode === 'asynchronous' ||
+              edgeData.mode === 'streaming' ||
+              edgeData.mode === 'conditional'
+                ? edgeData.mode
+                : undefined,
+            protocol:
+              edgeData.protocol === 'https' ||
+              edgeData.protocol === 'grpc' ||
+              edgeData.protocol === 'tcp' ||
+              edgeData.protocol === 'udp' ||
+              edgeData.protocol === 'websocket' ||
+              edgeData.protocol === 'amqp' ||
+              edgeData.protocol === 'kafka'
+                ? edgeData.protocol
+                : undefined
+          },
+          targetData
+        ),
         successRatio: edgeSuccessRatio(edgeData)
       }
     })


### PR DESCRIPTION
This branch improves simulation observability across both the engine and renderer. It adds a per-request outcome ledger to the engine and surfaces that data in the UI through a live traffic monitor, a post-run outcome log, and richer results-tray diagnostics. It also introduces clearer runtime health visualization by separating node reliability and capacity signals, adds a canvas legend, and moves edge editing into the shared right-hand inspector so edge selection behaves consistently with node selection.

The branch also improves edge modeling and usability. It adds edge property tooltips, consistent edge-mode inference and visualization, and lower per-message protocol overhead for streaming edges. Alongside that, it centralizes tooltip and health-presentation config, keeps sub-millisecond latencies displayed in milliseconds, and includes small renderer cleanup changes for UI copy, formatting, and serializer/helper cleanup.

- Record per-request outcomes in the engine and include them in simulation results.
- Add a live traffic monitor and post-run outcome log to the results tray.
- Visualize runtime node reliability and capacity separately.
- Add canvas legend support and move edge properties into the shared inspector.
- Improve edge mode semantics, tooltips, and streaming-edge overhead behavior.
- Clean up renderer copy, formatting, and serializer/helper leftovers.