### PR TITLE
Fix sample-scenario fidelity and make cache/routing metrics honest

### DIFF
--- a/src/engine/__samples__/circuit-breaker-fail-fast.json
+++ b/src/engine/__samples__/circuit-breaker-fail-fast.json
@@ -5,8 +5,8 @@
       "id": "client",
       "type": "serviceNode",
       "position": {
-        "x": 80,
-        "y": 260
+        "x": 1206.5045225315553,
+        "y": -435.0376884128205
       },
       "data": {
         "schemaVersion": 2,
@@ -15,34 +15,20 @@
         "structuralRole": "source",
         "profile": "source",
         "rendererType": "serviceNode",
-        "label": "Client App",
+        "label": "Client",
         "subLabel": "Browser / Mobile",
         "iconKey": "monitor",
         "source": {
           "requestDistribution": [
             {
-              "type": "GET",
+              "type": "charge",
               "weight": 1,
               "sizeBytes": 1024
             }
           ],
           "defaultWorkload": {
-            "pattern": "poisson",
-            "baseRps": 120,
-            "bursty": {
-              "burstRps": 500,
-              "burstDuration": 2000,
-              "normalDuration": 8000
-            },
-            "spike": {
-              "spikeTime": 30000,
-              "spikeRps": 900,
-              "spikeDuration": 5000
-            },
-            "sawtooth": {
-              "peakRps": 300,
-              "rampDuration": 10000
-            }
+            "pattern": "constant",
+            "baseRps": 20
           }
         }
       },
@@ -50,15 +36,70 @@
       "expandParent": false,
       "selected": false,
       "width": 256,
-      "height": 117,
+      "height": 118,
+      "positionAbsolute": {
+        "x": 1206.5045225315553,
+        "y": -435.0376884128205
+      },
+      "dragging": false,
       "nodes": []
     },
     {
-      "id": "api",
+      "id": "sidecar",
       "type": "computeNode",
       "position": {
-        "x": 680,
-        "y": 260
+        "x": 868.496180860711,
+        "y": -170.53477385782563
+      },
+      "data": {
+        "schemaVersion": 2,
+        "templateId": "sidecar-proxy",
+        "componentType": "sidecar",
+        "structuralRole": "processor",
+        "profile": "compute-service",
+        "rendererType": "computeNode",
+        "label": "Service Mesh Sidecar",
+        "subLabel": "Local Data Plane",
+        "iconKey": "SIDECAR",
+        "sim": {
+          "queue": {
+            "workers": 8,
+            "capacity": 32,
+            "discipline": "fifo"
+          },
+          "processing": {
+            "distribution": {
+              "type": "exponential",
+              "lambda": 1
+            },
+            "timeout": 500
+          },
+          "circuitBreaker": {
+            "failureThreshold": 0.5,
+            "failureCount": 4,
+            "recoveryTimeout": 2000,
+            "halfOpenRequests": 1
+          }
+        }
+      },
+      "zIndex": 0,
+      "expandParent": false,
+      "selected": false,
+      "width": 274,
+      "height": 115,
+      "positionAbsolute": {
+        "x": 868.496180860711,
+        "y": -170.53477385782563
+      },
+      "dragging": false,
+      "nodes": []
+    },
+    {
+      "id": "payment",
+      "type": "computeNode",
+      "position": {
+        "x": 526.6823115559862,
+        "y": 25.522211053552155
       },
       "data": {
         "schemaVersion": 2,
@@ -67,48 +108,68 @@
         "structuralRole": "processor",
         "profile": "compute-service",
         "rendererType": "computeNode",
-        "label": "API Server",
-        "subLabel": "Single Instance",
+        "label": "Failing Payment Service",
+        "subLabel": "Long-running Process",
         "iconKey": "SERVER",
         "sim": {
           "queue": {
             "workers": 4,
-            "capacity": 24,
+            "capacity": 16,
             "discipline": "fifo"
           },
           "processing": {
             "distribution": {
-              "type": "constant",
-              "value": 8
+              "type": "exponential",
+              "lambda": 0.125
             },
-            "timeout": 250
-          }
+            "timeout": 800
+          },
+          "nodeErrorRate": 1
         }
       },
       "zIndex": 0,
       "expandParent": false,
-      "selected": false,
-      "width": 190,
+      "selected": true,
+      "width": 274,
       "height": 115,
+      "positionAbsolute": {
+        "x": 526.6823115559862,
+        "y": 25.522211053552155
+      },
+      "dragging": false,
       "nodes": []
     }
   ],
   "edges": [
     {
-      "id": "client-to-api",
-      "type": "packet",
+      "id": "client-sidecar",
       "source": "client",
-      "target": "api",
-      "sourceHandle": "right-1-source",
-      "targetHandle": "left-1-target",
-      "animated": true,
+      "target": "sidecar",
       "data": {
         "protocol": "https",
         "mode": "synchronous",
-        "latencyMu": 2.1,
+        "latencyMu": 0,
         "latencySigma": 0.35,
+        "pathType": "same-dc",
+        "bandwidth": 100,
+        "maxConcurrentRequests": 100,
+        "packetLossRate": 0,
+        "errorRate": 0
+      },
+      "selected": false
+    },
+    {
+      "id": "sidecar-payment",
+      "source": "sidecar",
+      "target": "payment",
+      "data": {
+        "protocol": "grpc",
+        "mode": "synchronous",
+        "latencyMu": -0.3,
+        "latencySigma": 0.25,
+        "pathType": "same-rack",
         "bandwidth": 1000,
-        "maxConcurrentRequests": 200,
+        "maxConcurrentRequests": 50,
         "packetLossRate": 0,
         "errorRate": 0
       },
@@ -117,16 +178,13 @@
   ],
   "scenario": {
     "global": {
-      "simulationDuration": 60000,
-      "warmupDuration": 5000,
-      "seed": "sample-direct-client-server",
-      "defaultTimeout": 1000,
-      "traceSampleRate": 0.05
+      "simulationDuration": 15000,
+      "warmupDuration": 1000,
+      "seed": "breaker-seed",
+      "defaultTimeout": 5000,
+      "traceSampleRate": 0.01
     },
     "selectedSourceNodeId": "client",
-    "workloadOverride": {
-      "pattern": "poisson",
-      "baseRps": 120
-    }
+    "workloadOverride": {}
   }
 }

--- a/src/engine/__samples__/dns-weighted-routing.json
+++ b/src/engine/__samples__/dns-weighted-routing.json
@@ -5,8 +5,8 @@
       "id": "client",
       "type": "serviceNode",
       "position": {
-        "x": 1206.5045225315553,
-        "y": -435.0376884128205
+        "x": 774.4462362422744,
+        "y": -494.6972896812895
       },
       "data": {
         "schemaVersion": 2,
@@ -21,14 +21,18 @@
         "source": {
           "requestDistribution": [
             {
-              "type": "charge",
+              "type": "resolve",
               "weight": 1,
-              "sizeBytes": 1024
+              "sizeBytes": 256,
+              "metadata": {
+                "host": "catalog.internal",
+                "origin": "us"
+              }
             }
           ],
           "defaultWorkload": {
             "pattern": "constant",
-            "baseRps": 20
+            "baseRps": 40
           }
         }
       },
@@ -38,47 +42,87 @@
       "width": 256,
       "height": 118,
       "positionAbsolute": {
-        "x": 1206.5045225315553,
-        "y": -435.0376884128205
+        "x": 774.4462362422744,
+        "y": -494.6972896812895
       },
       "dragging": false,
       "nodes": []
     },
     {
-      "id": "sidecar",
-      "type": "computeNode",
+      "id": "dns",
+      "type": "serviceNode",
       "position": {
-        "x": 868.496180860711,
-        "y": -170.53477385782563
+        "x": 521.2437808730153,
+        "y": -295.55397179041904
       },
       "data": {
         "schemaVersion": 2,
-        "templateId": "sidecar-proxy",
-        "componentType": "sidecar",
-        "structuralRole": "processor",
-        "profile": "compute-service",
-        "rendererType": "computeNode",
-        "label": "Service Mesh Sidecar",
-        "subLabel": "Local Data Plane",
-        "iconKey": "SIDECAR",
+        "templateId": "dns-server",
+        "componentType": "internal-dns",
+        "structuralRole": "router",
+        "profile": "router",
+        "rendererType": "serviceNode",
+        "label": "Resolver",
+        "subLabel": "Internal DNS / Authoritative",
+        "iconKey": "server-cog",
         "sim": {
           "queue": {
             "workers": 8,
-            "capacity": 32,
+            "capacity": 16,
             "discipline": "fifo"
           },
           "processing": {
             "distribution": {
               "type": "exponential",
-              "lambda": 1
+              "lambda": 1.6666666666666667
             },
-            "timeout": 500
+            "timeout": 100
           },
-          "circuitBreaker": {
-            "failureThreshold": 0.5,
-            "failureCount": 4,
-            "recoveryTimeout": 2000,
-            "halfOpenRequests": 1
+          "dnsRoutingPolicy": "weighted",
+          "dnsCacheTtlSeconds": 30
+        }
+      },
+      "zIndex": 0,
+      "expandParent": false,
+      "selected": true,
+      "width": 256,
+      "height": 129,
+      "positionAbsolute": {
+        "x": 521.2437808730153,
+        "y": -295.55397179041904
+      },
+      "dragging": false,
+      "nodes": []
+    },
+    {
+      "id": "stable",
+      "type": "computeNode",
+      "position": {
+        "x": 185.47999793426015,
+        "y": 99.14331789087055
+      },
+      "data": {
+        "schemaVersion": 2,
+        "templateId": "backend-server",
+        "componentType": "microservice",
+        "structuralRole": "processor",
+        "profile": "compute-service",
+        "rendererType": "computeNode",
+        "label": "Stable API",
+        "subLabel": "Long-running Process",
+        "iconKey": "SERVER",
+        "sim": {
+          "queue": {
+            "workers": 8,
+            "capacity": 64,
+            "discipline": "fifo"
+          },
+          "processing": {
+            "distribution": {
+              "type": "exponential",
+              "lambda": 0.125
+            },
+            "timeout": 800
           }
         }
       },
@@ -88,18 +132,18 @@
       "width": 274,
       "height": 115,
       "positionAbsolute": {
-        "x": 868.496180860711,
-        "y": -170.53477385782563
+        "x": 185.47999793426015,
+        "y": 99.14331789087055
       },
       "dragging": false,
       "nodes": []
     },
     {
-      "id": "payment",
+      "id": "canary",
       "type": "computeNode",
       "position": {
-        "x": 526.6823115559862,
-        "y": 25.522211053552155
+        "x": 790.8124642215887,
+        "y": 36.77989908226331
       },
       "data": {
         "schemaVersion": 2,
@@ -108,13 +152,13 @@
         "structuralRole": "processor",
         "profile": "compute-service",
         "rendererType": "computeNode",
-        "label": "Failing Payment Service",
+        "label": "Canary API",
         "subLabel": "Long-running Process",
         "iconKey": "SERVER",
         "sim": {
           "queue": {
-            "workers": 4,
-            "capacity": 16,
+            "workers": 8,
+            "capacity": 64,
             "discipline": "fifo"
           },
           "processing": {
@@ -123,18 +167,17 @@
               "lambda": 0.125
             },
             "timeout": 800
-          },
-          "nodeErrorRate": 1
+          }
         }
       },
       "zIndex": 0,
       "expandParent": false,
-      "selected": true,
+      "selected": false,
       "width": 274,
       "height": 115,
       "positionAbsolute": {
-        "x": 526.6823115559862,
-        "y": 25.522211053552155
+        "x": 790.8124642215887,
+        "y": 36.77989908226331
       },
       "dragging": false,
       "nodes": []
@@ -142,14 +185,14 @@
   ],
   "edges": [
     {
-      "id": "client-sidecar",
+      "id": "client-dns",
       "source": "client",
-      "target": "sidecar",
+      "target": "dns",
       "data": {
-        "protocol": "https",
+        "protocol": "udp",
         "mode": "synchronous",
         "latencyMu": 0,
-        "latencySigma": 0.35,
+        "latencySigma": 0.3,
         "pathType": "same-dc",
         "bandwidth": 100,
         "maxConcurrentRequests": 100,
@@ -159,28 +202,47 @@
       "selected": false
     },
     {
-      "id": "sidecar-payment",
-      "source": "sidecar",
-      "target": "payment",
+      "id": "dns-stable",
+      "source": "dns",
+      "target": "stable",
       "data": {
-        "protocol": "grpc",
+        "protocol": "https",
         "mode": "synchronous",
-        "latencyMu": -0.3,
-        "latencySigma": 0.25,
-        "pathType": "same-rack",
-        "bandwidth": 1000,
-        "maxConcurrentRequests": 50,
+        "latencyMu": 0,
+        "latencySigma": 0.35,
+        "pathType": "same-dc",
+        "bandwidth": 100,
+        "maxConcurrentRequests": 100,
         "packetLossRate": 0,
-        "errorRate": 0
+        "errorRate": 0,
+        "weight": 80
+      },
+      "selected": false
+    },
+    {
+      "id": "dns-canary",
+      "source": "dns",
+      "target": "canary",
+      "data": {
+        "protocol": "https",
+        "mode": "synchronous",
+        "latencyMu": 0,
+        "latencySigma": 0.35,
+        "pathType": "same-dc",
+        "bandwidth": 100,
+        "maxConcurrentRequests": 100,
+        "packetLossRate": 0,
+        "errorRate": 0,
+        "weight": 20
       },
       "selected": false
     }
   ],
   "scenario": {
     "global": {
-      "simulationDuration": 15000,
-      "warmupDuration": 1000,
-      "seed": "breaker-seed",
+      "simulationDuration": 20000,
+      "warmupDuration": 2000,
+      "seed": "dns-weighted-seed",
       "defaultTimeout": 5000,
       "traceSampleRate": 0.01
     },

--- a/src/engine/__samples__/key-based-sharding.json
+++ b/src/engine/__samples__/key-based-sharding.json
@@ -2,11 +2,11 @@
   "version": "2.0.0",
   "nodes": [
     {
-      "id": "producer",
+      "id": "client",
       "type": "serviceNode",
       "position": {
-        "x": 410.47060205104196,
-        "y": -407.5069153936337
+        "x": 520,
+        "y": -420
       },
       "data": {
         "schemaVersion": 2,
@@ -15,64 +15,140 @@
         "structuralRole": "source",
         "profile": "source",
         "rendererType": "serviceNode",
-        "label": "Producer",
-        "subLabel": "Browser / Mobile",
+        "label": "Client",
+        "subLabel": "Keyed Requests",
         "iconKey": "monitor",
         "source": {
           "requestDistribution": [
             {
-              "type": "publish",
-              "weight": 1,
-              "sizeBytes": 2048
+              "type": "read",
+              "weight": 0.17,
+              "sizeBytes": 512,
+              "metadata": { "shardKey": "tenant-3" }
+            },
+            {
+              "type": "read",
+              "weight": 0.16,
+              "sizeBytes": 512,
+              "metadata": { "shardKey": "tenant-6" }
+            },
+            {
+              "type": "read",
+              "weight": 0.17,
+              "sizeBytes": 512,
+              "metadata": { "shardKey": "tenant-2" }
+            },
+            {
+              "type": "read",
+              "weight": 0.16,
+              "sizeBytes": 512,
+              "metadata": { "shardKey": "tenant-5" }
+            },
+            {
+              "type": "read",
+              "weight": 0.17,
+              "sizeBytes": 512,
+              "metadata": { "shardKey": "tenant-1" }
+            },
+            {
+              "type": "read",
+              "weight": 0.17,
+              "sizeBytes": 512,
+              "metadata": { "shardKey": "tenant-4" }
             }
           ],
           "defaultWorkload": {
             "pattern": "constant",
-            "baseRps": 100
+            "baseRps": 90
           }
+        }
+      },
+      "zIndex": 0,
+      "expandParent": false,
+      "selected": false,
+      "width": 256,
+      "height": 118,
+      "positionAbsolute": {
+        "x": 520,
+        "y": -420
+      },
+      "dragging": false,
+      "nodes": []
+    },
+    {
+      "id": "router",
+      "type": "serviceNode",
+      "position": {
+        "x": 520,
+        "y": -200
+      },
+      "data": {
+        "schemaVersion": 2,
+        "templateId": "sharding",
+        "componentType": "sharding",
+        "structuralRole": "router",
+        "profile": "router",
+        "rendererType": "serviceNode",
+        "label": "Shard Router",
+        "subLabel": "Hash-Routed by Key",
+        "iconKey": "sharding",
+        "sim": {
+          "queue": {
+            "workers": 8,
+            "capacity": 64,
+            "discipline": "fifo"
+          },
+          "processing": {
+            "distribution": {
+              "type": "exponential",
+              "lambda": 2
+            },
+            "timeout": 200
+          },
+          "routingKeyField": "shardKey"
         }
       },
       "zIndex": 0,
       "expandParent": false,
       "selected": true,
       "width": 256,
-      "height": 116,
+      "height": 129,
       "positionAbsolute": {
-        "x": 410.47060205104196,
-        "y": -407.5069153936337
+        "x": 520,
+        "y": -200
       },
       "dragging": false,
       "nodes": []
     },
     {
-      "id": "stream",
+      "id": "shard-a",
       "type": "serviceNode",
       "position": {
-        "x": 240.73603672684635,
-        "y": -14.818433287041216
+        "x": 180,
+        "y": 60
       },
       "data": {
         "schemaVersion": 2,
-        "templateId": "stream",
-        "componentType": "stream",
+        "templateId": "shard-node",
+        "componentType": "shard-node",
         "structuralRole": "storage",
-        "profile": "broker",
+        "profile": "datastore",
         "rendererType": "serviceNode",
-        "label": "Kafka Topic",
-        "subLabel": "Ordered Event Log",
-        "iconKey": "stream",
+        "label": "Shard A",
+        "subLabel": "Partition Replica",
+        "iconKey": "shard-node",
         "sim": {
           "queue": {
-            "workers": 1,
-            "capacity": 1000,
+            "workers": 4,
+            "capacity": 48,
             "discipline": "fifo"
           },
           "processing": {
             "distribution": {
               "type": "exponential",
-              "lambda": 0.05
+              "lambda": 0.2
             },
-            "timeout": 2000
+            "timeout": 800
           }
         }
       },
@@ -82,8 +158,96 @@
       "width": 256,
       "height": 129,
       "positionAbsolute": {
-        "x": 240.73603672684635,
-        "y": -14.818433287041216
+        "x": 180,
+        "y": 60
+      },
+      "dragging": false,
+      "nodes": []
+    },
+    {
+      "id": "shard-b",
+      "type": "serviceNode",
+      "position": {
+        "x": 520,
+        "y": 60
+      },
+      "data": {
+        "schemaVersion": 2,
+        "templateId": "shard-node",
+        "componentType": "shard-node",
+        "structuralRole": "storage",
+        "profile": "datastore",
+        "rendererType": "serviceNode",
+        "label": "Shard B",
+        "subLabel": "Partition Replica",
+        "iconKey": "shard-node",
+        "sim": {
+          "queue": {
+            "workers": 4,
+            "capacity": 48,
+            "discipline": "fifo"
+          },
+          "processing": {
+            "distribution": {
+              "type": "exponential",
+              "lambda": 0.2
+            },
+            "timeout": 800
+          }
+        }
+      },
+      "zIndex": 0,
+      "expandParent": false,
+      "selected": false,
+      "width": 256,
+      "height": 129,
+      "positionAbsolute": {
+        "x": 520,
+        "y": 60
+      },
+      "dragging": false,
+      "nodes": []
+    },
+    {
+      "id": "shard-c",
+      "type": "serviceNode",
+      "position": {
+        "x": 860,
+        "y": 60
+      },
+      "data": {
+        "schemaVersion": 2,
+        "templateId": "shard-node",
+        "componentType": "shard-node",
+        "structuralRole": "storage",
+        "profile": "datastore",
+        "rendererType": "serviceNode",
+        "label": "Shard C",
+        "subLabel": "Partition Replica",
+        "iconKey": "shard-node",
+        "sim": {
+          "queue": {
+            "workers": 4,
+            "capacity": 48,
+            "discipline": "fifo"
+          },
+          "processing": {
+            "distribution": {
+              "type": "exponential",
+              "lambda": 0.2
+            },
+            "timeout": 800
+          }
+        }
+      },
+      "zIndex": 0,
+      "expandParent": false,
+      "selected": false,
+      "width": 256,
+      "height": 129,
+      "positionAbsolute": {
+        "x": 860,
+        "y": 60
       },
       "dragging": false,
       "nodes": []
@@ -91,17 +255,68 @@
   ],
   "edges": [
     {
-      "id": "producer-stream",
-      "source": "producer",
-      "target": "stream",
+      "id": "client-router",
+      "source": "client",
+      "target": "router",
       "data": {
-        "protocol": "kafka",
-        "mode": "asynchronous",
+        "protocol": "https",
+        "mode": "synchronous",
         "latencyMu": 0,
-        "latencySigma": 0.35,
+        "latencySigma": 0.3,
         "pathType": "same-dc",
         "bandwidth": 1000,
-        "maxConcurrentRequests": 500,
+        "maxConcurrentRequests": 200,
+        "packetLossRate": 0,
+        "errorRate": 0
+      },
+      "selected": false
+    },
+    {
+      "id": "router-shard-a",
+      "source": "router",
+      "target": "shard-a",
+      "data": {
+        "protocol": "tcp",
+        "mode": "synchronous",
+        "latencyMu": 0,
+        "latencySigma": 0.25,
+        "pathType": "same-dc",
+        "bandwidth": 1000,
+        "maxConcurrentRequests": 100,
+        "packetLossRate": 0,
+        "errorRate": 0
+      },
+      "selected": false
+    },
+    {
+      "id": "router-shard-b",
+      "source": "router",
+      "target": "shard-b",
+      "data": {
+        "protocol": "tcp",
+        "mode": "synchronous",
+        "latencyMu": 0,
+        "latencySigma": 0.25,
+        "pathType": "same-dc",
+        "bandwidth": 1000,
+        "maxConcurrentRequests": 100,
+        "packetLossRate": 0,
+        "errorRate": 0
+      },
+      "selected": false
+    },
+    {
+      "id": "router-shard-c",
+      "source": "router",
+      "target": "shard-c",
+      "data": {
+        "protocol": "tcp",
+        "mode": "synchronous",
+        "latencyMu": 0,
+        "latencySigma": 0.25,
+        "pathType": "same-dc",
+        "bandwidth": 1000,
+        "maxConcurrentRequests": 100,
         "packetLossRate": 0,
         "errorRate": 0
       },
@@ -112,11 +327,11 @@
     "global": {
       "simulationDuration": 20000,
       "warmupDuration": 2000,
-      "seed": "consumer-lag-seed",
+      "seed": "key-based-sharding-seed",
       "defaultTimeout": 5000,
       "traceSampleRate": 0.01
     },
-    "selectedSourceNodeId": "producer",
+    "selectedSourceNodeId": "client",
     "workloadOverride": {}
   }
 }

--- a/src/engine/__samples__/stream-consumer-lag.json
+++ b/src/engine/__samples__/stream-consumer-lag.json
@@ -2,11 +2,11 @@
   "version": "2.0.0",
   "nodes": [
     {
-      "id": "client",
+      "id": "producer",
       "type": "serviceNode",
       "position": {
-        "x": 774.4462362422744,
-        "y": -494.6972896812895
+        "x": 410.47060205104196,
+        "y": -407.5069153936337
       },
       "data": {
         "schemaVersion": 2,
@@ -15,169 +15,75 @@
         "structuralRole": "source",
         "profile": "source",
         "rendererType": "serviceNode",
-        "label": "Client",
+        "label": "Producer",
         "subLabel": "Browser / Mobile",
         "iconKey": "monitor",
         "source": {
           "requestDistribution": [
             {
-              "type": "resolve",
+              "type": "publish",
               "weight": 1,
-              "sizeBytes": 256,
-              "metadata": {
-                "host": "catalog.internal",
-                "origin": "us"
-              }
+              "sizeBytes": 2048
             }
           ],
           "defaultWorkload": {
             "pattern": "constant",
-            "baseRps": 40
+            "baseRps": 100
           }
-        }
-      },
-      "zIndex": 0,
-      "expandParent": false,
-      "selected": false,
-      "width": 256,
-      "height": 118,
-      "positionAbsolute": {
-        "x": 774.4462362422744,
-        "y": -494.6972896812895
-      },
-      "dragging": false,
-      "nodes": []
-    },
-    {
-      "id": "dns",
-      "type": "serviceNode",
-      "position": {
-        "x": 521.2437808730153,
-        "y": -295.55397179041904
-      },
-      "data": {
-        "schemaVersion": 2,
-        "templateId": "dns-server",
-        "componentType": "internal-dns",
-        "structuralRole": "router",
-        "profile": "router",
-        "rendererType": "serviceNode",
-        "label": "Resolver",
-        "subLabel": "Internal DNS / Authoritative",
-        "iconKey": "server-cog",
-        "sim": {
-          "queue": {
-            "workers": 8,
-            "capacity": 16,
-            "discipline": "fifo"
-          },
-          "processing": {
-            "distribution": {
-              "type": "exponential",
-              "lambda": 1.6666666666666667
-            },
-            "timeout": 100
-          },
-          "dnsRoutingPolicy": "weighted",
-          "dnsCacheTtlSeconds": 30
         }
       },
       "zIndex": 0,
       "expandParent": false,
       "selected": true,
       "width": 256,
+      "height": 116,
+      "positionAbsolute": {
+        "x": 410.47060205104196,
+        "y": -407.5069153936337
+      },
+      "dragging": false,
+      "nodes": []
+    },
+    {
+      "id": "stream",
+      "type": "serviceNode",
+      "position": {
+        "x": 240.73603672684635,
+        "y": -14.818433287041216
+      },
+      "data": {
+        "schemaVersion": 2,
+        "templateId": "stream",
+        "componentType": "stream",
+        "structuralRole": "storage",
+        "profile": "broker",
+        "rendererType": "serviceNode",
+        "label": "Kafka Topic",
+        "subLabel": "Ordered Event Log",
+        "iconKey": "stream",
+        "sim": {
+          "queue": {
+            "workers": 1,
+            "capacity": 1000,
+            "discipline": "fifo"
+          },
+          "processing": {
+            "distribution": {
+              "type": "exponential",
+              "lambda": 0.05
+            },
+            "timeout": 2000
+          }
+        }
+      },
+      "zIndex": 0,
+      "expandParent": false,
+      "selected": false,
+      "width": 256,
       "height": 129,
       "positionAbsolute": {
-        "x": 521.2437808730153,
-        "y": -295.55397179041904
-      },
-      "dragging": false,
-      "nodes": []
-    },
-    {
-      "id": "stable",
-      "type": "computeNode",
-      "position": {
-        "x": 185.47999793426015,
-        "y": 99.14331789087055
-      },
-      "data": {
-        "schemaVersion": 2,
-        "templateId": "backend-server",
-        "componentType": "microservice",
-        "structuralRole": "processor",
-        "profile": "compute-service",
-        "rendererType": "computeNode",
-        "label": "Stable API",
-        "subLabel": "Long-running Process",
-        "iconKey": "SERVER",
-        "sim": {
-          "queue": {
-            "workers": 8,
-            "capacity": 64,
-            "discipline": "fifo"
-          },
-          "processing": {
-            "distribution": {
-              "type": "exponential",
-              "lambda": 0.125
-            },
-            "timeout": 800
-          }
-        }
-      },
-      "zIndex": 0,
-      "expandParent": false,
-      "selected": false,
-      "width": 274,
-      "height": 115,
-      "positionAbsolute": {
-        "x": 185.47999793426015,
-        "y": 99.14331789087055
-      },
-      "dragging": false,
-      "nodes": []
-    },
-    {
-      "id": "canary",
-      "type": "computeNode",
-      "position": {
-        "x": 790.8124642215887,
-        "y": 36.77989908226331
-      },
-      "data": {
-        "schemaVersion": 2,
-        "templateId": "backend-server",
-        "componentType": "microservice",
-        "structuralRole": "processor",
-        "profile": "compute-service",
-        "rendererType": "computeNode",
-        "label": "Canary API",
-        "subLabel": "Long-running Process",
-        "iconKey": "SERVER",
-        "sim": {
-          "queue": {
-            "workers": 8,
-            "capacity": 64,
-            "discipline": "fifo"
-          },
-          "processing": {
-            "distribution": {
-              "type": "exponential",
-              "lambda": 0.125
-            },
-            "timeout": 800
-          }
-        }
-      },
-      "zIndex": 0,
-      "expandParent": false,
-      "selected": false,
-      "width": 274,
-      "height": 115,
-      "positionAbsolute": {
-        "x": 790.8124642215887,
-        "y": 36.77989908226331
+        "x": 240.73603672684635,
+        "y": -14.818433287041216
       },
       "dragging": false,
       "nodes": []
@@ -185,51 +91,17 @@
   ],
   "edges": [
     {
-      "id": "client-dns",
-      "source": "client",
-      "target": "dns",
+      "id": "producer-stream",
+      "source": "producer",
+      "target": "stream",
       "data": {
-        "protocol": "udp",
-        "mode": "synchronous",
-        "latencyMu": 0,
-        "latencySigma": 0.3,
-        "pathType": "same-dc",
-        "bandwidth": 100,
-        "maxConcurrentRequests": 100,
-        "packetLossRate": 0,
-        "errorRate": 0
-      },
-      "selected": false
-    },
-    {
-      "id": "dns-stable",
-      "source": "dns",
-      "target": "stable",
-      "data": {
-        "protocol": "https",
-        "mode": "synchronous",
+        "protocol": "kafka",
+        "mode": "asynchronous",
         "latencyMu": 0,
         "latencySigma": 0.35,
         "pathType": "same-dc",
-        "bandwidth": 100,
-        "maxConcurrentRequests": 100,
-        "packetLossRate": 0,
-        "errorRate": 0
-      },
-      "selected": false
-    },
-    {
-      "id": "dns-canary",
-      "source": "dns",
-      "target": "canary",
-      "data": {
-        "protocol": "https",
-        "mode": "synchronous",
-        "latencyMu": 0,
-        "latencySigma": 0.35,
-        "pathType": "same-dc",
-        "bandwidth": 100,
-        "maxConcurrentRequests": 100,
+        "bandwidth": 1000,
+        "maxConcurrentRequests": 500,
         "packetLossRate": 0,
         "errorRate": 0
       },
@@ -240,11 +112,11 @@
     "global": {
       "simulationDuration": 20000,
       "warmupDuration": 2000,
-      "seed": "dns-weighted-seed",
+      "seed": "consumer-lag-seed",
       "defaultTimeout": 5000,
       "traceSampleRate": 0.01
     },
-    "selectedSourceNodeId": "client",
+    "selectedSourceNodeId": "producer",
     "workloadOverride": {}
   }
 }

--- a/src/engine/traits/cache.ts
+++ b/src/engine/traits/cache.ts
@@ -99,7 +99,7 @@ export const cacheCapabilityModule: NodeCapabilityModule = {
       {
         id: 'caching',
         title: 'Caching',
-        note: 'Empty cache hit rate means this node behaves as a pass-through cache. Cache hit latency only applies to hits. TTL is shown for topology intent, but the current simulator does not model expiry over time.',
+        note: 'Empty cache hit rate means this node behaves as a pass-through cache and the results-view cache panel stays hidden. Try it: 0.9 = warm cache (~90% hits), 0.5 = half served locally, 1.0 = every request a hit; leave empty to disable. After a run, select this node to see the resulting hit/miss split. Cache hit latency only applies to hits. TTL is shown for topology intent, but the current simulator does not model expiry over time.',
         fields: [
           {
             path: 'sim.cacheHitRate',
@@ -108,7 +108,7 @@ export const cacheCapabilityModule: NodeCapabilityModule = {
             step: 0.01,
             unit: 'ratio',
             placeholder: defaultCacheHitRatePlaceholder,
-            why: 'Controls how much traffic this node serves locally instead of forwarding. Leave empty to disable cache hits.'
+            why: 'Controls how much traffic this node serves locally instead of forwarding — e.g. 0.9 serves 90% from cache. Leave empty to disable cache hits.'
           },
           {
             path: 'sim.cacheHitLatencyMs',

--- a/src/engine/traits/coldStart.ts
+++ b/src/engine/traits/coldStart.ts
@@ -1,4 +1,5 @@
 import { msToMicro } from '../core/time'
+import type { CanvasNodeDataV2 } from '../catalog/nodeSpecTypes'
 import type {
   ComponentNode,
   ComponentType,
@@ -30,6 +31,17 @@ function asPositiveNumber(value: unknown): number | null {
 function asPositiveInt(value: unknown): number | null {
   const num = asPositiveNumber(value)
   return num !== null ? Math.round(num) : null
+}
+
+function coldStartLatencyPlaceholder(data: CanvasNodeDataV2): string {
+  // The engine also accepts a full distribution via `sim.coldStartLatency`; when that
+  // is set (as some sample scenarios do) this scalar field is intentionally left empty,
+  // so surface the effective value instead of showing a blank, broken-looking input.
+  const distribution = data.sim?.coldStartLatency
+  if (distribution && distribution.type === 'exponential' && distribution.lambda > 0) {
+    return `Using distribution ≈ ${Math.round(1 / distribution.lambda)}ms mean`
+  }
+  return `Default: ${DEFAULT_COLD_START_LATENCY_MS}ms after idle`
 }
 
 function createTraitRng(random?: () => number): RandomGenerator {
@@ -127,6 +139,7 @@ export const coldStartCapabilityModule: NodeCapabilityModule = {
             label: 'Cold start latency',
             unit: 'ms',
             step: 1,
+            placeholder: coldStartLatencyPlaceholder,
             why: 'Adds one-off startup latency after the function has been idle.'
           },
           {

--- a/src/renderer/src/components/canvas/PacketEdge.tsx
+++ b/src/renderer/src/components/canvas/PacketEdge.tsx
@@ -4,9 +4,9 @@ import type { AnyNodeData, EdgeSimulationData } from '@renderer/types/ui'
 import { getEdgeModePresentation, inferCanvasEdgeMode } from '@renderer/config/edgeSemantics'
 import useStore, { type EdgeFlowRunConfig, type EdgeFlowState } from '@renderer/store/useStore'
 import { getRoutingPreviewSnapshot } from '@renderer/utils/routingStrategyPreview'
-import { failureRateLevelFromRatio } from '@renderer/utils/failureRatePresentation'
+import { inferEdgeDefaults } from '../../../../engine/defaults/edgeDefaults'
 import { patternMultiplier } from './edgeFlowPatterns'
-import type { EdgeFailureCause } from '../../../../engine/core/events'
+import { resolveEdgeLensProjection } from './edgeLensPresentation'
 
 const EDGE_VISUAL_WINDOW_MS = 3_000
 const FAILED_PULSE_MS = 650
@@ -21,34 +21,6 @@ const EMPTY_EDGE_FLOW_BY_ID: Record<string, EdgeFlowState> = {}
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value))
-}
-
-function fmtFailureRate(ratio: number): string {
-  const percent = clamp(ratio, 0, 1) * 100
-  if (percent > 0 && percent < 0.1) {
-    return '<0.1% fail'
-  }
-  return `${percent.toFixed(1)}% fail`
-}
-
-function fmtPercent(percent: number): string {
-  if (percent > 0 && percent < 0.1) {
-    return '<0.1%'
-  }
-  return `${percent.toFixed(1)}%`
-}
-
-function labelForFailureCause(cause: EdgeFailureCause): string {
-  switch (cause) {
-    case 'connection_refused':
-      return 'saturation'
-    case 'deadline_exceeded':
-      return 'deadline'
-    case 'edge_error_rate':
-      return 'edge error'
-    case 'packet_loss':
-      return 'packet loss'
-  }
 }
 
 function compressedPacketCount(arrivalRate: number): number {
@@ -130,6 +102,7 @@ export const PacketEdge = ({
   const hasLabel = typeof label === 'string' && label.trim().length > 0
   const flow = useStore((state) => state.edgeFlowById[id])
   const flowStatus = useStore((state) => state.edgeFlowStatus)
+  const metricLens = useStore((state) => state.metricLens)
   const runConfig = useStore((state) => state.edgeFlowRunConfig)
   const playback = useStore((state) => state.edgeFlowPlayback)
   const routingVisualization = useStore((state) => state.routingStrategyVisualization)
@@ -141,6 +114,7 @@ export const PacketEdge = ({
   const nodes = useStore((state) => state.nodes)
   const edges = useStore((state) => state.edges)
   const metricsByNode = useStore((state) => state.simulationMetricsByNode)
+  const sourceNodeData = nodes.find((node) => node.id === source)?.data as AnyNodeData | undefined
   const targetNodeData = nodes.find((node) => node.id === target)?.data as AnyNodeData | undefined
   const edgeData = (data ?? {}) as EdgeSimulationData
   const edgeMode = inferCanvasEdgeMode(edgeData, targetNodeData)
@@ -197,40 +171,20 @@ export const PacketEdge = ({
   const liveSuccessRate = Math.max(flow?.successPerSecond ?? 0, flow?.avgSuccessPerSecond ?? 0)
   const postRunPacketRate = flow?.avgPostWarmupSuccessPerSecond ?? 0
   const arrivedRequestCount = flow?.totalPostWarmupSuccess ?? 0
-  const liveFailedRate = Math.max(flow?.failedPerSecond ?? 0, flow?.avgFailedPerSecond ?? 0)
-  const liveFailureRatio = liveIncomingRate > 0 ? liveFailedRate / liveIncomingRate : 0
-  const postWarmupAttemptedCount = flow?.totalPostWarmupAttempted ?? 0
-  const postRunFailureRatio =
-    postWarmupAttemptedCount > 0 ? (flow?.totalPostWarmupFailed ?? 0) / postWarmupAttemptedCount : 0
-  const failureRatio = isComplete ? postRunFailureRatio : liveFailureRatio
-  const failureBreakdown = useMemo(() => {
-    const attempted = isComplete ? postWarmupAttemptedCount : (flow?.totalAttempted ?? 0)
-    const counts = isComplete
-      ? (flow?.totalPostWarmupFailedByCause ?? {})
-      : (flow?.totalFailedByCause ?? {})
-
-    if (attempted <= 0) {
-      return []
-    }
-
-    return Object.entries(counts)
-      .filter((entry): entry is [EdgeFailureCause, number] => entry[1] > 0)
-      .sort((a, b) => b[1] - a[1])
-      .map(([cause, count]) => ({
-        cause,
-        label: labelForFailureCause(cause),
-        percent: (count / attempted) * 100
-      }))
-  }, [
-    flow?.totalAttempted,
-    flow?.totalFailedByCause,
-    flow?.totalPostWarmupFailedByCause,
-    isComplete,
-    postWarmupAttemptedCount
-  ])
-  const failureBreakdownText = failureBreakdown
-    .map((entry) => `${entry.label} ${fmtPercent(entry.percent)}`)
-    .join(' • ')
+  const edgeDefaults = useMemo(
+    () => inferEdgeDefaults(sourceNodeData, targetNodeData),
+    [sourceNodeData, targetNodeData]
+  )
+  const lensProjection = useMemo(
+    () =>
+      resolveEdgeLensProjection({
+        lens: metricLens,
+        flow,
+        config: (data ?? {}) as EdgeSimulationData,
+        defaults: edgeDefaults
+      }),
+    [metricLens, flow, data, edgeDefaults]
+  )
   const visualMultiplier = patternMultiplier(runConfig, playback, now, id, hash01)
   const steadyRequestRate = isComplete ? postRunPacketRate : liveSuccessRate
   const previewShare =
@@ -263,24 +217,27 @@ export const PacketEdge = ({
       : selected
         ? 3
         : 2
-  const failureLevel = failureRateLevelFromRatio(failureRatio)
+  // Health severity drives the stroke colour and is computed independently of
+  // the active lens, so a failing link stays red even under a non-error lens.
   const failureStroke =
-    failureLevel === 'crit'
+    lensProjection.severity === 'crit'
       ? FLOW_DANGER_COLOR
-      : failureLevel === 'warn'
+      : lensProjection.severity === 'warn'
         ? FLOW_WARNING_COLOR
         : undefined
+  // Node-first lenses (timeout, queue capacity) recede: the edge dims to its
+  // identity and lets the nodes carry the lens.
+  const lensRecedes = !isRoutingPreviewEdge && lensProjection.recedes
   const flowLabelText = isRoutingPreviewEdge
     ? routingPreview?.isSelected
       ? `${routingPreview.selectedCount}/${routingPreview.totalCount} preview`
       : 'not selected'
     : isInactiveAfterRun
       ? 'inactive'
-      : fmtFailureRate(failureRatio)
-  const flowLabelTitle =
-    failureBreakdownText.length > 0 && !isRoutingPreviewEdge
-      ? `${flowLabelText} (${failureBreakdownText})`
-      : flowLabelText
+      : lensProjection.headline
+  const flowLabelSub = isRoutingPreviewEdge ? undefined : lensProjection.sub
+  const flowLabelTitle = isRoutingPreviewEdge ? flowLabelText : lensProjection.why
+  const showFlowLabel = isRoutingPreviewEdge || flowLabelText.length > 0
   const flowLabelClassName = [
     'rounded-full border px-2 py-0.5 text-[12px] font-semibold leading-none tracking-wide shadow-md',
     isRoutingPreviewEdge
@@ -289,9 +246,9 @@ export const PacketEdge = ({
         : 'border-nss-border bg-nss-panel text-nss-muted'
       : isInactiveAfterRun
         ? 'border-nss-border bg-nss-panel text-nss-muted'
-        : failureLevel === 'crit'
+        : lensProjection.severity === 'crit'
           ? 'border-nss-danger/50 bg-nss-panel text-nss-danger'
-          : failureLevel === 'warn'
+          : lensProjection.severity === 'warn'
             ? 'border-nss-warning/50 bg-nss-panel text-nss-warning'
             : 'border-nss-primary/40 bg-nss-panel text-nss-primary'
   ].join(' ')
@@ -336,7 +293,7 @@ export const PacketEdge = ({
             ? routingPreview?.isSelected
               ? 1
               : 0.28
-            : isInactiveAfterRun
+            : isInactiveAfterRun || lensRecedes
               ? 0.28
               : 1
         }}
@@ -416,7 +373,7 @@ export const PacketEdge = ({
         style={{ pointerEvents: 'all', ...(selected ? { opacity: 1 } : {}) }}
       />
 
-      {(hasLabel || isRoutingPreviewEdge || flowStatus === 'complete' || flow) && (
+      {(hasLabel || showFlowLabel) && (
         <EdgeLabelRenderer>
           <div
             style={{
@@ -432,14 +389,14 @@ export const PacketEdge = ({
                   {label.toString()}
                 </span>
               )}
-              {(isRoutingPreviewEdge || flowStatus === 'complete' || flow) && (
+              {showFlowLabel && (
                 <span className={flowLabelClassName} title={flowLabelTitle}>
                   {flowLabelText}
                 </span>
               )}
-              {!isRoutingPreviewEdge && selected && failureBreakdownText.length > 0 && (
+              {!isRoutingPreviewEdge && selected && flowLabelSub && (
                 <span className="bg-nss-bg px-2 py-0.5 text-[11px] font-semibold leading-none tracking-wide text-nss-muted">
-                  {failureBreakdownText}
+                  {flowLabelSub}
                 </span>
               )}
             </div>

--- a/src/renderer/src/components/canvas/edgeLensPresentation.ts
+++ b/src/renderer/src/components/canvas/edgeLensPresentation.ts
@@ -1,0 +1,258 @@
+import type { MetricLens, EdgeSimulationData } from '@renderer/types/ui'
+import type { EdgeFlowState } from '@renderer/store/useStore'
+import { EDGE_PATH_TYPE_HELP } from '@renderer/config/edgeSemantics'
+import { failureRateLevelFromRatio } from '@renderer/utils/failureRatePresentation'
+import type { EdgeDefaults } from '../../../../engine/defaults/edgeDefaults'
+import type { EdgeFailureCause } from '../../../../engine/core/events'
+
+/**
+ * Projects the active metric lens onto a single edge. The edge does not decide
+ * what to display — it renders the edge-side view of whatever lens is active,
+ * mirroring the node-side `getLensCard` / `getPreRunMetric` split in
+ * `nodePresentation.ts`. Pre-run lenses read declared capacity from config;
+ * runtime lenses read measured behaviour from the post-warmup flow.
+ */
+export type EdgeSeverity = 'ok' | 'warn' | 'crit'
+
+export interface EdgeLensProjection {
+  /** Always-shown label text, e.g. "145 rps". Empty when the edge recedes. */
+  headline: string
+  /** On-select / hover detail, e.g. "offered 160" or "packet loss 3%". */
+  sub?: string
+  /** Drives STROKE COLOR — computed independently of the lens so a failing
+   *  link stays red even under a non-error lens. */
+  severity: EdgeSeverity
+  /** True for node-first lenses: the edge dims to its identity and lets the
+   *  nodes carry the lens. */
+  recedes: boolean
+  /** Tooltip explaining what the headline means. */
+  why: string
+}
+
+export interface EdgeLensInput {
+  lens: MetricLens
+  /** Undefined before a run, or on edges that carried no traffic. */
+  flow: EdgeFlowState | undefined
+  /** The edge's explicit config (values the user set). */
+  config: EdgeSimulationData
+  /** Inferred defaults for any field the config leaves unset — resolved the
+   *  same way the edge properties panel resolves them, so a default-only edge
+   *  still shows a real number instead of receding. */
+  defaults: EdgeDefaults
+}
+
+const FAILURE_CAUSE_LABELS: Record<EdgeFailureCause, string> = {
+  connection_refused: 'saturation',
+  deadline_exceeded: 'deadline',
+  edge_error_rate: 'edge error',
+  packet_loss: 'packet loss'
+}
+
+function fmtRps(rps: number): string {
+  if (rps <= 0) return '0 rps'
+  if (rps < 10) return `${rps.toFixed(1)} rps`
+  return `${Math.round(rps)} rps`
+}
+
+function fmtPercent(ratio: number): string {
+  const pct = Math.min(1, Math.max(0, ratio)) * 100
+  if (pct > 0 && pct < 0.1) return '<0.1%'
+  return `${pct.toFixed(1)}%`
+}
+
+function fmtMs(ms: number): string {
+  return ms < 10 ? `${ms.toFixed(1)}ms` : `${Math.round(ms)}ms`
+}
+
+/**
+ * Modeled typical transit for this hop, derived from the edge's latency config
+ * (not measured). Median of the constant/log-normal distribution — the same
+ * "median hop" the edge properties panel reports. Falls back to the inferred
+ * default profile when the edge sets no explicit latency, so a default-only
+ * edge still shows a real number.
+ */
+function modeledHopLatencyMs(config: EdgeSimulationData, defaults: EdgeDefaults): number {
+  const type =
+    config.latencyDistributionType ?? (config.latencyValue !== undefined ? 'constant' : undefined)
+  if (type === 'constant' && config.latencyValue != null) {
+    return config.latencyValue
+  }
+  // Median of a log-normal is e^mu (ms); mu comes from the edge or the default
+  // path-type profile.
+  const mu = config.latencyMu ?? defaults.latencyDistribution.mu
+  return Math.exp(mu)
+}
+
+/** p50 over the retained sampled packet stream — same calc the Edge Results
+ *  panel uses, so the label and the panel can never disagree. */
+function edgeLatencyP50(flow: EdgeFlowState | undefined): number | null {
+  if (!flow || flow.recent.length === 0) return null
+  const latencies = flow.recent
+    .filter((event) => event.status === 'success')
+    .map((event) => event.latencyMs)
+  if (latencies.length === 0) return null
+  const sorted = [...latencies].sort((a, b) => a - b)
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * 0.5) - 1))
+  return sorted[index] ?? null
+}
+
+/** Post-warmup failure ratio, falling back to the live windowed ratio. */
+function postWarmupFailureRatio(flow: EdgeFlowState | undefined): number {
+  if (!flow) return 0
+  if (flow.totalPostWarmupAttempted > 0) {
+    return flow.totalPostWarmupFailed / flow.totalPostWarmupAttempted
+  }
+  return flow.failureRatio
+}
+
+function edgeSeverity(flow: EdgeFlowState | undefined): EdgeSeverity {
+  const level = failureRateLevelFromRatio(postWarmupFailureRatio(flow))
+  return level === 'crit' ? 'crit' : level === 'warn' ? 'warn' : 'ok'
+}
+
+/**
+ * In-flight ÷ max-concurrent via Little's Law (L = λ × W). Uses post-warmup
+ * averages, so it is time-weighted rather than a point sample. Null when the
+ * edge declares no concurrency cap or has no latency samples yet.
+ */
+function edgeUtilization(
+  flow: EdgeFlowState | undefined,
+  config: EdgeSimulationData,
+  defaults: EdgeDefaults
+): number | null {
+  const cap = config.maxConcurrentRequests ?? defaults.maxConcurrentRequests
+  if (!cap || cap <= 0 || !flow) return null
+  const lambda = flow.avgPostWarmupSuccessPerSecond
+  const w = edgeLatencyP50(flow)
+  if (w == null) return null
+  const inFlight = lambda * (w / 1000)
+  return Math.min(inFlight / cap, 1)
+}
+
+/** The dominant failure cause as a labelled percentage, e.g. "packet loss 3%". */
+function topFailureCause(flow: EdgeFlowState | undefined): string | undefined {
+  if (!flow) return undefined
+  const attempted =
+    flow.totalPostWarmupAttempted > 0 ? flow.totalPostWarmupAttempted : flow.totalAttempted
+  const counts =
+    flow.totalPostWarmupAttempted > 0 ? flow.totalPostWarmupFailedByCause : flow.totalFailedByCause
+  if (attempted <= 0) return undefined
+
+  const top = Object.entries(counts)
+    .filter((entry): entry is [EdgeFailureCause, number] => entry[1] > 0)
+    .sort((a, b) => b[1] - a[1])[0]
+  if (!top) return undefined
+
+  const [cause, count] = top
+  return `${FAILURE_CAUSE_LABELS[cause]} ${fmtPercent(count / attempted)}`
+}
+
+export function resolveEdgeLensProjection({
+  lens,
+  flow,
+  config,
+  defaults
+}: EdgeLensInput): EdgeLensProjection {
+  const severity = edgeSeverity(flow)
+  const recede = (why: string): EdgeLensProjection => ({
+    headline: '',
+    severity,
+    recedes: true,
+    why
+  })
+
+  switch (lens) {
+    // ── PRE-RUN: declared capacity, config value or its inferred default ──
+    case 'concurrency': {
+      const cap = config.maxConcurrentRequests ?? defaults.maxConcurrentRequests
+      return {
+        headline: `${cap} max`,
+        severity,
+        recedes: false,
+        why: 'Link concurrency cap (max concurrent requests in transit)'
+      }
+    }
+
+    case 'queueCapacity': {
+      // Edges have no queue → node-first; surface pipe size as a quiet proxy.
+      const bandwidth = config.bandwidth ?? defaults.bandwidth
+      return {
+        headline: `${bandwidth} Mbps`,
+        severity,
+        recedes: true,
+        why: 'Edges have no queue; bandwidth shown as pipe capacity'
+      }
+    }
+
+    case 'timeout': {
+      // The edge cannot time out on its own — the deadline is enforced at the
+      // node. Its honest contribution is the transit budget this hop consumes.
+      const hopMs = modeledHopLatencyMs(config, defaults)
+      const pathType = config.pathType ?? defaults.pathType
+      return {
+        headline: `~${fmtMs(hopMs)} hop`,
+        sub: pathType ? EDGE_PATH_TYPE_HELP[pathType].title : undefined,
+        severity,
+        recedes: false,
+        why: 'Modeled transit this hop adds to the deadline budget (enforced at the node)'
+      }
+    }
+
+    // ── RUNTIME: measured behaviour, read from the post-warmup flow ────
+    case 'traffic': {
+      const rps = flow?.avgAttemptedPerSecond ?? 0
+      return {
+        headline: `${fmtRps(rps)} in`,
+        severity,
+        recedes: false,
+        why: 'Offered request rate crossing this edge'
+      }
+    }
+
+    case 'throughput': {
+      const rps = flow?.avgPostWarmupSuccessPerSecond ?? 0
+      const offered = flow?.avgAttemptedPerSecond ?? 0
+      return {
+        headline: fmtRps(rps),
+        sub: offered > rps * 1.02 ? `offered ${fmtRps(offered)}` : undefined,
+        severity,
+        recedes: false,
+        why: 'Successful requests delivered across this edge per second'
+      }
+    }
+
+    case 'latency': {
+      const p50 = edgeLatencyP50(flow)
+      return {
+        headline: p50 != null ? `${p50.toFixed(1)}ms` : '—',
+        sub: p50 != null ? 'this hop only' : undefined,
+        severity,
+        recedes: false,
+        why: 'Transit latency across this link (this hop only, not cumulative)'
+      }
+    }
+
+    case 'saturation': {
+      const util = edgeUtilization(flow, config, defaults)
+      return util != null
+        ? {
+            headline: `${(util * 100).toFixed(0)}%`,
+            severity,
+            recedes: false,
+            why: 'In-flight ÷ max concurrent (Little’s Law: λ × latency)'
+          }
+        : recede('No concurrency cap set on this edge')
+    }
+
+    case 'errors': {
+      const ratio = postWarmupFailureRatio(flow)
+      return {
+        headline: `${fmtPercent(ratio)} fail`,
+        sub: topFailureCause(flow),
+        severity,
+        recedes: false,
+        why: 'Failures attributable to this hop'
+      }
+    }
+  }
+}

--- a/src/renderer/src/components/layout/Header.tsx
+++ b/src/renderer/src/components/layout/Header.tsx
@@ -25,6 +25,8 @@ interface HeaderProps {
 
   // Simulation
   onRun: () => void
+  onReset: () => void
+  isPostRun: boolean
   onPause: () => void
   onResume: () => void
   onStop: () => void
@@ -48,6 +50,8 @@ export const Header = memo(
     fileName,
     isUnsaved,
     onRun,
+    onReset,
+    isPostRun,
     onPause,
     onResume,
     onStop,
@@ -86,6 +90,8 @@ export const Header = memo(
 
           <SimulationControls
             onRun={onRun}
+            onReset={onReset}
+            isPostRun={isPostRun}
             onPause={onPause}
             onResume={onResume}
             onStop={onStop}

--- a/src/renderer/src/components/layout/WorkspaceLayout.tsx
+++ b/src/renderer/src/components/layout/WorkspaceLayout.tsx
@@ -543,6 +543,19 @@ export const WorkspaceLayout = () => {
     startSimulation()
   }
 
+  // Leave the post-run state and return to pre-run setup: discard the run's
+  // results (node metrics, edge flow) and reset the lens back to the pre-run
+  // family. The topology itself is untouched. sim.reset() clears the edge flow
+  // and flips status to idle, which cascades into clearSimulationMetrics.
+  const handleResetRun = useCallback(() => {
+    sim.reset()
+    clearSimulationMetrics()
+    setShowResults(false)
+    setLastRunContext(null)
+    setRunIssues({ messages: [], tone: 'warning' })
+    setRunInspectorPinned(false)
+  }, [clearSimulationMetrics, setRunInspectorPinned, sim])
+
   const handleSampleLoad = useCallback(
     async (sample: SampleScenario) => {
       const loaded = await loadFromData(sample.raw, `${sample.id}.json`)
@@ -560,6 +573,7 @@ export const WorkspaceLayout = () => {
 
   const isRunning = sim.status === 'running'
   const isPaused = sim.status === 'paused' && !sim.stopped
+  const isPostRun = sim.status === 'complete'
   const sourceNodes: SourceNodeOption[] = nodes
     .filter((node) => (node.data as CanvasNodeDataV2).profile === 'source')
     .map((node) => {
@@ -604,6 +618,8 @@ export const WorkspaceLayout = () => {
         fileName={fileName}
         isUnsaved={isUnsaved}
         onRun={handleRun}
+        onReset={handleResetRun}
+        isPostRun={isPostRun}
         onPause={sim.pause}
         onResume={sim.resume}
         onStop={() => {

--- a/src/renderer/src/components/properties/NodeMetricsDetail.tsx
+++ b/src/renderer/src/components/properties/NodeMetricsDetail.tsx
@@ -9,6 +9,24 @@ type NodeMetrics = ReturnType<typeof useNodeMetrics>
 
 interface NodeMetricsDetailProps {
   metrics: NodeMetrics
+  /**
+   * The node-level cache trait's configured hit rate (`sim.cacheHitRate`).
+   * The Cache panel below reports hit/miss counters that only mean anything when
+   * this trait is actually enabled. When it's absent or 0 the node is a plain
+   * datastore that happens to be a cache *type* (e.g. a Redis node fed by
+   * routing-level cache-aside), and the trait counts every arrival as a "miss" —
+   * producing a misleading 0% hit ratio. Gate the panel on this so we never
+   * surface phantom misses.
+   */
+  configuredCacheHitRate?: number
+  /**
+   * How this node's outbound traffic was split across its downstream targets,
+   * highest share first. Present only for nodes that fan out to more than one
+   * target. This is the honest source of truth for routing-level behaviour
+   * (cache-aside hit/miss, DNS weighting, sharding) — the split you'd otherwise
+   * have to infer from a per-node cache panel.
+   */
+  downstreamSplit?: { targetLabel: string; count: number; share: number }[]
 }
 
 function latencyMetricItem(value: number | null | undefined): {
@@ -78,14 +96,23 @@ export const SourceNodeMetricsDetail = ({
  * never had room for. This is what "click for detail" on the canvas card
  * links to - nothing here duplicates onto the card itself.
  */
-export const NodeMetricsDetail = ({ metrics }: NodeMetricsDetailProps) => {
+export const NodeMetricsDetail = ({
+  metrics,
+  configuredCacheHitRate,
+  downstreamSplit
+}: NodeMetricsDetailProps) => {
   const rejectionEntries = Object.entries(metrics.rejectionsByReason ?? {}).sort(
     (a, b) => b[1] - a[1]
   )
   const traitCounterEntries = Object.entries(metrics.traitCounters ?? {}).filter(
     ([key]) => key !== 'cacheHits' && key !== 'cacheMisses'
   )
+  // Only show the Cache panel when the node-level cache trait is actually enabled
+  // (a configured hit rate > 0). Otherwise the hit/miss counters are phantom
+  // misses from a node that's really just a fast datastore.
+  const cacheTraitEnabled = (configuredCacheHitRate ?? 0) > 0
   const hasCacheData =
+    cacheTraitEnabled &&
     metrics.cacheHitRatio !== undefined &&
     ((metrics.cacheHits ?? 0) > 0 || (metrics.cacheMisses ?? 0) > 0)
   const inFlightColour =
@@ -145,6 +172,37 @@ export const NodeMetricsDetail = ({ metrics }: NodeMetricsDetailProps) => {
           />
         </div>
       </Section>
+
+      {downstreamSplit && downstreamSplit.length > 0 && (
+        <Section title="Downstream Routing Split">
+          <div className="space-y-2">
+            {downstreamSplit.map((row) => (
+              <div key={row.targetLabel} className="space-y-1">
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-nss-text">{row.targetLabel}</span>
+                  <span className="font-semibold text-nss-text tabular-nums">
+                    {(row.share * 100).toFixed(1)}%
+                    <span className="ml-1 text-nss-muted font-normal">
+                      ({row.count.toLocaleString()} req)
+                    </span>
+                  </span>
+                </div>
+                <div className="h-1.5 w-full overflow-hidden rounded-full bg-nss-surface">
+                  <div
+                    className="h-full rounded-full bg-nss-primary"
+                    style={{ width: `${Math.max(row.share * 100, 1)}%` }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+          <p className="mt-3 text-xs text-nss-muted">
+            Share of this node&apos;s outbound requests routed to each target. For a cache-aside
+            path this is the real hit/miss split — cache hits and misses are modelled as which
+            backend the request is routed to.
+          </p>
+        </Section>
+      )}
 
       <Section title="Latency">
         <div className="grid grid-cols-3 gap-4">

--- a/src/renderer/src/components/properties/PropertiesPanel.tsx
+++ b/src/renderer/src/components/properties/PropertiesPanel.tsx
@@ -819,6 +819,29 @@ export const PropertiesPanel = () => {
       ? sourceEmittedCount(selectedNode.id, edges, edgeFlowById)
       : 0
 
+    // When a node fans out to more than one downstream target, the share of its
+    // traffic reaching each target *is* the routing outcome — the honest source of
+    // truth for cache-aside hit/miss, DNS weighting, sharding, etc. Surface it so
+    // the split is visible instead of being inferred from a misleading node panel.
+    const selectedOutboundEdges = edges.filter((edge) => edge.source === selectedNode.id)
+    const downstreamSplit =
+      selectedOutboundEdges.length > 1
+        ? (() => {
+            const rows = selectedOutboundEdges.map((edge) => ({
+              targetLabel:
+                (nodes.find((n) => n.id === edge.target)?.data as { label?: string } | undefined)
+                  ?.label ?? edge.target,
+              count: edgeFlowById[edge.id]?.totalAttempted ?? 0
+            }))
+            const total = rows.reduce((sum, row) => sum + row.count, 0)
+            return total > 0
+              ? rows
+                  .map((row) => ({ ...row, share: row.count / total }))
+                  .sort((a, b) => b.share - a.share)
+              : undefined
+          })()
+        : undefined
+
     return (
       <div className="h-full w-full bg-nss-panel border-l border-nss-border flex flex-col text-nss-text font-sans shadow-xl">
         <PropertiesHeader
@@ -841,7 +864,11 @@ export const PropertiesPanel = () => {
                 emitted={selectedEmitted}
               />
             ) : (
-              <NodeMetricsDetail metrics={metrics} />
+              <NodeMetricsDetail
+                metrics={metrics}
+                configuredCacheHitRate={data.sim?.cacheHitRate}
+                downstreamSplit={downstreamSplit}
+              />
             )
           ) : (
             <PropertiesForm nodeId={selectedNode.id} data={data} onUpdate={handleUpdate} />

--- a/src/renderer/src/components/simulation/ResultsTray.tsx
+++ b/src/renderer/src/components/simulation/ResultsTray.tsx
@@ -3825,7 +3825,23 @@ function buildPerNodeFindings(
 
 function PerNodeTable({ output }: { output: SimulationOutput }) {
   const [showInactive, setShowInactive] = useState(false)
+  const nodes = useStore((state) => state.nodes)
   const entries = Object.entries(output.perNode)
+
+  // Source nodes emit traffic rather than receive it, so their `postWarmupArrived`
+  // is always 0. Without this, the driver of the whole run gets mislabelled as an
+  // "inactive node with no post-warmup traffic". Split them out explicitly.
+  const sourceNodeIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const node of nodes) {
+      const data = node.data as { structuralRole?: unknown; profile?: unknown } | undefined
+      if (data?.structuralRole === 'source' || data?.profile === 'source') {
+        ids.add(node.id)
+      }
+    }
+    return ids
+  }, [nodes])
+
   if (entries.length === 0) return null
 
   const llByNode = new Map(output.littlesLawCheck.map((r) => [r.nodeId, r]))
@@ -3834,7 +3850,9 @@ function PerNodeTable({ output }: { output: SimulationOutput }) {
   )
 
   const activeEntries = entries.filter(([, m]) => m.postWarmupArrived > 0)
-  const inactiveEntries = entries.filter(([, m]) => m.postWarmupArrived === 0)
+  const idleEntries = entries.filter(([, m]) => m.postWarmupArrived === 0)
+  const sourceEntries = idleEntries.filter(([nodeId]) => sourceNodeIds.has(nodeId))
+  const inactiveEntries = idleEntries.filter(([nodeId]) => !sourceNodeIds.has(nodeId))
   const findings = buildPerNodeFindings(entries)
 
   return (
@@ -3980,6 +3998,20 @@ function PerNodeTable({ output }: { output: SimulationOutput }) {
         </table>
       </div>
 
+      {sourceEntries.length > 0 && (
+        <table className="w-full text-xs tabular-nums mt-1 opacity-60">
+          <tbody>
+            {sourceEntries.map(([nodeId, m]) => (
+              <tr key={nodeId} className="border-b border-nss-border">
+                <td className="py-0.5 pr-2 text-nss-muted">{m.nodeLabel ?? nodeId}</td>
+                <td className="text-right text-nss-muted text-[10px] italic" colSpan={16}>
+                  source · emits traffic (not measured by arrivals)
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
       {inactiveEntries.length > 0 && (
         <div>
           <button

--- a/src/renderer/src/components/simulation/SimulationControls.tsx
+++ b/src/renderer/src/components/simulation/SimulationControls.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Pause, Play, Square, X } from 'lucide-react'
+import { Pause, Play, RotateCcw, Square, X } from 'lucide-react'
 import type { FaultSpec, WorkloadProfile } from '../../../../engine/core/types'
 import type { FaultTargetOption, ScenarioState, SourceNodeOption } from '@renderer/types/ui'
 import { mergeWorkloadDefaults } from '@renderer/utils/workloadDefaults'
@@ -70,6 +70,8 @@ const ACTION_BUTTON_BASE =
 
 interface SimulationControlsProps {
   onRun: () => void
+  onReset: () => void
+  isPostRun: boolean
   onPause: () => void
   onResume: () => void
   onStop: () => void
@@ -94,6 +96,8 @@ function updateWorkloadOverride(
 
 export function SimulationControls({
   onRun,
+  onReset,
+  isPostRun,
   onPause,
   onResume,
   onStop,
@@ -216,14 +220,26 @@ export function SimulationControls({
   return (
     <div ref={wrapperRef} className="relative flex items-center gap-1.5">
       {!isRunning && !isPaused && (
-        <button
-          onClick={() => setIsOpen((prev) => !prev)}
-          disabled={disabled}
-          className={`${ACTION_BUTTON_BASE} flex items-center gap-1.5 bg-nss-primary text-white border-transparent hover:bg-nss-primary-hover`}
-        >
-          <Play size={12} className="fill-white" />
-          Run
-        </button>
+        <>
+          {isPostRun && (
+            <button
+              onClick={onReset}
+              title="Clear results and return to setup"
+              className={`${ACTION_BUTTON_BASE} flex items-center gap-1.5 bg-nss-surface text-nss-text border-nss-border hover:bg-nss-bg`}
+            >
+              <RotateCcw size={12} />
+              Reset
+            </button>
+          )}
+          <button
+            onClick={() => setIsOpen((prev) => !prev)}
+            disabled={disabled}
+            className={`${ACTION_BUTTON_BASE} flex items-center gap-1.5 bg-nss-primary text-white border-transparent hover:bg-nss-primary-hover`}
+          >
+            <Play size={12} className="fill-white" />
+            {isPostRun ? 'Run again' : 'Run'}
+          </button>
+        </>
       )}
 
       {isRunning && !isPaused && (

--- a/src/renderer/src/hooks/useTopologySerializer.ts
+++ b/src/renderer/src/hooks/useTopologySerializer.ts
@@ -30,6 +30,7 @@ type EdgeRuntimeData = {
   packetLossRate?: number
   errorRate?: number
   condition?: string
+  weight?: number
 }
 
 function asPositiveNumber(value: unknown): number | null {
@@ -215,7 +216,8 @@ function serializeEdge(
     condition:
       typeof edgeData.condition === 'string' && edgeData.condition.trim().length > 0
         ? edgeData.condition.trim()
-        : undefined
+        : undefined,
+    weight: asPositiveNumber(edgeData.weight) ?? undefined
   }
 }
 


### PR DESCRIPTION
## Summary

The sample scenarios shipped with their **file contents rotated by one relative to their filenames and menu entries** — clicking "Circuit Breaker Fail-Fast" loaded a plain client-server topology, "DNS Weighted Routing" loaded the circuit-breaker sidecar, and so on. The real **Key-Based Sharding** scenario didn't exist at all. This PR restores every sample to the scenario its name promises, adds the missing sharding scenario, and fixes several metric/UX honesty issues surfaced while diagnosing it (most notably the cache panel reporting a misleading 0% hit ratio for a Redis node that was actually serving ~90% of reads).

The engine traits themselves were all correct — the problems were in scenario data, one serialization gap, and how a few metrics were surfaced.

## What changed

**Sample scenarios**
- Un-shuffled `circuit-breaker-fail-fast`, `dns-weighted-routing`, and `stream-consumer-lag` so each file matches its filename and menu entry. `dns-weighted-routing` now carries explicit 80/20 edge weights.
- Added a real **Key-Based Sharding** scenario (Client → Shard Router → Shard A/B/C) with keys chosen to hash deterministically across the three shard-node datastores, so the same key always lands on the same shard across reruns.

**Metrics / routing honesty**
- **Edge weight serialization:** `serializeEdge` never copied `weight`, so weighted DNS/routing policies always ran an even split. `data.weight` now reaches the engine, making the 80/20 DNS split real.
- **Cache panel gating:** the per-node Cache panel is suppressed unless the node has a configured `cacheHitRate > 0`. An unconfigured cache node counted every arrival as a "miss", producing a phantom 0% hit ratio for nodes fed by routing-level cache-aside.
- **Downstream routing split:** fan-out nodes now show each downstream target's share of outbound traffic — the honest hit/miss split for cache-aside (e.g. API Server → ~90% Redis / ~10% Primary DB).
- **Source labeling:** sources (zero arrivals by definition) are no longer filed under "Inactive nodes — no post-warmup traffic"; they get a "source · emits traffic" row.

**Config UX**
- Cold-start latency field shows a placeholder with the effective value instead of a blank input.
- The Caching config panel documents what to try (`0.9` warm, `0.5` half-local, `1.0` all hits, empty to disable), making the node-level cache trait discoverable.

**Canvas / controls** *(carried in from a concurrent session, included for completeness)*
- Packet edges now project the active metric lens instead of a hardcoded failure-rate label.
- Post-run **Reset** control that clears results and returns to setup; "Run" becomes "Run again".

## Testing
- `npm run typecheck` clean; full suite **293 passing** (2 skipped).
- Verified live in the web app: cache-aside run shows the routing split (Redis 89.8% / Primary DB 10.2%), the Redis Cache panel no longer shows phantom misses, the per-node table labels the source correctly, and the Key-Based Sharding scenario runs clean (no protocol warning, deterministic ~1/3 split across shards).