### PR TITLE
Add locality rollups, request-aware routing analysis, and Run Inspector UX improvements

### DIFF
--- a/src/engine/__samples__/cross-region-auto-latency.json
+++ b/src/engine/__samples__/cross-region-auto-latency.json
@@ -1,0 +1,317 @@
+{
+  "version": "2.0.0",
+  "nodes": [
+    {
+      "id": "region-east",
+      "type": "vpcNode",
+      "position": {
+        "x": 60,
+        "y": 80
+      },
+      "width": 914,
+      "height": 480,
+      "data": {
+        "schemaVersion": 2,
+        "templateId": "vpc-region",
+        "structuralRole": "composite",
+        "profile": "composite",
+        "rendererType": "vpcNode",
+        "label": "US East Region",
+        "subLabel": "Isolated Network",
+        "iconKey": "cloud",
+        "sim": {
+          "locationId": "us-east-1"
+        }
+      },
+      "zIndex": 0,
+      "expandParent": false,
+      "selected": false,
+      "dragging": false,
+      "style": {
+        "width": 914,
+        "height": 480
+      },
+      "resizing": false,
+      "nodes": [
+        {
+          "id": "az-a",
+          "type": "vpcNode",
+          "position": {
+            "x": 31,
+            "y": 80
+          },
+          "width": 349,
+          "height": 368,
+          "data": {
+            "schemaVersion": 2,
+            "templateId": "availability-zone",
+            "structuralRole": "composite",
+            "profile": "composite",
+            "rendererType": "vpcNode",
+            "label": "AZ A",
+            "subLabel": "Fault Domain",
+            "iconKey": "az",
+            "sim": {
+              "locationId": "us-east-1a"
+            }
+          },
+          "extent": "parent",
+          "zIndex": 10,
+          "expandParent": false,
+          "selected": false,
+          "dragging": false,
+          "style": {
+            "width": 349,
+            "height": 368
+          },
+          "resizing": false,
+          "nodes": [
+            {
+              "id": "subnet-a",
+              "type": "vpcNode",
+              "position": {
+                "x": 20,
+                "y": 64
+              },
+              "width": 300,
+              "height": 278,
+              "data": {
+                "schemaVersion": 2,
+                "templateId": "subnet",
+                "structuralRole": "composite",
+                "profile": "composite",
+                "rendererType": "vpcNode",
+                "label": "Private Subnet A",
+                "subLabel": "Network Partition",
+                "iconKey": "subnet",
+                "sim": {
+                  "locationId": "10.0.1.0/24"
+                }
+              },
+              "extent": "parent",
+              "zIndex": 10,
+              "expandParent": false,
+              "selected": false,
+              "dragging": false,
+              "style": {
+                "width": 300,
+                "height": 278
+              },
+              "resizing": false,
+              "nodes": [
+                {
+                  "id": "orders-web",
+                  "type": "serviceNode",
+                  "position": {
+                    "x": 22.617880856482543,
+                    "y": 92.37417002311071
+                  },
+                  "data": {
+                    "schemaVersion": 2,
+                    "templateId": "client-user",
+                    "componentType": "api-endpoint",
+                    "structuralRole": "source",
+                    "profile": "source",
+                    "rendererType": "serviceNode",
+                    "label": "Orders Web",
+                    "subLabel": "Regional Frontend",
+                    "iconKey": "monitor",
+                    "source": {
+                      "requestDistribution": [
+                        {
+                          "type": "GET",
+                          "weight": 1,
+                          "sizeBytes": 1024
+                        }
+                      ],
+                      "defaultWorkload": {
+                        "pattern": "poisson",
+                        "baseRps": 90,
+                        "bursty": {
+                          "burstRps": 500,
+                          "burstDuration": 2000,
+                          "normalDuration": 8000
+                        },
+                        "spike": {
+                          "spikeTime": 30000,
+                          "spikeRps": 900,
+                          "spikeDuration": 5000
+                        },
+                        "sawtooth": {
+                          "peakRps": 300,
+                          "rampDuration": 10000
+                        }
+                      }
+                    }
+                  },
+                  "extent": "parent",
+                  "zIndex": 10,
+                  "expandParent": false,
+                  "selected": false,
+                  "width": 256,
+                  "height": 117,
+                  "positionAbsolute": {
+                    "x": 133.61788085648254,
+                    "y": 316.3741700231107
+                  },
+                  "dragging": false,
+                  "nodes": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "az-b",
+          "type": "vpcNode",
+          "position": {
+            "x": 480,
+            "y": 80
+          },
+          "width": 401,
+          "height": 368,
+          "data": {
+            "schemaVersion": 2,
+            "templateId": "availability-zone",
+            "structuralRole": "composite",
+            "profile": "composite",
+            "rendererType": "vpcNode",
+            "label": "AZ B",
+            "subLabel": "Fault Domain",
+            "iconKey": "az",
+            "sim": {
+              "locationId": "us-east-1b"
+            }
+          },
+          "extent": "parent",
+          "zIndex": 10,
+          "expandParent": false,
+          "selected": false,
+          "dragging": false,
+          "style": {
+            "width": 401,
+            "height": 368
+          },
+          "resizing": false,
+          "nodes": [
+            {
+              "id": "subnet-b",
+              "type": "vpcNode",
+              "position": {
+                "x": 20,
+                "y": 64
+              },
+              "width": 356,
+              "height": 276,
+              "data": {
+                "schemaVersion": 2,
+                "templateId": "subnet",
+                "structuralRole": "composite",
+                "profile": "composite",
+                "rendererType": "vpcNode",
+                "label": "Private Subnet B",
+                "subLabel": "Network Partition",
+                "iconKey": "subnet",
+                "sim": {
+                  "locationId": "10.0.2.0/24"
+                }
+              },
+              "extent": "parent",
+              "zIndex": 10,
+              "expandParent": false,
+              "selected": false,
+              "dragging": false,
+              "style": {
+                "width": 356,
+                "height": 276
+              },
+              "resizing": false,
+              "nodes": [
+                {
+                  "id": "orders-api",
+                  "type": "computeNode",
+                  "position": {
+                    "x": 42.585429722209255,
+                    "y": 93.75628916662816
+                  },
+                  "data": {
+                    "schemaVersion": 2,
+                    "templateId": "backend-server",
+                    "componentType": "microservice",
+                    "structuralRole": "processor",
+                    "profile": "compute-service",
+                    "rendererType": "computeNode",
+                    "label": "Orders API",
+                    "subLabel": "AZ B Worker Pool",
+                    "iconKey": "SERVER",
+                    "sim": {
+                      "queue": {
+                        "workers": 6,
+                        "capacity": 30,
+                        "discipline": "fifo"
+                      },
+                      "processing": {
+                        "distribution": {
+                          "type": "constant",
+                          "value": 12
+                        },
+                        "timeout": 400
+                      }
+                    }
+                  },
+                  "extent": "parent",
+                  "zIndex": 10,
+                  "expandParent": false,
+                  "selected": false,
+                  "width": 274,
+                  "height": 116,
+                  "positionAbsolute": {
+                    "x": 602.5854297222093,
+                    "y": 317.75628916662816
+                  },
+                  "dragging": false,
+                  "nodes": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "id": "orders-web-to-orders-api",
+      "type": "packet",
+      "source": "orders-web",
+      "target": "orders-api",
+      "sourceHandle": "right-1-source",
+      "targetHandle": "left-1-target",
+      "animated": true,
+      "data": {
+        "protocol": "https",
+        "mode": "synchronous",
+        "bandwidth": 1000,
+        "maxConcurrentRequests": 220,
+        "packetLossRate": 0,
+        "errorRate": 0
+      },
+      "selected": false
+    }
+  ],
+  "scenario": {
+    "global": {
+      "simulationDuration": 60000,
+      "warmupDuration": 5000,
+      "seed": "sample-multi-az-auto-latency",
+      "defaultTimeout": 1000,
+      "traceSampleRate": 0.05
+    },
+    "selectedSourceNodeId": "orders-web",
+    "workloadOverride": {
+      "pattern": "poisson",
+      "baseRps": 90
+    },
+    "faults": []
+  }
+}

--- a/src/engine/__samples__/endpoint-routing-request-mix.json
+++ b/src/engine/__samples__/endpoint-routing-request-mix.json
@@ -1,0 +1,358 @@
+{
+  "version": "2.0.0",
+  "nodes": [
+    {
+      "id": "client",
+      "type": "serviceNode",
+      "position": {
+        "x": 80,
+        "y": 340
+      },
+      "data": {
+        "schemaVersion": 2,
+        "templateId": "client-user",
+        "componentType": "api-endpoint",
+        "structuralRole": "source",
+        "profile": "source",
+        "rendererType": "serviceNode",
+        "label": "Storefront Client",
+        "subLabel": "Endpoint Traffic Mix",
+        "iconKey": "monitor",
+        "source": {
+          "requestDistribution": [
+            {
+              "type": "browse-catalog",
+              "weight": 0.55,
+              "sizeBytes": 1200,
+              "metadata": {
+                "method": "GET",
+                "host": "catalog.internal",
+                "path": "/catalog"
+              }
+            },
+            {
+              "type": "submit-checkout",
+              "weight": 0.3,
+              "sizeBytes": 2200,
+              "metadata": {
+                "method": "POST",
+                "host": "api.internal",
+                "path": "/checkout"
+              }
+            },
+            {
+              "type": "fraud-review",
+              "weight": 0.15,
+              "sizeBytes": 1800,
+              "metadata": {
+                "method": "POST",
+                "host": "api.internal",
+                "path": "/fraud/check"
+              }
+            }
+          ],
+          "defaultWorkload": {
+            "pattern": "poisson",
+            "baseRps": 240,
+            "bursty": {
+              "burstRps": 520,
+              "burstDuration": 1500,
+              "normalDuration": 8500
+            },
+            "spike": {
+              "spikeTime": 32000,
+              "spikeRps": 700,
+              "spikeDuration": 4000
+            },
+            "sawtooth": {
+              "peakRps": 340,
+              "rampDuration": 12000
+            }
+          }
+        }
+      },
+      "zIndex": 0,
+      "expandParent": false,
+      "selected": false,
+      "width": 256,
+      "height": 117,
+      "nodes": []
+    },
+    {
+      "id": "api-gateway",
+      "type": "serviceNode",
+      "position": {
+        "x": 620,
+        "y": 320
+      },
+      "data": {
+        "schemaVersion": 2,
+        "templateId": "api-gateway",
+        "componentType": "api-gateway",
+        "structuralRole": "router",
+        "profile": "router",
+        "rendererType": "serviceNode",
+        "label": "API Gateway",
+        "subLabel": "Path Routing + Rate Limit",
+        "iconKey": "globe",
+        "routingStrategy": "round-robin",
+        "sim": {
+          "queue": {
+            "workers": 12,
+            "capacity": 96,
+            "discipline": "fifo"
+          },
+          "processing": {
+            "distribution": {
+              "type": "constant",
+              "value": 2
+            },
+            "timeout": 120
+          },
+          "maxTokens": 48,
+          "refillRatePerSecond": 210,
+          "routingRules": [
+            {
+              "matchField": "path",
+              "matchValue": "/catalog",
+              "targetNodeId": "catalog-api"
+            },
+            {
+              "matchField": "path",
+              "matchValue": "/checkout",
+              "targetNodeId": "checkout-api"
+            },
+            {
+              "matchField": "path",
+              "matchValue": "/fraud/check",
+              "targetNodeId": "fraud-api"
+            }
+          ]
+        }
+      },
+      "zIndex": 0,
+      "expandParent": false,
+      "selected": false,
+      "width": 256,
+      "height": 164,
+      "nodes": []
+    },
+    {
+      "id": "catalog-api",
+      "type": "computeNode",
+      "position": {
+        "x": 1180,
+        "y": 80
+      },
+      "data": {
+        "schemaVersion": 2,
+        "templateId": "backend-server",
+        "componentType": "microservice",
+        "structuralRole": "processor",
+        "profile": "compute-service",
+        "rendererType": "computeNode",
+        "label": "Catalog API",
+        "subLabel": "Fast Read Endpoint",
+        "iconKey": "SERVER",
+        "sim": {
+          "queue": {
+            "workers": 8,
+            "capacity": 80,
+            "discipline": "fifo"
+          },
+          "processing": {
+            "distribution": {
+              "type": "constant",
+              "value": 4
+            },
+            "timeout": 160
+          }
+        }
+      },
+      "zIndex": 0,
+      "expandParent": false,
+      "selected": false,
+      "width": 190,
+      "height": 115,
+      "nodes": []
+    },
+    {
+      "id": "checkout-api",
+      "type": "computeNode",
+      "position": {
+        "x": 1180,
+        "y": 320
+      },
+      "data": {
+        "schemaVersion": 2,
+        "templateId": "backend-server",
+        "componentType": "microservice",
+        "structuralRole": "processor",
+        "profile": "compute-service",
+        "rendererType": "computeNode",
+        "label": "Checkout API",
+        "subLabel": "Write Path Bottleneck",
+        "iconKey": "SERVER",
+        "sim": {
+          "queue": {
+            "workers": 2,
+            "capacity": 12,
+            "discipline": "fifo"
+          },
+          "processing": {
+            "distribution": {
+              "type": "constant",
+              "value": 55
+            },
+            "timeout": 100
+          }
+        }
+      },
+      "zIndex": 0,
+      "expandParent": false,
+      "selected": false,
+      "width": 190,
+      "height": 115,
+      "nodes": []
+    },
+    {
+      "id": "fraud-api",
+      "type": "computeNode",
+      "position": {
+        "x": 1180,
+        "y": 560
+      },
+      "data": {
+        "schemaVersion": 2,
+        "templateId": "backend-server",
+        "componentType": "microservice",
+        "structuralRole": "processor",
+        "profile": "compute-service",
+        "rendererType": "computeNode",
+        "label": "Fraud API",
+        "subLabel": "Slow Review Path",
+        "iconKey": "SERVER",
+        "sim": {
+          "queue": {
+            "workers": 1,
+            "capacity": 8,
+            "discipline": "fifo"
+          },
+          "processing": {
+            "distribution": {
+              "type": "constant",
+              "value": 110
+            },
+            "timeout": 85
+          }
+        }
+      },
+      "zIndex": 0,
+      "expandParent": false,
+      "selected": false,
+      "width": 190,
+      "height": 115,
+      "nodes": []
+    }
+  ],
+  "edges": [
+    {
+      "id": "client-to-api-gateway",
+      "type": "packet",
+      "source": "client",
+      "target": "api-gateway",
+      "sourceHandle": "right-1-source",
+      "targetHandle": "left-1-target",
+      "animated": true,
+      "data": {
+        "protocol": "https",
+        "mode": "synchronous",
+        "pathType": "internet",
+        "latencyMu": 2.7,
+        "latencySigma": 0.4,
+        "bandwidth": 1000,
+        "maxConcurrentRequests": 900,
+        "packetLossRate": 0,
+        "errorRate": 0
+      },
+      "selected": false
+    },
+    {
+      "id": "api-gateway-to-catalog-api",
+      "type": "packet",
+      "source": "api-gateway",
+      "target": "catalog-api",
+      "sourceHandle": "right-0-source",
+      "targetHandle": "left-1-target",
+      "animated": true,
+      "data": {
+        "protocol": "https",
+        "mode": "synchronous",
+        "pathType": "same-dc",
+        "latencyMu": 0.8,
+        "latencySigma": 0.25,
+        "bandwidth": 1000,
+        "maxConcurrentRequests": 500,
+        "packetLossRate": 0,
+        "errorRate": 0
+      },
+      "selected": false
+    },
+    {
+      "id": "api-gateway-to-checkout-api",
+      "type": "packet",
+      "source": "api-gateway",
+      "target": "checkout-api",
+      "sourceHandle": "right-1-source",
+      "targetHandle": "left-1-target",
+      "animated": true,
+      "data": {
+        "protocol": "https",
+        "mode": "synchronous",
+        "pathType": "same-dc",
+        "latencyMu": 0.9,
+        "latencySigma": 0.25,
+        "bandwidth": 1000,
+        "maxConcurrentRequests": 250,
+        "packetLossRate": 0,
+        "errorRate": 0
+      },
+      "selected": false
+    },
+    {
+      "id": "api-gateway-to-fraud-api",
+      "type": "packet",
+      "source": "api-gateway",
+      "target": "fraud-api",
+      "sourceHandle": "right-2-source",
+      "targetHandle": "left-1-target",
+      "animated": true,
+      "data": {
+        "protocol": "https",
+        "mode": "synchronous",
+        "pathType": "same-dc",
+        "latencyMu": 1.1,
+        "latencySigma": 0.3,
+        "bandwidth": 1000,
+        "maxConcurrentRequests": 180,
+        "packetLossRate": 0,
+        "errorRate": 0
+      },
+      "selected": false
+    }
+  ],
+  "scenario": {
+    "global": {
+      "simulationDuration": 60000,
+      "warmupDuration": 5000,
+      "seed": "sample-endpoint-routing-request-mix",
+      "defaultTimeout": 1000,
+      "traceSampleRate": 0.05
+    },
+    "selectedSourceNodeId": "client",
+    "workloadOverride": {
+      "pattern": "poisson",
+      "baseRps": 240
+    }
+  }
+}

--- a/src/engine/__samples__/multi-az-auto-latency.json
+++ b/src/engine/__samples__/multi-az-auto-latency.json
@@ -1,0 +1,317 @@
+{
+  "version": "2.0.0",
+  "nodes": [
+    {
+      "id": "region-east",
+      "type": "vpcNode",
+      "position": {
+        "x": 60,
+        "y": 80
+      },
+      "width": 860,
+      "height": 470,
+      "data": {
+        "schemaVersion": 2,
+        "templateId": "vpc-region",
+        "structuralRole": "composite",
+        "profile": "composite",
+        "rendererType": "vpcNode",
+        "label": "US East Region",
+        "subLabel": "Isolated Network",
+        "iconKey": "cloud",
+        "sim": {
+          "locationId": "us-east-1"
+        }
+      },
+      "zIndex": 0,
+      "expandParent": false,
+      "selected": false,
+      "dragging": false,
+      "style": {
+        "width": 860,
+        "height": 470
+      },
+      "resizing": false,
+      "nodes": [
+        {
+          "id": "az-a",
+          "type": "vpcNode",
+          "position": {
+            "x": 40,
+            "y": 80
+          },
+          "width": 340,
+          "height": 362,
+          "data": {
+            "schemaVersion": 2,
+            "templateId": "availability-zone",
+            "structuralRole": "composite",
+            "profile": "composite",
+            "rendererType": "vpcNode",
+            "label": "AZ A",
+            "subLabel": "Fault Domain",
+            "iconKey": "az",
+            "sim": {
+              "locationId": "us-east-1a"
+            }
+          },
+          "extent": "parent",
+          "zIndex": 10,
+          "expandParent": false,
+          "selected": false,
+          "dragging": false,
+          "style": {
+            "width": 340,
+            "height": 362
+          },
+          "resizing": false,
+          "nodes": [
+            {
+              "id": "subnet-a",
+              "type": "vpcNode",
+              "position": {
+                "x": 20,
+                "y": 64
+              },
+              "width": 300,
+              "height": 268,
+              "data": {
+                "schemaVersion": 2,
+                "templateId": "subnet",
+                "structuralRole": "composite",
+                "profile": "composite",
+                "rendererType": "vpcNode",
+                "label": "Private Subnet A",
+                "subLabel": "Network Partition",
+                "iconKey": "subnet",
+                "sim": {
+                  "locationId": "10.0.1.0/24"
+                }
+              },
+              "extent": "parent",
+              "zIndex": 10,
+              "expandParent": false,
+              "selected": false,
+              "dragging": false,
+              "style": {
+                "width": 300,
+                "height": 268
+              },
+              "resizing": false,
+              "nodes": [
+                {
+                  "id": "orders-web",
+                  "type": "serviceNode",
+                  "position": {
+                    "x": 23,
+                    "y": 94
+                  },
+                  "data": {
+                    "schemaVersion": 2,
+                    "templateId": "client-user",
+                    "componentType": "api-endpoint",
+                    "structuralRole": "source",
+                    "profile": "source",
+                    "rendererType": "serviceNode",
+                    "label": "Orders Web",
+                    "subLabel": "Regional Frontend",
+                    "iconKey": "monitor",
+                    "source": {
+                      "requestDistribution": [
+                        {
+                          "type": "GET",
+                          "weight": 1,
+                          "sizeBytes": 1024
+                        }
+                      ],
+                      "defaultWorkload": {
+                        "pattern": "poisson",
+                        "baseRps": 90,
+                        "bursty": {
+                          "burstRps": 500,
+                          "burstDuration": 2000,
+                          "normalDuration": 8000
+                        },
+                        "spike": {
+                          "spikeTime": 30000,
+                          "spikeRps": 900,
+                          "spikeDuration": 5000
+                        },
+                        "sawtooth": {
+                          "peakRps": 300,
+                          "rampDuration": 10000
+                        }
+                      }
+                    }
+                  },
+                  "extent": "parent",
+                  "zIndex": 10,
+                  "expandParent": false,
+                  "selected": false,
+                  "width": 256,
+                  "height": 117,
+                  "positionAbsolute": {
+                    "x": 143,
+                    "y": 318
+                  },
+                  "dragging": false,
+                  "nodes": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "az-b",
+          "type": "vpcNode",
+          "position": {
+            "x": 480,
+            "y": 80
+          },
+          "width": 363,
+          "height": 373,
+          "data": {
+            "schemaVersion": 2,
+            "templateId": "availability-zone",
+            "structuralRole": "composite",
+            "profile": "composite",
+            "rendererType": "vpcNode",
+            "label": "AZ B",
+            "subLabel": "Fault Domain",
+            "iconKey": "az",
+            "sim": {
+              "locationId": "us-east-1b"
+            }
+          },
+          "extent": "parent",
+          "zIndex": 10,
+          "expandParent": false,
+          "selected": false,
+          "dragging": false,
+          "style": {
+            "width": 363,
+            "height": 373
+          },
+          "resizing": false,
+          "nodes": [
+            {
+              "id": "subnet-b",
+              "type": "vpcNode",
+              "position": {
+                "x": 20,
+                "y": 64
+              },
+              "width": 318,
+              "height": 284,
+              "data": {
+                "schemaVersion": 2,
+                "templateId": "subnet",
+                "structuralRole": "composite",
+                "profile": "composite",
+                "rendererType": "vpcNode",
+                "label": "Private Subnet B",
+                "subLabel": "Network Partition",
+                "iconKey": "subnet",
+                "sim": {
+                  "locationId": "10.0.2.0/24"
+                }
+              },
+              "extent": "parent",
+              "zIndex": 10,
+              "expandParent": false,
+              "selected": false,
+              "dragging": false,
+              "style": {
+                "width": 318,
+                "height": 284
+              },
+              "resizing": false,
+              "nodes": [
+                {
+                  "id": "orders-api",
+                  "type": "computeNode",
+                  "position": {
+                    "x": 28,
+                    "y": 93
+                  },
+                  "data": {
+                    "schemaVersion": 2,
+                    "templateId": "backend-server",
+                    "componentType": "microservice",
+                    "structuralRole": "processor",
+                    "profile": "compute-service",
+                    "rendererType": "computeNode",
+                    "label": "Orders API",
+                    "subLabel": "AZ B Worker Pool",
+                    "iconKey": "SERVER",
+                    "sim": {
+                      "queue": {
+                        "workers": 6,
+                        "capacity": 30,
+                        "discipline": "fifo"
+                      },
+                      "processing": {
+                        "distribution": {
+                          "type": "constant",
+                          "value": 12
+                        },
+                        "timeout": 400
+                      }
+                    }
+                  },
+                  "extent": "parent",
+                  "zIndex": 10,
+                  "expandParent": false,
+                  "selected": false,
+                  "width": 274,
+                  "height": 116,
+                  "positionAbsolute": {
+                    "x": 588,
+                    "y": 317
+                  },
+                  "dragging": false,
+                  "nodes": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "id": "orders-web-to-orders-api",
+      "type": "packet",
+      "source": "orders-web",
+      "target": "orders-api",
+      "sourceHandle": "right-1-source",
+      "targetHandle": "left-1-target",
+      "animated": true,
+      "data": {
+        "protocol": "https",
+        "mode": "synchronous",
+        "bandwidth": 1000,
+        "maxConcurrentRequests": 220,
+        "packetLossRate": 0,
+        "errorRate": 0
+      },
+      "selected": false
+    }
+  ],
+  "scenario": {
+    "global": {
+      "simulationDuration": 60000,
+      "warmupDuration": 5000,
+      "seed": "sample-multi-az-auto-latency",
+      "defaultTimeout": 1000,
+      "traceSampleRate": 0.05
+    },
+    "selectedSourceNodeId": "orders-web",
+    "workloadOverride": {
+      "pattern": "poisson",
+      "baseRps": 90
+    },
+    "faults": []
+  }
+}

--- a/src/engine/analysis/output.ts
+++ b/src/engine/analysis/output.ts
@@ -237,7 +237,8 @@ export function generateSimulationOutput(
     debuggedLifecycle: debugData?.debuggedLifecycle ?? null,
     requestOutcomes,
     requestOutcomeTotal: debugData?.requestOutcomeTotal ?? requestOutcomes.length,
-    requestOutcomeBreakdown: debugData?.requestOutcomeBreakdown ?? createEmptyRequestOutcomeBreakdown(),
+    requestOutcomeBreakdown:
+      debugData?.requestOutcomeBreakdown ?? createEmptyRequestOutcomeBreakdown(),
     requestOutcomesSampled: debugData?.requestOutcomesSampled ?? false
   }
 }

--- a/src/engine/analysis/output.ts
+++ b/src/engine/analysis/output.ts
@@ -7,6 +7,10 @@ import type {
   RequestOutcomeRecord
 } from '../core/event-stream'
 import { createEmptyEventCounts } from '../core/event-stream'
+import {
+  createEmptyRequestOutcomeBreakdown,
+  type RequestOutcomeFamily
+} from '../core/requestOutcomeSemantics'
 import { MetricsCollector, PerEdgeMetrics, PerNodeMetrics, SimulationSummary } from '../metrics'
 import { RequestTrace, RequestTracer } from '../tracer'
 
@@ -169,6 +173,8 @@ export interface SimulationOutput {
   requestOutcomes: RequestOutcomeRecord[]
   /** Total outcome rows before any UI transport sampling. */
   requestOutcomeTotal: number
+  /** Exact counts by request outcome family across the full run. */
+  requestOutcomeBreakdown: Record<RequestOutcomeFamily, number>
   /** True when `requestOutcomes` is a sampled subset of the total outcome ledger. */
   requestOutcomesSampled: boolean
 }
@@ -189,6 +195,7 @@ export function generateSimulationOutput(
     statusTimeline?: StatusWindow[]
     requestOutcomes?: RequestOutcomeRecord[]
     requestOutcomeTotal?: number
+    requestOutcomeBreakdown?: Record<RequestOutcomeFamily, number>
     requestOutcomesSampled?: boolean
   }
 ): SimulationOutput {
@@ -230,6 +237,7 @@ export function generateSimulationOutput(
     debuggedLifecycle: debugData?.debuggedLifecycle ?? null,
     requestOutcomes,
     requestOutcomeTotal: debugData?.requestOutcomeTotal ?? requestOutcomes.length,
+    requestOutcomeBreakdown: debugData?.requestOutcomeBreakdown ?? createEmptyRequestOutcomeBreakdown(),
     requestOutcomesSampled: debugData?.requestOutcomesSampled ?? false
   }
 }

--- a/src/engine/catalog/componentSpecs.ts
+++ b/src/engine/catalog/componentSpecs.ts
@@ -8,7 +8,10 @@ import type {
   StructuralRole
 } from './nodeSpecTypes'
 import { CACHE_COMPONENT_TYPES } from '../traits/cache'
-import { L4_CONTENT_ROUTING_FORBIDDEN_MESSAGE } from '../traits/contentRouting'
+import {
+  CONTENT_ROUTING_MATCH_FIELDS,
+  L4_CONTENT_ROUTING_FORBIDDEN_MESSAGE
+} from '../traits/contentRouting'
 import { HEALTH_AWARE_COMPONENT_TYPES } from '../traits/healthAwareRouting'
 import { asDistributionConfig } from '../traits/serviceTimeOverride'
 
@@ -595,9 +598,9 @@ function validateSimulationNode(data: CanvasNodeDataV2): string[] {
       errors.push(L4_CONTENT_ROUTING_FORBIDDEN_MESSAGE)
     } else {
       routingRules.forEach((rule, ruleIndex) => {
-        if (!['type', 'path', 'host'].includes(rule.matchField)) {
+        if (!(CONTENT_ROUTING_MATCH_FIELDS as readonly string[]).includes(rule.matchField)) {
           errors.push(
-            `routingRules[${ruleIndex}].matchField must be one of "type", "path", "host".`
+            `routingRules[${ruleIndex}].matchField must be one of ${CONTENT_ROUTING_MATCH_FIELDS.map((field) => `"${field}"`).join(', ')}.`
           )
         }
         if (!rule.matchValue) {

--- a/src/engine/catalog/nodeSpecTypes.ts
+++ b/src/engine/catalog/nodeSpecTypes.ts
@@ -60,6 +60,7 @@ export interface NodeSimulationConfig {
   coldStartLatencyMs?: number
   idleTimeoutMs?: number
   maxConcurrency?: number
+  locationId?: string
   routingKeyField?: string
   dnsRoutingPolicy?: 'simple' | 'weighted' | 'failover' | 'latency-based' | 'geolocation'
   dnsCacheTtlSeconds?: number

--- a/src/engine/core/event-stream.ts
+++ b/src/engine/core/event-stream.ts
@@ -1,4 +1,8 @@
 import type { EventType, SimulationEvent } from './events'
+import type {
+  RequestOutcomeFamily,
+  RequestOutcomeStatusClass
+} from './requestOutcomeSemantics'
 
 export const CANONICAL_EVENT_TYPES = [
   'request-generated',
@@ -42,6 +46,7 @@ export type RequestOutcomeStatus = TerminalRequestStatus | 'in-flight'
 export interface RequestOutcomeRecord {
   requestId: string
   status: RequestOutcomeStatus
+  reasonCode: string | null
   /** Wall-clock-independent sim time (ms) the request was generated. */
   createdAtMs: number
   /** Sim time (ms) the request reached its terminal status; null while in flight. */
@@ -52,6 +57,14 @@ export interface RequestOutcomeRecord {
   attempts: number
   /** End-to-end latency (ms) for terminal requests; null while in flight. */
   latencyMs: number | null
+  requestType: string | null
+  method: string | null
+  host: string | null
+  path: string | null
+  operationLabel: string
+  outcomeFamily: RequestOutcomeFamily
+  statusClass: RequestOutcomeStatusClass
+  statusCodeHint: string | null
 }
 
 export type JsonSafeValue =

--- a/src/engine/core/event-stream.ts
+++ b/src/engine/core/event-stream.ts
@@ -1,8 +1,5 @@
 import type { EventType, SimulationEvent } from './events'
-import type {
-  RequestOutcomeFamily,
-  RequestOutcomeStatusClass
-} from './requestOutcomeSemantics'
+import type { RequestOutcomeFamily, RequestOutcomeStatusClass } from './requestOutcomeSemantics'
 
 export const CANONICAL_EVENT_TYPES = [
   'request-generated',

--- a/src/engine/core/requestOutcomeSemantics.test.ts
+++ b/src/engine/core/requestOutcomeSemantics.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { classifyRequestOutcome, createEmptyRequestOutcomeBreakdown } from './requestOutcomeSemantics'
+import {
+  classifyRequestOutcome,
+  createEmptyRequestOutcomeBreakdown
+} from './requestOutcomeSemantics'
 
 describe('request outcome semantics', () => {
   it('classifies rate limits as inferred 4xx outcomes', () => {

--- a/src/engine/core/requestOutcomeSemantics.test.ts
+++ b/src/engine/core/requestOutcomeSemantics.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { classifyRequestOutcome, createEmptyRequestOutcomeBreakdown } from './requestOutcomeSemantics'
+
+describe('request outcome semantics', () => {
+  it('classifies rate limits as inferred 4xx outcomes', () => {
+    expect(classifyRequestOutcome('rejected', 'rate_limited')).toMatchObject({
+      family: 'client_error_4xx',
+      statusClass: '4xx',
+      statusCodeHint: '429'
+    })
+  })
+
+  it('classifies connection refusals as network drops', () => {
+    expect(classifyRequestOutcome('rejected', 'connection_refused')).toMatchObject({
+      family: 'network_drop',
+      statusClass: 'dropped'
+    })
+  })
+
+  it('creates zeroed breakdown buckets for every family', () => {
+    const breakdown = createEmptyRequestOutcomeBreakdown()
+    expect(Object.values(breakdown).every((value) => value === 0)).toBe(true)
+    expect(Object.keys(breakdown)).toHaveLength(7)
+  })
+})

--- a/src/engine/core/requestOutcomeSemantics.ts
+++ b/src/engine/core/requestOutcomeSemantics.ts
@@ -1,0 +1,122 @@
+export const REQUEST_OUTCOME_FAMILIES = [
+  'success_2xx',
+  'client_error_4xx',
+  'server_error_5xx',
+  'network_timeout',
+  'network_drop',
+  'connection_reset',
+  'in_flight'
+] as const
+
+export type RequestOutcomeFamily = (typeof REQUEST_OUTCOME_FAMILIES)[number]
+export type RequestOutcomeStatusClass =
+  | '2xx'
+  | '4xx'
+  | '5xx'
+  | 'timeout'
+  | 'dropped'
+  | 'reset'
+  | 'in-flight'
+
+export interface RequestOutcomeClassification {
+  family: RequestOutcomeFamily
+  statusClass: RequestOutcomeStatusClass
+  label: string
+  statusCodeHint: string | null
+}
+
+type OutcomeStatusLike = 'success' | 'timeout' | 'rejected' | 'connection_reset' | 'in-flight'
+
+const CLIENT_ERROR_HINTS: Record<string, string> = {
+  rate_limited: '429',
+  security_blocked: '403'
+}
+
+const SERVER_ERROR_HINTS: Record<string, string> = {
+  capacity_exceeded: '503',
+  max_concurrency_exceeded: '503',
+  no_healthy_targets: '503',
+  circuit_breaker_open: '503',
+  read_only_node: '503',
+  node_failed: '503',
+  node_error_rate: '500',
+  trait_invalid_reroute: '500',
+  test_reject: '500'
+}
+
+const NETWORK_DROP_REASONS = new Set(['connection_refused', 'edge_error_rate'])
+const NETWORK_TIMEOUT_REASONS = new Set(['packet_loss', 'deadline_exceeded'])
+
+export function createEmptyRequestOutcomeBreakdown(): Record<RequestOutcomeFamily, number> {
+  return Object.fromEntries(REQUEST_OUTCOME_FAMILIES.map((key) => [key, 0])) as Record<
+    RequestOutcomeFamily,
+    number
+  >
+}
+
+export function classifyRequestOutcome(
+  status: OutcomeStatusLike,
+  reasonCode?: string | null
+): RequestOutcomeClassification {
+  switch (status) {
+    case 'success':
+      return {
+        family: 'success_2xx',
+        statusClass: '2xx',
+        label: '2xx success',
+        statusCodeHint: null
+      }
+    case 'timeout':
+      return {
+        family: 'network_timeout',
+        statusClass: 'timeout',
+        label: 'Timeout',
+        statusCodeHint: null
+      }
+    case 'connection_reset':
+      return {
+        family: 'connection_reset',
+        statusClass: 'reset',
+        label: 'Reset',
+        statusCodeHint: null
+      }
+    case 'in-flight':
+      return {
+        family: 'in_flight',
+        statusClass: 'in-flight',
+        label: 'In flight',
+        statusCodeHint: null
+      }
+    case 'rejected':
+      if (reasonCode && Object.hasOwn(CLIENT_ERROR_HINTS, reasonCode)) {
+        return {
+          family: 'client_error_4xx',
+          statusClass: '4xx',
+          label: '4xx reject',
+          statusCodeHint: CLIENT_ERROR_HINTS[reasonCode]
+        }
+      }
+      if (reasonCode && NETWORK_DROP_REASONS.has(reasonCode)) {
+        return {
+          family: 'network_drop',
+          statusClass: 'dropped',
+          label: 'Network drop',
+          statusCodeHint: null
+        }
+      }
+      if (reasonCode && NETWORK_TIMEOUT_REASONS.has(reasonCode)) {
+        return {
+          family: 'network_timeout',
+          statusClass: 'timeout',
+          label: 'Timeout',
+          statusCodeHint: null
+        }
+      }
+      return {
+        family: 'server_error_5xx',
+        statusClass: '5xx',
+        label: '5xx failure',
+        statusCodeHint: (reasonCode && SERVER_ERROR_HINTS[reasonCode]) ?? null
+      }
+  }
+}

--- a/src/engine/core/requestSemantics.test.ts
+++ b/src/engine/core/requestSemantics.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { describeRequestOperation } from './requestSemantics'
+
+describe('describeRequestOperation', () => {
+  it('builds an endpoint-aware operation label when method, host, and path exist', () => {
+    expect(
+      describeRequestOperation({
+        type: 'create-order',
+        metadata: {
+          method: 'POST',
+          host: 'api.internal',
+          path: '/checkout'
+        }
+      })
+    ).toMatchObject({
+      method: 'POST',
+      host: 'api.internal',
+      path: '/checkout',
+      endpointLabel: 'api.internal/checkout',
+      operationLabel: 'POST api.internal/checkout'
+    })
+  })
+
+  it('falls back to the coarse request type when no endpoint metadata exists', () => {
+    expect(describeRequestOperation({ type: 'GET' })).toMatchObject({
+      requestType: 'GET',
+      method: 'GET',
+      operationLabel: 'GET'
+    })
+  })
+})

--- a/src/engine/core/requestSemantics.ts
+++ b/src/engine/core/requestSemantics.ts
@@ -1,0 +1,114 @@
+import type { Request } from './events'
+
+export const HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] as const
+
+export type HttpMethod = (typeof HTTP_METHODS)[number]
+
+export const REQUEST_MATCH_FIELDS = ['type', 'method', 'path', 'host'] as const
+
+export type RequestMatchField = (typeof REQUEST_MATCH_FIELDS)[number]
+
+export interface RequestSemanticsInput {
+  type?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface RequestOperationSummary {
+  requestType: string | null
+  method: string | null
+  host: string | null
+  path: string | null
+  endpointLabel: string | null
+  operationLabel: string
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined
+}
+
+export function inferHttpMethodFromRequestType(
+  requestType: string | undefined
+): HttpMethod | undefined {
+  const normalized = asNonEmptyString(requestType)?.toUpperCase()
+  if (!normalized) {
+    return undefined
+  }
+
+  return (HTTP_METHODS as readonly string[]).includes(normalized)
+    ? (normalized as HttpMethod)
+    : undefined
+}
+
+export function requestFieldValue(
+  request: RequestSemanticsInput,
+  field: RequestMatchField
+): string | undefined {
+  if (field === 'type') {
+    return asNonEmptyString(request.type)
+  }
+
+  if (field === 'method') {
+    const explicitMethod = asNonEmptyString(request.metadata?.method)
+    if (explicitMethod) {
+      return explicitMethod.toUpperCase()
+    }
+
+    return inferHttpMethodFromRequestType(request.type)
+  }
+
+  return asNonEmptyString(request.metadata?.[field])
+}
+
+export function requestFieldMatches(
+  request: RequestSemanticsInput,
+  field: RequestMatchField,
+  expectedValue: string
+): boolean {
+  const actualValue = requestFieldValue(request, field)
+  if (!actualValue) {
+    return false
+  }
+
+  if (field === 'method') {
+    return actualValue === expectedValue.trim().toUpperCase()
+  }
+
+  return actualValue === expectedValue
+}
+
+function joinEndpoint(host: string | null, path: string | null): string | null {
+  if (host && path) return `${host}${path}`
+  return path ?? host
+}
+
+export function describeRequestOperation(
+  request: RequestSemanticsInput | Pick<Request, 'type' | 'metadata'>
+): RequestOperationSummary {
+  const requestType = asNonEmptyString(request.type) ?? null
+  const method = requestFieldValue(request, 'method') ?? null
+  const host = requestFieldValue(request, 'host') ?? null
+  const path = requestFieldValue(request, 'path') ?? null
+  const endpointLabel = joinEndpoint(host, path)
+
+  let operationLabel = requestType ?? endpointLabel ?? 'request'
+  if (method && endpointLabel) {
+    operationLabel = `${method} ${endpointLabel}`
+  } else if (method && requestType && requestType.toUpperCase() !== method) {
+    operationLabel = `${method} · ${requestType}`
+  } else if (method) {
+    operationLabel = method
+  } else if (endpointLabel && requestType) {
+    operationLabel = `${requestType} · ${endpointLabel}`
+  } else if (endpointLabel) {
+    operationLabel = endpointLabel
+  }
+
+  return {
+    requestType,
+    method,
+    host,
+    path,
+    endpointLabel,
+    operationLabel
+  }
+}

--- a/src/engine/engine.test.ts
+++ b/src/engine/engine.test.ts
@@ -198,6 +198,57 @@ describe('SimulationEngine', () => {
     })
   })
 
+  it('least-conn steers traffic away from a congested backend where round-robin would not', () => {
+    const buildTopology = (strategy: string) =>
+      makeTopology({
+        global: {
+          simulationDuration: 2_000,
+          warmupDuration: 0,
+          defaultTimeout: 100_000,
+          traceSampleRate: 0
+        },
+        nodes: [
+          makeNode('source'),
+          makeRouterNode('lb', 'load-balancer', { routingStrategy: strategy }),
+          {
+            ...makeNode('fast'),
+            queue: { workers: 20, capacity: 100, discipline: 'fifo' },
+            processing: { distribution: { type: 'constant', value: 1 }, timeout: 100_000 }
+          },
+          {
+            ...makeNode('slow'),
+            queue: { workers: 1, capacity: 100, discipline: 'fifo' },
+            processing: { distribution: { type: 'constant', value: 20 }, timeout: 100_000 }
+          }
+        ],
+        edges: [
+          makeEdge('source-lb', 'source', 'lb'),
+          makeEdge('lb-fast', 'lb', 'fast'),
+          makeEdge('lb-slow', 'lb', 'slow')
+        ],
+        workload: {
+          sourceNodeId: 'source',
+          pattern: 'constant',
+          baseRps: 200,
+          requestDistribution: [{ type: 'GET', weight: 1, sizeBytes: 100 }]
+        }
+      })
+
+    const leastConn = new SimulationEngine(buildTopology('least-conn')).run()
+    const roundRobin = new SimulationEngine(buildTopology('round-robin')).run()
+
+    const lcFast = leastConn.perNode['fast'].totalArrived
+    const lcSlow = leastConn.perNode['slow'].totalArrived
+    const rrFast = roundRobin.perNode['fast'].totalArrived
+    const rrSlow = roundRobin.perNode['slow'].totalArrived
+
+    // least-conn keeps the congested (high in-flight) backend under-loaded...
+    expect(lcFast).toBeGreaterThan(lcSlow)
+    // ...far more lopsidedly than round-robin, which splits roughly evenly.
+    expect(lcFast / lcSlow).toBeGreaterThan(rrFast / rrSlow)
+    expect(rrFast / rrSlow).toBeLessThan(1.3)
+  })
+
   it('emits rejection events and admission decisions with terminal node snapshots', () => {
     const worker: ComponentNode = {
       ...makeNode('worker'),
@@ -278,10 +329,17 @@ describe('SimulationEngine', () => {
     // Conservation: Σ(rows by status, including in-flight) === generated.
     const summed = Object.values(byStatus).reduce((sum, count) => sum + count, 0)
     expect(summed).toBe(generated)
+    const breakdownSummed = Object.values(output.requestOutcomeBreakdown).reduce(
+      (sum, count) => sum + count,
+      0
+    )
+    expect(breakdownSummed).toBe(output.requestOutcomeTotal)
+    expect(output.requestOutcomeBreakdown.success_2xx).toBe(byStatus.success ?? 0)
 
     // Terminal rows carry a latency and a resolved node; in-flight rows carry neither.
     for (const row of output.requestOutcomes) {
       expect(row.attempts).toBeGreaterThanOrEqual(1)
+      expect(row.operationLabel.length).toBeGreaterThan(0)
       if (row.status === 'in-flight') {
         expect(row.terminalAtMs).toBeNull()
         expect(row.latencyMs).toBeNull()

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -33,6 +33,8 @@ import {
   type Request,
   type SimulationEvent
 } from './core/events'
+import { classifyRequestOutcome, createEmptyRequestOutcomeBreakdown } from './core/requestOutcomeSemantics'
+import { describeRequestOperation } from './core/requestSemantics'
 import { microToMs, msToMicro, secToMicro } from './core/time'
 import { ComponentNode, EdgeDefinition, EventScheduler, TopologyJSON } from './core/types'
 import {
@@ -145,6 +147,7 @@ export class SimulationEngine {
    */
   private readonly retainedRequestOutcomes: RequestOutcomeRecord[] = []
   private requestOutcomeTotal = 0
+  private readonly requestOutcomeBreakdown = createEmptyRequestOutcomeBreakdown()
   private readonly simulationDurationUs: bigint
   private readonly snapshotIntervalUs = secToMicro(1)
 
@@ -1103,7 +1106,7 @@ export class SimulationEngine {
     }
     this.tracer.setPhaseRecord(request.id, request.phaseRecord)
     this.tracer.markStatus(request.id, 'rejected')
-    this.markRequestTerminal(request, 'rejected')
+    this.markRequestTerminal(request, 'rejected', reason)
   }
 
   private handleNodeFailure(event: SimulationEvent): void {
@@ -1220,7 +1223,7 @@ export class SimulationEngine {
     }
     this.tracer.setPhaseRecord(request.id, request.phaseRecord)
     this.tracer.markStatus(request.id, 'connection_reset')
-    this.markRequestTerminal(request, 'connection_reset')
+    this.markRequestTerminal(request, 'connection_reset', 'connection_reset')
   }
 
   private assertAllNodeInvariants(): void {
@@ -1460,19 +1463,35 @@ export class SimulationEngine {
     request.path.push(nodeId)
   }
 
-  private markRequestTerminal(request: Request, status: TerminalRequestStatus): void {
+  private markRequestTerminal(
+    request: Request,
+    status: TerminalRequestStatus,
+    reasonCode?: string | null
+  ): void {
     request.metadata.__terminal = status
     this.markTerminalTombstone(request.id)
     const createdAtMs = microToMs(request.createdAt)
     const terminalAtMs = microToMs(this.clock)
+    const operation = describeRequestOperation(request)
+    const classification = classifyRequestOutcome(status, reasonCode)
+    this.requestOutcomeBreakdown[classification.family]++
     this.retainRequestOutcome({
       requestId: request.id,
       status,
+      reasonCode: reasonCode ?? null,
       createdAtMs,
       terminalAtMs,
       nodeId: request.path.length > 0 ? request.path[request.path.length - 1] : null,
       attempts: (request.retryCount ?? 0) + 1,
-      latencyMs: Math.max(0, terminalAtMs - createdAtMs)
+      latencyMs: Math.max(0, terminalAtMs - createdAtMs),
+      requestType: operation.requestType,
+      method: operation.method,
+      host: operation.host,
+      path: operation.path,
+      operationLabel: operation.operationLabel,
+      outcomeFamily: classification.family,
+      statusClass: classification.statusClass,
+      statusCodeHint: classification.statusCodeHint
     })
     this.requestById.delete(request.id)
   }
@@ -1538,14 +1557,25 @@ export class SimulationEngine {
    */
   private buildRequestOutcomes(): RequestOutcomeRecord[] {
     for (const request of this.requestById.values()) {
+      const operation = describeRequestOperation(request)
+      const classification = classifyRequestOutcome('in-flight')
       this.retainRequestOutcome({
         requestId: request.id,
         status: 'in-flight',
+        reasonCode: null,
         createdAtMs: microToMs(request.createdAt),
         terminalAtMs: null,
         nodeId: request.path.length > 0 ? request.path[request.path.length - 1] : null,
         attempts: (request.retryCount ?? 0) + 1,
-        latencyMs: null
+        latencyMs: null,
+        requestType: operation.requestType,
+        method: operation.method,
+        host: operation.host,
+        path: operation.path,
+        operationLabel: operation.operationLabel,
+        outcomeFamily: classification.family,
+        statusClass: classification.statusClass,
+        statusCodeHint: classification.statusCodeHint
       })
     }
 
@@ -1556,6 +1586,13 @@ export class SimulationEngine {
       if (a.createdAtMs !== b.createdAtMs) return a.createdAtMs - b.createdAtMs
       return a.requestId.localeCompare(b.requestId)
     })
+  }
+
+  private buildRequestOutcomeBreakdown() {
+    return {
+      ...this.requestOutcomeBreakdown,
+      in_flight: this.requestById.size
+    }
   }
 
   private hash32(value: string): number {
@@ -1631,6 +1668,7 @@ export class SimulationEngine {
         statusTimeline: this.buildStatusTimeline(),
         requestOutcomes: this.buildRequestOutcomes(),
         requestOutcomeTotal: this.requestOutcomeTotal,
+        requestOutcomeBreakdown: this.buildRequestOutcomeBreakdown(),
         requestOutcomesSampled: this.requestOutcomeTotal > DEFAULT_MAX_RETAINED_REQUEST_OUTCOMES
       }
     )
@@ -1828,6 +1866,7 @@ export class SimulationEngine {
       clock: this.clock,
       isTargetHealthy: (nodeId) => this.isNodeHealthy(nodeId),
       isEdgeHealthy: (edge) => this.isEdgeHealthy(edge),
+      getInFlight: (nodeId) => this.nodes.get(nodeId)?.getState().totalInSystem ?? 0,
       onTraitDecision: (decision) => {
         this.recordTraitPayloadMetrics(decision.nodeId, decision.payload)
         this.recordTraitDecision(decision.nodeId, request.id, decision.traitName, decision.hook, {

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -33,7 +33,10 @@ import {
   type Request,
   type SimulationEvent
 } from './core/events'
-import { classifyRequestOutcome, createEmptyRequestOutcomeBreakdown } from './core/requestOutcomeSemantics'
+import {
+  classifyRequestOutcome,
+  createEmptyRequestOutcomeBreakdown
+} from './core/requestOutcomeSemantics'
 import { describeRequestOperation } from './core/requestSemantics'
 import { microToMs, msToMicro, secToMicro } from './core/time'
 import { ComponentNode, EdgeDefinition, EventScheduler, TopologyJSON } from './core/types'

--- a/src/engine/routing.test.ts
+++ b/src/engine/routing.test.ts
@@ -159,6 +159,65 @@ describe('RoutingTable', () => {
     expect(picks.map((route) => route.targetNodeId)).toEqual(['a', 'b', 'c', 'a', 'b', 'c'])
   })
 
+  it('least-conn routes to the target with the fewest in-flight requests', () => {
+    const edges = [
+      makeEdge('e1', 'lb', 'a'),
+      makeEdge('e2', 'lb', 'b'),
+      makeEdge('e3', 'lb', 'c')
+    ]
+    const nodes: ComponentNode[] = [
+      { ...makeNode('lb'), config: { routingStrategy: 'least-conn' } }
+    ]
+    const routing = new RoutingTable(edges, createRandom('least-conn'), nodes)
+    const inFlight: Record<string, number> = { a: 5, b: 1, c: 3 }
+
+    const pick = routing.resolveTarget('lb', makeRequest(), {
+      getInFlight: (nodeId) => inFlight[nodeId] ?? 0
+    })[0]
+
+    expect(pick.targetNodeId).toBe('b')
+  })
+
+  it('least-conn breaks ties by rotating through the tied targets', () => {
+    const edges = [
+      makeEdge('e1', 'lb', 'a'),
+      makeEdge('e2', 'lb', 'b'),
+      makeEdge('e3', 'lb', 'c')
+    ]
+    const nodes: ComponentNode[] = [
+      { ...makeNode('lb'), config: { routingStrategy: 'least-conn' } }
+    ]
+    const routing = new RoutingTable(edges, createRandom('least-conn-tie'), nodes)
+    // a and c are tied for the minimum; b is heavier and never chosen.
+    const inFlight: Record<string, number> = { a: 2, b: 9, c: 2 }
+    const getInFlight = (nodeId: string) => inFlight[nodeId] ?? 0
+
+    const picks = Array.from(
+      { length: 4 },
+      () => routing.resolveTarget('lb', makeRequest(), { getInFlight })[0].targetNodeId
+    )
+
+    expect(picks).toEqual(['a', 'c', 'a', 'c'])
+  })
+
+  it('passthrough forwards to the first eligible target without balancing', () => {
+    const edges = [
+      makeEdge('e1', 'proxy', 'a'),
+      makeEdge('e2', 'proxy', 'b'),
+      makeEdge('e3', 'proxy', 'c')
+    ]
+    const nodes: ComponentNode[] = [
+      { ...makeNode('proxy'), config: { routingStrategy: 'passthrough' } }
+    ]
+    const routing = new RoutingTable(edges, createRandom('passthrough'), nodes)
+    const picks = Array.from(
+      { length: 5 },
+      () => routing.resolveTarget('proxy', makeRequest())[0].targetNodeId
+    )
+
+    expect(picks).toEqual(['a', 'a', 'a', 'a', 'a'])
+  })
+
   it('plain services do not round-robin just because their id looks like a load balancer', () => {
     const edges = [
       makeEdge('e1', 'lb-ish-thing', 'a'),

--- a/src/engine/routing.test.ts
+++ b/src/engine/routing.test.ts
@@ -160,11 +160,7 @@ describe('RoutingTable', () => {
   })
 
   it('least-conn routes to the target with the fewest in-flight requests', () => {
-    const edges = [
-      makeEdge('e1', 'lb', 'a'),
-      makeEdge('e2', 'lb', 'b'),
-      makeEdge('e3', 'lb', 'c')
-    ]
+    const edges = [makeEdge('e1', 'lb', 'a'), makeEdge('e2', 'lb', 'b'), makeEdge('e3', 'lb', 'c')]
     const nodes: ComponentNode[] = [
       { ...makeNode('lb'), config: { routingStrategy: 'least-conn' } }
     ]
@@ -179,11 +175,7 @@ describe('RoutingTable', () => {
   })
 
   it('least-conn breaks ties by rotating through the tied targets', () => {
-    const edges = [
-      makeEdge('e1', 'lb', 'a'),
-      makeEdge('e2', 'lb', 'b'),
-      makeEdge('e3', 'lb', 'c')
-    ]
+    const edges = [makeEdge('e1', 'lb', 'a'), makeEdge('e2', 'lb', 'b'), makeEdge('e3', 'lb', 'c')]
     const nodes: ComponentNode[] = [
       { ...makeNode('lb'), config: { routingStrategy: 'least-conn' } }
     ]

--- a/src/engine/routing.ts
+++ b/src/engine/routing.ts
@@ -30,6 +30,12 @@ export interface ResolveTargetOptions {
   clock?: bigint
   isTargetHealthy?: (nodeId: string) => boolean
   isEdgeHealthy?: (edge: EdgeDefinition) => boolean
+  /**
+   * Live in-flight (queued + in-service) count for a target node, used by the
+   * `least-conn` strategy. The engine supplies this from each node's runtime
+   * state; when absent, least-conn degrades to round-robin so it still spreads.
+   */
+  getInFlight?: (nodeId: string) => number
   onTraitDecision?: (decision: {
     traitName: string
     nodeId: string
@@ -61,10 +67,17 @@ export class RoutingTable {
   private readonly roundRobinIndexBySource = new Map<string, number>()
 
   /**
-   * Set of node IDs that should use round-robin routing, derived from node
-   * config metadata. Only populated when node definitions are provided.
+   * Per-source rotating cursor used to break ties in `least-conn` when several
+   * targets share the smallest in-flight count, mirroring the routing preview.
    */
-  private readonly roundRobinSourceIds: Set<string>
+  private readonly leastConnTieIndexBySource = new Map<string, number>()
+
+  /**
+   * Effective routing strategy per source node, resolved once from explicit
+   * config (`routingStrategy`) with a trait hint fallback. Drives `pickSyncRoute`
+   * so the selector the user picks is what the engine actually runs.
+   */
+  private readonly strategyBySourceId = new Map<string, string>()
   private readonly nodeById = new Map<string, ComponentNode>()
   private readonly traitsBySourceId = new Map<string, readonly NodeBehaviourTrait[]>()
   private readonly traitStateBySourceId = new Map<string, Map<string, unknown>>()
@@ -101,17 +114,16 @@ export class RoutingTable {
       }
     }
 
-    this.roundRobinSourceIds = new Set(
-      nodes
-        .filter(
-          (node) =>
-            node.config?.['routingStrategy'] === 'round-robin' ||
-            (this.traitsBySourceId.get(node.id) ?? []).some(
-              (trait) => trait.routingStrategyHint === 'round-robin'
-            )
-        )
-        .map((node) => node.id)
-    )
+    for (const node of nodes) {
+      const configured = node.config?.['routingStrategy']
+      const traitHint = (this.traitsBySourceId.get(node.id) ?? []).find(
+        (trait) => trait.routingStrategyHint !== undefined
+      )?.routingStrategyHint
+      const strategy = typeof configured === 'string' ? configured : traitHint
+      if (strategy) {
+        this.strategyBySourceId.set(node.id, strategy)
+      }
+    }
   }
 
   /**
@@ -182,7 +194,7 @@ export class RoutingTable {
     if (syncRoutes.length === 1) {
       results.push(syncRoutes[0])
     } else if (syncRoutes.length > 1) {
-      results.push(this.pickSyncRoute(sourceNodeId, syncRoutes))
+      results.push(this.pickSyncRoute(sourceNodeId, syncRoutes, options.getInFlight))
     }
 
     results.push(...asyncRoutes)
@@ -191,23 +203,70 @@ export class RoutingTable {
   }
 
   /**
-   * Selects one edge from synchronous candidates using round-robin,
-   * weighted, or uniform random strategy.
+   * Selects one edge from synchronous candidates. The node's configured routing
+   * strategy is authoritative: whatever the user picks (and the preview animates)
+   * is what runs here. A source with no explicit strategy honours edge weights
+   * when present and otherwise spreads uniformly at random.
    */
-  private pickSyncRoute(sourceNodeId: string, routes: ResolveRoute[]): ResolveRoute {
-    if (this.isRoundRobinSource(sourceNodeId)) {
-      const current = this.roundRobinIndexBySource.get(sourceNodeId) ?? 0
-      const safeIndex = current % routes.length
-      const route = routes[safeIndex]
-      this.roundRobinIndexBySource.set(sourceNodeId, (safeIndex + 1) % routes.length)
-      return route
+  private pickSyncRoute(
+    sourceNodeId: string,
+    routes: ResolveRoute[],
+    getInFlight?: (nodeId: string) => number
+  ): ResolveRoute {
+    switch (this.strategyBySourceId.get(sourceNodeId)) {
+      case 'round-robin':
+        return this.pickRoundRobin(sourceNodeId, routes)
+      case 'least-conn':
+        return this.pickLeastConnected(sourceNodeId, routes, getInFlight)
+      case 'weighted':
+        return this.pickByWeight(routes)
+      case 'passthrough':
+        // No balancing: forward to the first eligible target, matching the preview.
+        return routes[0]
+      case 'random':
+        return routes[this.rng.integer(0, routes.length - 1)]
+      default:
+        if (routes.some((route) => route.edge.weight !== undefined)) {
+          return this.pickByWeight(routes)
+        }
+        return routes[this.rng.integer(0, routes.length - 1)]
+    }
+  }
+
+  private pickRoundRobin(sourceNodeId: string, routes: ResolveRoute[]): ResolveRoute {
+    const current = this.roundRobinIndexBySource.get(sourceNodeId) ?? 0
+    const safeIndex = current % routes.length
+    const route = routes[safeIndex]
+    this.roundRobinIndexBySource.set(sourceNodeId, (safeIndex + 1) % routes.length)
+    return route
+  }
+
+  /**
+   * Picks the candidate whose target currently has the fewest in-flight requests.
+   * Ties rotate through the tied set via a per-source cursor, matching the routing
+   * preview's tie-break. Without a live in-flight signal, degrades to round-robin.
+   */
+  private pickLeastConnected(
+    sourceNodeId: string,
+    routes: ResolveRoute[],
+    getInFlight?: (nodeId: string) => number
+  ): ResolveRoute {
+    if (!getInFlight) {
+      return this.pickRoundRobin(sourceNodeId, routes)
     }
 
-    if (routes.some((route) => route.edge.weight !== undefined)) {
-      return this.pickByWeight(routes)
+    const loads = routes.map((route) => getInFlight(route.targetNodeId))
+    const minLoad = Math.min(...loads)
+    const tied = routes.filter((_, index) => loads[index] === minLoad)
+
+    if (tied.length === 1) {
+      return tied[0]
     }
 
-    return routes[this.rng.integer(0, routes.length - 1)]
+    const tieIndex = this.leastConnTieIndexBySource.get(sourceNodeId) ?? 0
+    const chosen = tied[tieIndex % tied.length]
+    this.leastConnTieIndexBySource.set(sourceNodeId, (tieIndex + 1) % tied.length)
+    return chosen
   }
 
   /**
@@ -308,14 +367,6 @@ export class RoutingTable {
     }
 
     return routes[routes.length - 1]
-  }
-
-  /**
-   * Returns true if the source node should use round-robin routing.
-   * Resolution is driven by explicit node config and type-derived trait hints.
-   */
-  private isRoundRobinSource(sourceNodeId: string): boolean {
-    return this.roundRobinSourceIds.has(sourceNodeId)
   }
 
   private getTraitStateStore(sourceNodeId: string): TraitStateStore {

--- a/src/engine/traits/capabilityModules.ts
+++ b/src/engine/traits/capabilityModules.ts
@@ -198,6 +198,20 @@ const SOURCE_WORKLOAD_MODULE: NodeCapabilityModule = {
         ]
       },
       {
+        id: 'request-templates',
+        title: 'Request Templates',
+        fields: [
+          {
+            path: 'source.requestDistribution',
+            type: 'input',
+            label: 'Requests',
+            renderer: 'request-distribution',
+            inputType: 'text',
+            why: 'Defines the mix of operations this source emits. Type is the coarse request class; method, host, and path add HTTP-aware routing context.'
+          }
+        ]
+      },
+      {
         id: 'pattern',
         title: 'Pattern',
         fields: [
@@ -300,6 +314,50 @@ const ROUTING_STRATEGY_MODULE: NodeCapabilityModule = {
   honesty: {
     simulates: ['route selection strategy at the node level'],
     notModeled: ['per-connection stickiness, protocol-specific balancing heuristics']
+  }
+}
+
+const COMPOSITE_LOCATION_MODULE: NodeCapabilityModule = {
+  name: 'composite.location',
+  appliesWhen: (data) => data.profile === 'composite',
+  config: {
+    sections: [
+      {
+        id: 'location',
+        title: 'Location',
+        note: 'Grouping container — not simulated as a node. It shapes edge latency by where nodes sit: same subnet → same-rack, same AZ → same-dc, same region → cross-zone, different region → cross-region. This only fills an edge’s default latency; a latency set on an edge manually is kept. This field is descriptive metadata for labels/export and renderer-side location rollups; latency math uses containment, not this text. (AZ fault-domain failure and distance-aware cross-region latency are not modeled yet.)',
+        noteTone: 'info',
+        fields: [
+          {
+            path: 'sim.locationId',
+            type: 'input',
+            inputType: 'text',
+            label: (data) =>
+              data.templateId === 'vpc-region'
+                ? 'Region ID'
+                : data.templateId === 'availability-zone'
+                  ? 'AZ ID'
+                  : 'Subnet / CIDR',
+            placeholder: (data) =>
+              data.templateId === 'vpc-region'
+                ? 'e.g. us-east-1'
+                : data.templateId === 'availability-zone'
+                  ? 'e.g. us-east-1a'
+                  : 'e.g. 10.0.1.0/24',
+            why: 'A human label for this boundary. Today it is metadata only; the latency math uses which container a node sits in, not this text.'
+          }
+        ]
+      }
+    ]
+  },
+  defaults: [],
+  honesty: {
+    simulates: ['groups nodes so cross-boundary edge latency can be derived'],
+    notModeled: [
+      'fault-domain failure',
+      'distance-aware cross-region latency',
+      'IP/CIDR validation'
+    ]
   }
 }
 
@@ -580,6 +638,103 @@ const SERVICE_REGISTRY_HONESTY_MODULE: NodeCapabilityModule = {
   }
 }
 
+/**
+ * Builds a config-only "Model" section that states plainly how a node is
+ * simulated versus what its name implies but the engine does not yet model.
+ * These nodes currently fall back to the generic queue/processing model, so the
+ * note prevents the UI from over-promising specialised behaviour that isn't there
+ * (mirroring SERVICE_REGISTRY_HONESTY_MODULE). Adds no engine behaviour.
+ */
+function honestyNoteModule(
+  name: string,
+  types: readonly ComponentType[],
+  note: string,
+  notModeled: readonly string[],
+  simulates: readonly string[] = ['generic request queue behavior only']
+): NodeCapabilityModule {
+  return {
+    name,
+    appliesTo: types,
+    config: {
+      sections: [{ id: 'model', title: 'Model', fields: [], note, noteTone: 'info' }]
+    },
+    defaults: [],
+    honesty: { simulates, notModeled }
+  }
+}
+
+const STREAMING_BROKER_HONESTY_MODULE = honestyNoteModule(
+  'streaming-broker.honesty',
+  ['message-broker', 'pub-sub'],
+  'Broadcast fan-out to every subscriber is modeled, along with concurrency, queueing, and latency. Not yet modeled: partitions, message ordering, consumer groups, or consumer lag. For a backlog/lag model, use the Event Stream node instead.',
+  ['partitions', 'message ordering', 'consumer groups', 'consumer lag'],
+  ['broadcast fan-out plus generic queueing and latency']
+)
+
+const OBSERVABILITY_SINK_HONESTY_MODULE = honestyNoteModule(
+  'observability-sink.honesty',
+  ['metrics-store', 'centralized-logging', 'distributed-tracing', 'alerting-hook'],
+  'Currently simulates as a synchronous request queue: concurrency, queueing, and latency. Not yet modeled: asynchronous fire-and-forget ingestion, sampling, batching, or retention. Because it is synchronous here, a saturated collector can back-pressure its caller, which a real telemetry pipeline usually would not.',
+  ['async fire-and-forget ingestion', 'sampling', 'batching', 'retention']
+)
+
+const NETWORK_GATEWAY_HONESTY_MODULE = honestyNoteModule(
+  'network-gateway.honesty',
+  ['nat-gateway', 'vpn-gateway'],
+  'Currently simulates as a generic router: concurrency, queueing, and latency. Not yet modeled: connection/port-table limits, NAT translation cost, or tunnel/encryption overhead.',
+  ['connection/port-table limits', 'NAT translation cost', 'tunnel/encryption overhead']
+)
+
+const HEALTH_CHECK_MANAGER_HONESTY_MODULE = honestyNoteModule(
+  'health-check-manager.honesty',
+  ['health-check-manager'],
+  'Currently simulates as a generic request queue: concurrency, queueing, and latency. Not yet modeled: active health probing, node health-state transitions, or removing unhealthy targets from rotation.',
+  ['active health probing', 'health-state transitions', 'removing unhealthy targets']
+)
+
+const LLM_GATEWAY_HONESTY_MODULE = honestyNoteModule(
+  'llm-gateway.honesty',
+  ['llm-gateway'],
+  'Currently simulates as a generic request queue: concurrency, queueing, and latency. Not yet modeled: token-based latency and cost, prompt/response sizing, model or provider routing, or provider rate limits.',
+  ['token-based latency and cost', 'model/provider routing', 'provider rate limits']
+)
+
+const AGENT_INFRA_HONESTY_MODULES: readonly NodeCapabilityModule[] = [
+  honestyNoteModule(
+    'agent-orchestrator.honesty',
+    ['agent-orchestrator'],
+    'Currently simulates as a generic request queue: concurrency, queueing, and latency. Not yet modeled: agent planning/tool-calling loops, multi-step orchestration, or fan-out to tools and models.',
+    ['agent planning/tool-calling loops', 'multi-step orchestration', 'tool/model fan-out']
+  ),
+  honestyNoteModule(
+    'memory-fabric.honesty',
+    ['memory-fabric'],
+    'Currently simulates as a generic request queue: concurrency, queueing, and latency. Not yet modeled: vector/semantic retrieval cost, recall vs. write paths, or eviction.',
+    ['vector/semantic retrieval cost', 'recall vs. write paths', 'eviction']
+  ),
+  honestyNoteModule(
+    'tool-registry.honesty',
+    ['tool-registry'],
+    'Currently simulates as a generic request queue: concurrency, queueing, and latency. Not yet modeled: tool discovery/registration, capability lookup, or per-tool latency.',
+    ['tool discovery/registration', 'capability lookup', 'per-tool latency']
+  ),
+  honestyNoteModule(
+    'safety-observability-mesh.honesty',
+    ['safety-observability-mesh'],
+    'Currently simulates as a generic request queue: concurrency, queueing, and latency. Not yet modeled: safety-policy or guardrail evaluation, blocking decisions, or trace/telemetry emission.',
+    ['safety-policy/guardrail evaluation', 'blocking decisions', 'trace/telemetry emission']
+  )
+]
+
+const NODE_HONESTY_MODULES: readonly NodeCapabilityModule[] = [
+  STREAMING_BROKER_HONESTY_MODULE,
+  OBSERVABILITY_SINK_HONESTY_MODULE,
+  NETWORK_GATEWAY_HONESTY_MODULE,
+  HEALTH_CHECK_MANAGER_HONESTY_MODULE,
+  LLM_GATEWAY_HONESTY_MODULE,
+  ...AGENT_INFRA_HONESTY_MODULES
+]
+
 export const TRAIT_CAPABILITY_MODULES: readonly NodeCapabilityModule[] = [
   rateLimiterCapabilityModule,
   contentRoutingCapabilityModule,
@@ -598,13 +753,15 @@ export const TRAIT_CAPABILITY_MODULES: readonly NodeCapabilityModule[] = [
 export const NODE_CONFIG_MODULES: readonly NodeCapabilityModule[] = [
   SOURCE_WORKLOAD_MODULE,
   ROUTING_STRATEGY_MODULE,
+  COMPOSITE_LOCATION_MODULE,
   ...TRAIT_CAPABILITY_MODULES,
   BASE_QUEUE_MODULE,
   PROCESSING_MODULE,
   SECURITY_POLICY_MODULE,
   CHAOS_MODULE,
   SLO_MODULE,
-  SERVICE_REGISTRY_HONESTY_MODULE
+  SERVICE_REGISTRY_HONESTY_MODULE,
+  ...NODE_HONESTY_MODULES
 ]
 
 function moduleIncludesComponentType(

--- a/src/engine/traits/contentRouting.test.ts
+++ b/src/engine/traits/contentRouting.test.ts
@@ -135,4 +135,33 @@ describe('contentRoutingTrait', () => {
       routes: [expect.objectContaining({ targetNodeId: 'api-svc' })]
     })
   })
+
+  it('matches on method using explicit metadata or legacy request types', () => {
+    const explicitMethodResult = contentRoutingTrait.filterRoutes?.({
+      node: makeGatewayNode({
+        routingRules: [{ matchField: 'method', matchValue: 'POST', targetNodeId: 'write-svc' }]
+      }),
+      request: makeRequest({ type: 'create-order', metadata: { method: 'post' } }),
+      clock: 0n,
+      candidates: [makeRoute('write-svc'), makeRoute('read-svc')]
+    })
+
+    const legacyTypeResult = contentRoutingTrait.filterRoutes?.({
+      node: makeGatewayNode({
+        routingRules: [{ matchField: 'method', matchValue: 'GET', targetNodeId: 'read-svc' }]
+      }),
+      request: makeRequest({ type: 'GET' }),
+      clock: 0n,
+      candidates: [makeRoute('write-svc'), makeRoute('read-svc')]
+    })
+
+    expect(explicitMethodResult).toMatchObject({
+      decision: 'content-routed',
+      routes: [expect.objectContaining({ targetNodeId: 'write-svc' })]
+    })
+    expect(legacyTypeResult).toMatchObject({
+      decision: 'content-routed',
+      routes: [expect.objectContaining({ targetNodeId: 'read-svc' })]
+    })
+  })
 })

--- a/src/engine/traits/contentRouting.ts
+++ b/src/engine/traits/contentRouting.ts
@@ -4,7 +4,6 @@ import {
   type RequestMatchField
 } from '../core/requestSemantics'
 import type { ComponentType } from '../core/types'
-import type { TraitContext } from './types'
 import type { NodeBehaviourTrait, NodeCapabilityModule } from './types'
 
 export const CONTENT_ROUTING_COMPONENT_TYPES = [

--- a/src/engine/traits/contentRouting.ts
+++ b/src/engine/traits/contentRouting.ts
@@ -1,3 +1,8 @@
+import {
+  REQUEST_MATCH_FIELDS,
+  requestFieldMatches,
+  type RequestMatchField
+} from '../core/requestSemantics'
 import type { ComponentType } from '../core/types'
 import type { TraitContext } from './types'
 import type { NodeBehaviourTrait, NodeCapabilityModule } from './types'
@@ -8,15 +13,15 @@ export const CONTENT_ROUTING_COMPONENT_TYPES = [
   'ingress-controller'
 ] as const satisfies readonly ComponentType[]
 
-export type ContentRoutingMatchField = 'type' | 'path' | 'host'
+export const CONTENT_ROUTING_MATCH_FIELDS = REQUEST_MATCH_FIELDS
+
+export type ContentRoutingMatchField = RequestMatchField
 
 export interface ContentRoutingRule {
   matchField: ContentRoutingMatchField
   matchValue: string
   targetNodeId: string
 }
-
-const MATCH_FIELDS: readonly ContentRoutingMatchField[] = ['type', 'path', 'host']
 
 export const L4_CONTENT_ROUTING_FORBIDDEN_MESSAGE =
   'L4 operates at the transport layer and cannot inspect HTTP content. Use an L7 Load Balancer for content-based routing.'
@@ -28,7 +33,7 @@ function isContentRoutingRule(value: unknown): value is ContentRoutingRule {
   const rule = value as Partial<ContentRoutingRule>
   return (
     typeof rule.matchField === 'string' &&
-    (MATCH_FIELDS as readonly string[]).includes(rule.matchField) &&
+    (CONTENT_ROUTING_MATCH_FIELDS as readonly string[]).includes(rule.matchField) &&
     typeof rule.matchValue === 'string' &&
     rule.matchValue.length > 0 &&
     typeof rule.targetNodeId === 'string' &&
@@ -43,17 +48,6 @@ export function parseRoutingRules(value: unknown): ContentRoutingRule[] {
   return value.filter(isContentRoutingRule)
 }
 
-function fieldValue(
-  request: TraitContext['request'],
-  field: ContentRoutingMatchField
-): string | undefined {
-  if (field === 'type') {
-    return request.type
-  }
-  const raw = request.metadata?.[field]
-  return typeof raw === 'string' ? raw : undefined
-}
-
 export const contentRoutingTrait: NodeBehaviourTrait = {
   name: 'routing.content',
   filterRoutes: ({ node, request, candidates }) => {
@@ -62,8 +56,8 @@ export const contentRoutingTrait: NodeBehaviourTrait = {
       return { routes: candidates, decision: 'no-rules-configured' }
     }
 
-    const matchedRule = rules.find(
-      (rule) => fieldValue(request, rule.matchField) === rule.matchValue
+    const matchedRule = rules.find((rule) =>
+      requestFieldMatches(request, rule.matchField, rule.matchValue)
     )
     if (!matchedRule) {
       return { routes: candidates, decision: 'no-rule-matched' }
@@ -125,7 +119,7 @@ export const contentRoutingCapabilityModule: NodeCapabilityModule = {
   },
   defaults: [],
   honesty: {
-    simulates: ['request matching by type, path, or host'],
+    simulates: ['request matching by type, method, path, or host'],
     notModeled: ['header transforms, regex matching, SSL termination overhead']
   }
 }

--- a/src/engine/traits/keyBasedRouting.ts
+++ b/src/engine/traits/keyBasedRouting.ts
@@ -67,6 +67,7 @@ export const keyBasedRoutingCapabilityModule: NodeCapabilityModule = {
           {
             path: 'sim.routingKeyField',
             type: 'input',
+            inputType: 'text',
             label: 'Routing key field',
             placeholder: DEFAULT_ROUTING_KEY_FIELD,
             why: 'Reads the shard key from request metadata so the same key lands on the same shard.'

--- a/src/engine/traits/types.ts
+++ b/src/engine/traits/types.ts
@@ -10,7 +10,12 @@ export type FieldPath = string
 export type AccuracyClass = 'invariant' | 'default-override' | 'user-parameter' | 'not-simulated'
 export type ConfigAltitude = 'primary' | 'advanced'
 export type ConfigNoteTone = 'info' | 'locked'
-export type ConfigCustomRenderer = 'default' | 'routing-rules' | 'health-preset'
+export type ConfigCustomRenderer =
+  | 'default'
+  | 'routing-rules'
+  | 'health-preset'
+  | 'request-distribution'
+export type ConfigInputType = 'number' | 'text'
 
 export interface ConfigDisplayTransform {
   toDisplay: (rawValue: unknown, data: CanvasNodeDataV2) => unknown
@@ -44,6 +49,7 @@ export type ConfigField =
   | (ConfigFieldBase & {
       type: 'input'
       step?: number
+      inputType?: ConfigInputType
     })
   | (ConfigFieldBase & {
       type: 'boolean'

--- a/src/engine/validation/validator.test.ts
+++ b/src/engine/validation/validator.test.ts
@@ -460,7 +460,7 @@ describe('validateTopology node config validation', () => {
       category: 'network-and-edge',
       role: 'router',
       config: {
-        routingRules: [{ matchField: 'type', matchValue: 'write', targetNodeId: 'service' }]
+        routingRules: [{ matchField: 'method', matchValue: 'POST', targetNodeId: 'service' }]
       }
     }
     const service = makeProcessorNode('service', 'Service')
@@ -514,7 +514,17 @@ describe('validateTopology advanced trait validation', () => {
     topology.workload = {
       ...topology.workload!,
       requestDistribution: [
-        { type: 'lookup', weight: 1, sizeBytes: 256, metadata: { shardKey: 'tenant-a' } }
+        {
+          type: 'lookup',
+          weight: 1,
+          sizeBytes: 256,
+          metadata: {
+            shardKey: 'tenant-a',
+            method: 'GET',
+            host: 'api.internal',
+            path: '/lookup'
+          }
+        }
       ]
     }
 
@@ -522,7 +532,10 @@ describe('validateTopology advanced trait validation', () => {
 
     expect(result.valid).toBe(true)
     expect(result.data?.workload?.requestDistribution[0]?.metadata).toEqual({
-      shardKey: 'tenant-a'
+      shardKey: 'tenant-a',
+      method: 'GET',
+      host: 'api.internal',
+      path: '/lookup'
     })
   })
 

--- a/src/engine/validation/validator.ts
+++ b/src/engine/validation/validator.ts
@@ -7,7 +7,10 @@ import type {
 } from '../core/types'
 import { inferStructuralRole } from '../catalog/componentSpecs'
 import { validateEdgeConstraintSelection } from '../defaults/edgeConstraints'
-import { L4_CONTENT_ROUTING_FORBIDDEN_MESSAGE } from '../traits/contentRouting'
+import {
+  CONTENT_ROUTING_MATCH_FIELDS,
+  L4_CONTENT_ROUTING_FORBIDDEN_MESSAGE
+} from '../traits/contentRouting'
 import { asDistributionConfig } from '../traits/serviceTimeOverride'
 
 const COMPONENT_CATEGORIES = [
@@ -997,10 +1000,14 @@ export const validateTopology = (input: unknown): ValidationResult => {
             matchValue: unknown
             targetNodeId: unknown
           }>
-          if (!['type', 'path', 'host'].includes(candidate?.matchField as string)) {
+          if (
+            !(CONTENT_ROUTING_MATCH_FIELDS as readonly string[]).includes(
+              candidate?.matchField as string
+            )
+          ) {
             errors.push({
               path: `nodes[${index}].config.routingRules[${ruleIndex}].matchField`,
-              message: 'matchField must be one of "type", "path", "host".'
+              message: `matchField must be one of ${CONTENT_ROUTING_MATCH_FIELDS.map((field) => `"${field}"`).join(', ')}.`
             })
           }
           if (typeof candidate?.matchValue !== 'string' || candidate.matchValue.length === 0) {

--- a/src/renderer/src/components/canvas/hooks/useFlowDnD.ts
+++ b/src/renderer/src/components/canvas/hooks/useFlowDnD.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
-import { ReactFlowInstance, NodeDragHandler, Node, useReactFlow } from 'reactflow'
-import { findTargetVpc, getId } from '../utils/canvasUtils'
+import { ReactFlowInstance, NodeDragHandler, Node } from 'reactflow'
+import { findTargetVpc, getId, recomputeContainment } from '../utils/canvasUtils'
 import { instantiateTemplate } from '../../../../../engine/catalog/paletteTemplates'
 
 interface UseFlowDnDProps {
@@ -11,8 +11,6 @@ interface UseFlowDnDProps {
 }
 
 export const useFlowDnD = ({ nodes, addNode, setNodes, instance }: UseFlowDnDProps) => {
-  const { getIntersectingNodes } = useReactFlow()
-
   // 1. Drag Over
   const onDragOver = useCallback((event: React.DragEvent) => {
     event.preventDefault()
@@ -57,55 +55,21 @@ export const useFlowDnD = ({ nodes, addNode, setNodes, instance }: UseFlowDnDPro
     [instance, addNode, nodes]
   )
 
-  // 3. Drag Stop (Re-parenting / Nesting Logic)
+  // 3. Drag Stop — re-derive containment from geometry (center-inside).
+  // Works whether the user dragged a node INTO a container or dragged a
+  // container OVER existing nodes, and releases nodes whose center leaves their
+  // container. Runs over the whole graph so nesting stays consistent.
   const onNodeDragStop: NodeDragHandler = useCallback(
     (_, node) => {
-      // Find intersections using React Flow's helper, then filter for VPCs
-      const intersections = getIntersectingNodes(node).filter(
-        (n) => n.type === 'vpcNode' && n.id !== node.id
+      const withDraggedPosition = nodes.map((n) =>
+        n.id === node.id ? { ...n, position: node.position, parentNode: node.parentNode } : n
       )
-
-      // Manual sort since getIntersectingNodes doesn't guarantee order
-      intersections.sort((a, b) => {
-        const areaA = (a.width || 0) * (a.height || 0)
-        const areaB = (b.width || 0) * (b.height || 0)
-        return areaA - areaB
-      })
-
-      const targetVpc = intersections[0]
-
-      // Scenario A: Attach to Parent
-      if (targetVpc) {
-        // Prevent cycles
-        if (node.id === targetVpc.parentNode) return
-        // Prevent redundant updates
-        if (node.parentNode === targetVpc.id) return
-
-        const relativePosition = {
-          x: node.position.x - targetVpc.position.x,
-          y: node.position.y - targetVpc.position.y
-        }
-
-        setNodes(
-          nodes.map((n) =>
-            n.id === node.id
-              ? {
-                  ...n,
-                  parentNode: targetVpc.id,
-                  position: relativePosition,
-                  extent: 'parent',
-                  expandParent: false,
-                  zIndex: 10
-                }
-              : n
-          )
-        )
+      const recomputed = recomputeContainment(withDraggedPosition)
+      if (recomputed !== withDraggedPosition) {
+        setNodes(recomputed)
       }
-
-      // Scenario B: Detach is handled by Ungroup Button (Toolbar)
-      // We purposefully don't auto-detach on drag to prevent accidental removals.
     },
-    [nodes, setNodes, getIntersectingNodes]
+    [nodes, setNodes]
   )
 
   return { onDragOver, onDrop, onNodeDragStop }

--- a/src/renderer/src/components/canvas/utils/canvasUtils.test.ts
+++ b/src/renderer/src/components/canvas/utils/canvasUtils.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import type { Node } from 'reactflow'
+import { recomputeContainment } from './canvasUtils'
+
+function container(id: string, x: number, y: number, size: number, parentNode?: string): Node {
+  return {
+    id,
+    type: 'vpcNode',
+    position: { x, y },
+    width: size,
+    height: size,
+    parentNode,
+    data: {}
+  }
+}
+
+function box(id: string, x: number, y: number, parentNode?: string): Node {
+  return {
+    id,
+    type: 'serviceNode',
+    position: { x, y },
+    width: 40,
+    height: 40,
+    parentNode,
+    data: {}
+  }
+}
+
+describe('recomputeContainment (center-inside)', () => {
+  it('captures a node whose center falls inside a container', () => {
+    const nodes = [container('vpc', 0, 0, 300), box('n', 140, 140)] // center (160,160) is inside
+    const result = recomputeContainment(nodes)
+    const n = result.find((x) => x.id === 'n')!
+    expect(n.parentNode).toBe('vpc')
+    // position becomes relative to the container
+    expect(n.position).toEqual({ x: 140, y: 140 })
+  })
+
+  it('does not capture a node whose center is outside the container', () => {
+    const nodes = [container('vpc', 0, 0, 100), box('n', 400, 400)]
+    const result = recomputeContainment(nodes)
+    expect(result.find((x) => x.id === 'n')!.parentNode).toBeUndefined()
+    // unchanged input returns the same reference
+    expect(result).toBe(nodes)
+  })
+
+  it('releases a child whose center has been dragged outside its container', () => {
+    // child stored relative to a 300x300 container but positioned far outside it
+    const nodes = [container('vpc', 0, 0, 300), box('n', 900, 900, 'vpc')]
+    const result = recomputeContainment(nodes)
+    const n = result.find((x) => x.id === 'n')!
+    expect(n.parentNode).toBeUndefined()
+    // released back to absolute coordinates
+    expect(n.position).toEqual({ x: 900, y: 900 })
+  })
+
+  it('picks the deepest (smallest) container when nested', () => {
+    const nodes = [
+      container('region', 0, 0, 400),
+      container('az', 50, 50, 200, 'region'), // abs bounds (50,50)-(250,250)
+      box('n', 100, 100) // center (120,120) inside both; az is smaller
+    ]
+    const result = recomputeContainment(nodes)
+    const n = result.find((x) => x.id === 'n')!
+    expect(n.parentNode).toBe('az')
+    expect(n.position).toEqual({ x: 50, y: 50 })
+  })
+
+  it('never parents a container into its own descendant (no cycle)', () => {
+    // az currently inside region; even if geometry overlaps, region must not become az's child
+    const nodes = [
+      container('region', 0, 0, 400),
+      container('az', 0, 0, 400, 'region') // same bounds as region
+    ]
+    const result = recomputeContainment(nodes)
+    expect(result.find((x) => x.id === 'region')!.parentNode).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/canvas/utils/canvasUtils.ts
+++ b/src/renderer/src/components/canvas/utils/canvasUtils.ts
@@ -4,6 +4,114 @@ let id = 1
 export const getId = () => `node_${id++}`
 
 /**
+ * Resolves a node's absolute (world) position by walking its parent chain and
+ * accumulating each ancestor's offset. React Flow stores child positions
+ * relative to their parent, so containment maths must be done in world space.
+ */
+function absolutePosition(node: Node, byId: Map<string, Node>): XYPosition {
+  let { x, y } = node.position
+  let parentId = node.parentNode
+  const seen = new Set<string>()
+  while (parentId && !seen.has(parentId)) {
+    seen.add(parentId)
+    const parent = byId.get(parentId)
+    if (!parent) break
+    x += parent.position.x
+    y += parent.position.y
+    parentId = parent.parentNode
+  }
+  return { x, y }
+}
+
+/** Ids of every node nested (transitively) under `rootId`. */
+function descendantIds(rootId: string, nodes: Node[]): Set<string> {
+  const childrenByParent = new Map<string, string[]>()
+  for (const node of nodes) {
+    if (!node.parentNode) continue
+    const list = childrenByParent.get(node.parentNode)
+    if (list) list.push(node.id)
+    else childrenByParent.set(node.parentNode, [node.id])
+  }
+  const out = new Set<string>()
+  const stack = [rootId]
+  while (stack.length > 0) {
+    const current = stack.pop() as string
+    for (const child of childrenByParent.get(current) ?? []) {
+      if (!out.has(child)) {
+        out.add(child)
+        stack.push(child)
+      }
+    }
+  }
+  return out
+}
+
+/**
+ * Re-derives every node's container membership from geometry using CENTER-INSIDE
+ * semantics: a node belongs to the smallest (deepest) VPC container whose bounds
+ * contain the node's center. Nodes whose center is inside no container are
+ * released to the top level. Runs after any drag/resize so that both dragging a
+ * node into a container AND dragging a container over existing nodes capture
+ * correctly. Returns the same array reference when nothing changed.
+ */
+export const recomputeContainment = (nodes: Node[]): Node[] => {
+  const containers = nodes.filter((n) => n.type === 'vpcNode')
+  if (containers.length === 0) return nodes
+
+  const byId = new Map(nodes.map((n) => [n.id, n]))
+  const absById = new Map(nodes.map((n) => [n.id, absolutePosition(n, byId)]))
+
+  const centerOf = (n: Node): XYPosition => {
+    const pos = absById.get(n.id) as XYPosition
+    return { x: pos.x + (n.width ?? 0) / 2, y: pos.y + (n.height ?? 0) / 2 }
+  }
+  const containsCenter = (container: Node, point: XYPosition): boolean => {
+    const pos = absById.get(container.id) as XYPosition
+    return (
+      point.x > pos.x &&
+      point.x < pos.x + (container.width ?? 0) &&
+      point.y > pos.y &&
+      point.y < pos.y + (container.height ?? 0)
+    )
+  }
+
+  let changed = false
+  const next = nodes.map((node) => {
+    const center = centerOf(node)
+    const forbidden = descendantIds(node.id, nodes)
+    const candidates = containers
+      .filter((c) => c.id !== node.id && !forbidden.has(c.id) && containsCenter(c, center))
+      .sort((a, b) => (a.width ?? 0) * (a.height ?? 0) - (b.width ?? 0) * (b.height ?? 0))
+
+    const desiredParentId = candidates[0]?.id
+    if ((node.parentNode ?? undefined) === desiredParentId) return node
+
+    changed = true
+    const nodeAbs = absById.get(node.id) as XYPosition
+    if (desiredParentId) {
+      const parentAbs = absById.get(desiredParentId) as XYPosition
+      return {
+        ...node,
+        parentNode: desiredParentId,
+        expandParent: false,
+        extent: undefined,
+        zIndex: node.type === 'vpcNode' ? 1 : 10,
+        position: { x: nodeAbs.x - parentAbs.x, y: nodeAbs.y - parentAbs.y }
+      }
+    }
+    return {
+      ...node,
+      parentNode: undefined,
+      extent: undefined,
+      zIndex: 0,
+      position: { x: nodeAbs.x, y: nodeAbs.y }
+    }
+  })
+
+  return changed ? next : nodes
+}
+
+/**
  * Finds the smallest VPC node that intersects with the given position.
  * Prioritizes innermost nested VPCs by sorting by area.
  */

--- a/src/renderer/src/components/layout/WorkspaceLayout.tsx
+++ b/src/renderer/src/components/layout/WorkspaceLayout.tsx
@@ -737,7 +737,7 @@ export const WorkspaceLayout = () => {
             id="right-panel"
           >
             <Suspense fallback={<PanelFallback label="Loading inspector..." />}>
-              <PropertiesPanel />
+              <PropertiesPanel results={sim.results} />
             </Suspense>
           </Panel>
         </PanelGroup>

--- a/src/renderer/src/components/location/LocationRollupsPanel.tsx
+++ b/src/renderer/src/components/location/LocationRollupsPanel.tsx
@@ -1,0 +1,287 @@
+import {
+  type EdgeLocalityRollup,
+  type LocationLevel,
+  type NodeLocationRollup,
+  type NodeLocationRollups
+} from '@renderer/utils/locationTopology'
+import { TooltipInfo } from '@renderer/components/ui/Tooltip'
+
+const LEVEL_ORDER: readonly LocationLevel[] = ['region', 'az', 'subnet']
+
+const LEVEL_LABELS: Record<LocationLevel, string> = {
+  region: 'Regions',
+  az: 'Availability Zones',
+  subnet: 'Subnets'
+}
+
+function fmtRate(value: number): string {
+  return Number.isFinite(value) ? `${value.toFixed(1)} rps` : '0.0 rps'
+}
+
+function fmtMs(value: number | null): string {
+  return typeof value === 'number' && Number.isFinite(value) ? `${value.toFixed(1)}ms` : 'N/A'
+}
+
+function fmtPct(value: number | null): string {
+  return typeof value === 'number' && Number.isFinite(value) ? `${(value * 100).toFixed(1)}%` : 'N/A'
+}
+
+function isSourceOnlyRollup(rollup: NodeLocationRollup): boolean {
+  return rollup.activeNodeCount === 0 && rollup.sourceCount > 0
+}
+
+function LocationRollupTooltip() {
+  return (
+    <div className="space-y-1 text-[11px] leading-relaxed">
+      <p className="font-semibold text-nss-text">Deployment & locality</p>
+      <p className="text-nss-text/80">
+        Composite containers are deployment groupings, not simulated hops. These summaries group
+        runtime node results by region, availability zone, and subnet.
+      </p>
+      <p className="text-nss-muted">
+        Traffic locality shows which edge path classes were used at runtime, such as same-dc or
+        cross-region.
+      </p>
+    </div>
+  )
+}
+
+function CompactLevelCard({
+  level,
+  rollups
+}: {
+  level: LocationLevel
+  rollups: NodeLocationRollup[]
+}) {
+  const primary = rollups.find((rollup) => !isSourceOnlyRollup(rollup)) ?? rollups[0]
+
+  return (
+    <div className="rounded-lg border border-nss-border bg-nss-surface p-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-[10px] font-semibold uppercase tracking-wide text-nss-muted">
+          {LEVEL_LABELS[level]}
+        </div>
+        <div className="text-[10px] text-nss-muted">{rollups.length} group(s)</div>
+      </div>
+
+      {!primary ? (
+        <div className="mt-2 text-[11px] text-nss-muted">No nodes are grouped at this level.</div>
+      ) : (
+        <div className="mt-2 space-y-1">
+          <div className="truncate text-xs font-medium text-nss-text">{primary.label}</div>
+          {isSourceOnlyRollup(primary) ? (
+            <>
+              <div className="text-[10px] text-nss-muted">
+                {primary.sourceCount} source(s) only. Runtime arrivals begin on downstream nodes.
+              </div>
+              {rollups.length > 1 && (
+                <div className="text-[10px] text-nss-muted">
+                  +{(rollups.length - 1).toLocaleString()} more group(s)
+                </div>
+              )}
+            </>
+          ) : (
+            <>
+              <div className="flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-nss-muted tabular-nums">
+                <span>
+                  {primary.activeNodeCount}/{primary.nodeCount} active
+                </span>
+                <span>{fmtRate(primary.totalThroughput)}</span>
+                <span>p95 {fmtMs(primary.worstP95)}</span>
+                <span>err {fmtPct(primary.errorRate)}</span>
+              </div>
+              {(primary.sourceCount > 0 || rollups.length > 1) && (
+                <div className="text-[10px] text-nss-muted">
+                  {primary.sourceCount > 0 ? `${primary.sourceCount} source(s)` : 'runtime only'}
+                  {rollups.length > 1 ? ` · +${(rollups.length - 1).toLocaleString()} more` : ''}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface LocationRollupsPanelProps {
+  nodeRollups: NodeLocationRollups
+  edgeRollups: EdgeLocalityRollup[]
+  compact?: boolean
+  title?: string
+}
+
+export function LocationRollupsPanel({
+  nodeRollups,
+  edgeRollups,
+  compact = false,
+  title = 'Location Rollups'
+}: LocationRollupsPanelProps) {
+  const nodeRollupCount = LEVEL_ORDER.reduce((sum, level) => sum + nodeRollups[level].length, 0)
+  if (nodeRollupCount === 0 && edgeRollups.length === 0) return null
+
+  const nodeLimit = compact ? 2 : 4
+  const edgeLimit = compact ? 4 : 6
+
+  if (compact) {
+    const primaryEdgeRollup = edgeRollups[0]
+
+    return (
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <h3 className="text-xs font-semibold text-nss-text">{title}</h3>
+          <TooltipInfo
+            label={`Explain ${title}`}
+            content={<LocationRollupTooltip />}
+            width={320}
+          />
+        </div>
+
+        <div className="space-y-2">
+          {LEVEL_ORDER.map((level) => (
+            <CompactLevelCard key={level} level={level} rollups={nodeRollups[level]} />
+          ))}
+
+          {primaryEdgeRollup && (
+            <div className="rounded-lg border border-nss-border bg-nss-surface p-3">
+              <div className="flex items-center justify-between gap-2">
+                <div className="text-[10px] font-semibold uppercase tracking-wide text-nss-muted">
+                  Traffic Locality
+                </div>
+                <div className="text-[10px] text-nss-muted">{edgeRollups.length} group(s)</div>
+              </div>
+              <div className="mt-2 truncate text-xs font-medium text-nss-text">
+                {primaryEdgeRollup.pathType} · {primaryEdgeRollup.label}
+              </div>
+              <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-nss-muted tabular-nums">
+                <span>{primaryEdgeRollup.edgeCount} edge(s)</span>
+                <span>{primaryEdgeRollup.attempts.toLocaleString()} attempts</span>
+                <span>p95 {fmtMs(primaryEdgeRollup.worstP95)}</span>
+                <span>err {fmtPct(primaryEdgeRollup.errorRate)}</span>
+              </div>
+              {edgeRollups.length > 1 && (
+                <div className="mt-1 text-[10px] text-nss-muted">
+                  +{(edgeRollups.length - 1).toLocaleString()} more locality group(s)
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <h3 className="text-xs font-semibold text-nss-text">{title}</h3>
+        <TooltipInfo label={`Explain ${title}`} content={<LocationRollupTooltip />} width={320} />
+      </div>
+      <p className="text-[11px] text-nss-muted">
+        Containers group runtime results by placement. They do not add extra simulated hops.
+      </p>
+
+      <div className="grid gap-3 xl:grid-cols-3">
+        {LEVEL_ORDER.map((level) => {
+          const rollups = nodeRollups[level]
+          return (
+            <div key={level} className="rounded-lg border border-nss-border bg-nss-surface p-3">
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-nss-muted">
+                  {LEVEL_LABELS[level]}
+                </div>
+                <div className="text-[10px] text-nss-muted">{rollups.length} group(s)</div>
+              </div>
+
+              {rollups.length === 0 ? (
+                <div className="text-[11px] text-nss-muted">No nodes are grouped at this level.</div>
+              ) : (
+                <div className="space-y-2">
+                  {rollups.slice(0, nodeLimit).map((rollup) => {
+                    const sourceOnly = isSourceOnlyRollup(rollup)
+
+                    return (
+                      <div
+                        key={`${rollup.level}:${rollup.containerId}`}
+                        className="rounded border border-nss-border bg-nss-panel px-2.5 py-2"
+                      >
+                        <div className="flex items-start justify-between gap-2">
+                          <div className="truncate text-xs font-medium text-nss-text">
+                            {rollup.label}
+                          </div>
+                          {sourceOnly && (
+                            <span className="shrink-0 rounded-full border border-nss-border bg-nss-surface px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-nss-muted">
+                              Source only
+                            </span>
+                          )}
+                        </div>
+
+                        {sourceOnly ? (
+                          <div className="mt-1 space-y-1 text-[10px] text-nss-muted">
+                            <div>{rollup.sourceCount} source(s)</div>
+                            <div>Traffic is counted once it reaches the next runtime node.</div>
+                          </div>
+                        ) : (
+                          <div className="mt-1 grid grid-cols-2 gap-x-2 gap-y-1 text-[10px] text-nss-muted tabular-nums">
+                            <div>
+                              {rollup.activeNodeCount}/{rollup.nodeCount} active
+                            </div>
+                            <div className="text-right">{fmtRate(rollup.totalThroughput)}</div>
+                            <div>
+                              {rollup.sourceCount > 0
+                                ? `${rollup.sourceCount} source(s)`
+                                : `${rollup.totalArrived.toLocaleString()} arrived`}
+                            </div>
+                            <div className="text-right">p95 {fmtMs(rollup.worstP95)}</div>
+                            <div>{rollup.totalArrived.toLocaleString()} arrived</div>
+                            <div className="text-right">err {fmtPct(rollup.errorRate)}</div>
+                          </div>
+                        )}
+                      </div>
+                    )
+                  })}
+                  {rollups.length > nodeLimit && (
+                    <div className="text-[10px] text-nss-muted">
+                      +{(rollups.length - nodeLimit).toLocaleString()} more {LEVEL_LABELS[level].toLowerCase()}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      {edgeRollups.length > 0 && (
+        <div className="rounded-lg border border-nss-border bg-nss-surface p-3">
+          <div className="mb-2 flex items-center justify-between gap-2">
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-nss-muted">
+              Traffic Locality
+            </div>
+            <div className="text-[10px] text-nss-muted">{edgeRollups.length} group(s)</div>
+          </div>
+          <div className="grid gap-2 lg:grid-cols-2">
+            {edgeRollups.slice(0, edgeLimit).map((rollup) => (
+              <div key={rollup.key} className="rounded border border-nss-border bg-nss-panel px-2.5 py-2">
+                <div className="truncate text-xs font-medium text-nss-text">
+                  {rollup.pathType} · {rollup.label}
+                </div>
+                <div className="mt-1 grid grid-cols-2 gap-x-2 gap-y-1 text-[10px] text-nss-muted tabular-nums">
+                  <div>{rollup.edgeCount} edge(s)</div>
+                  <div className="text-right">{rollup.attempts.toLocaleString()} attempts</div>
+                  <div>err {fmtPct(rollup.errorRate)}</div>
+                  <div className="text-right">p95 {fmtMs(rollup.worstP95)}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+          {edgeRollups.length > edgeLimit && (
+            <div className="mt-2 text-[10px] text-nss-muted">
+              +{(edgeRollups.length - edgeLimit).toLocaleString()} more locality groups
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/location/LocationRollupsPanel.tsx
+++ b/src/renderer/src/components/location/LocationRollupsPanel.tsx
@@ -23,7 +23,9 @@ function fmtMs(value: number | null): string {
 }
 
 function fmtPct(value: number | null): string {
-  return typeof value === 'number' && Number.isFinite(value) ? `${(value * 100).toFixed(1)}%` : 'N/A'
+  return typeof value === 'number' && Number.isFinite(value)
+    ? `${(value * 100).toFixed(1)}%`
+    : 'N/A'
 }
 
 function isSourceOnlyRollup(rollup: NodeLocationRollup): boolean {
@@ -130,11 +132,7 @@ export function LocationRollupsPanel({
       <div className="space-y-2">
         <div className="flex items-center gap-2">
           <h3 className="text-xs font-semibold text-nss-text">{title}</h3>
-          <TooltipInfo
-            label={`Explain ${title}`}
-            content={<LocationRollupTooltip />}
-            width={320}
-          />
+          <TooltipInfo label={`Explain ${title}`} content={<LocationRollupTooltip />} width={320} />
         </div>
 
         <div className="space-y-2">
@@ -194,7 +192,9 @@ export function LocationRollupsPanel({
               </div>
 
               {rollups.length === 0 ? (
-                <div className="text-[11px] text-nss-muted">No nodes are grouped at this level.</div>
+                <div className="text-[11px] text-nss-muted">
+                  No nodes are grouped at this level.
+                </div>
               ) : (
                 <div className="space-y-2">
                   {rollups.slice(0, nodeLimit).map((rollup) => {
@@ -242,7 +242,8 @@ export function LocationRollupsPanel({
                   })}
                   {rollups.length > nodeLimit && (
                     <div className="text-[10px] text-nss-muted">
-                      +{(rollups.length - nodeLimit).toLocaleString()} more {LEVEL_LABELS[level].toLowerCase()}
+                      +{(rollups.length - nodeLimit).toLocaleString()} more{' '}
+                      {LEVEL_LABELS[level].toLowerCase()}
                     </div>
                   )}
                 </div>
@@ -262,7 +263,10 @@ export function LocationRollupsPanel({
           </div>
           <div className="grid gap-2 lg:grid-cols-2">
             {edgeRollups.slice(0, edgeLimit).map((rollup) => (
-              <div key={rollup.key} className="rounded border border-nss-border bg-nss-panel px-2.5 py-2">
+              <div
+                key={rollup.key}
+                className="rounded border border-nss-border bg-nss-panel px-2.5 py-2"
+              >
                 <div className="truncate text-xs font-medium text-nss-text">
                   {rollup.pathType} · {rollup.label}
                 </div>

--- a/src/renderer/src/components/nodes/LensMetricCard.tsx
+++ b/src/renderer/src/components/nodes/LensMetricCard.tsx
@@ -1,4 +1,5 @@
 import { clsx } from 'clsx'
+import { HoverTooltip } from '@renderer/components/ui/Tooltip'
 import type { LensCardData } from './nodePresentation'
 
 const GLYPH_COLOR: Record<LensCardData['tone'], string> = {
@@ -21,7 +22,34 @@ export const LensMetricCard = ({ card }: LensMetricCardProps) => (
     <div className="flex items-baseline gap-1.5 tabular-nums">
       <span className="text-lg font-bold text-nss-text">{card.value}</span>
       <span className="text-xs text-nss-muted">{card.limit}</span>
-      <span className={clsx('ml-auto text-sm', GLYPH_COLOR[card.tone])}>{card.glyph}</span>
+      <HoverTooltip
+        content={
+          <div className="space-y-1.5">
+            <div className={clsx('text-xs font-semibold', GLYPH_COLOR[card.tone])}>
+              {card.glyphTooltip.title}
+            </div>
+            <div className="text-[11px] leading-relaxed text-nss-muted">
+              {card.glyphTooltip.detail}
+            </div>
+          </div>
+        }
+        width={300}
+        estimatedHeight={132}
+      >
+        {(triggerProps) => (
+          <button
+            type="button"
+            aria-label={card.glyphTooltip.label}
+            className={clsx(
+              'nodrag nopan ml-auto inline-flex h-5 w-5 self-center items-center justify-center rounded-full border border-transparent text-sm transition-colors hover:border-nss-border hover:bg-nss-panel focus:outline-none focus:ring-2 focus:ring-nss-primary/50 focus:ring-offset-1 focus:ring-offset-nss-surface',
+              GLYPH_COLOR[card.tone]
+            )}
+            {...triggerProps}
+          >
+            {card.glyph}
+          </button>
+        )}
+      </HoverTooltip>
     </div>
     <div className="mt-1 text-[10px] text-nss-muted truncate" title={card.why}>
       {card.why}

--- a/src/renderer/src/components/nodes/VpcNode.tsx
+++ b/src/renderer/src/components/nodes/VpcNode.tsx
@@ -37,15 +37,15 @@ const VpcNode = ({ id, data, selected }: NodeProps) => {
   }
 
   return (
-      <div
-        onContextMenu={(e) => {
-          e.preventDefault()
-          e.stopPropagation()
-          setIsMenuOpen(true)
-        }}
-        className="pointer-events-none relative w-full h-full group transition-all duration-200 ease-in-out"
-        style={{ minWidth: minSize.width, minHeight: minSize.height }}
-      >
+    <div
+      onContextMenu={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        setIsMenuOpen(true)
+      }}
+      className="pointer-events-none relative w-full h-full group transition-all duration-200 ease-in-out"
+      style={{ minWidth: minSize.width, minHeight: minSize.height }}
+    >
       <VpcToolbar
         isVisible={selected}
         isUngrouped={isUngrouped}
@@ -53,9 +53,9 @@ const VpcNode = ({ id, data, selected }: NodeProps) => {
         onUngroup={handleUngroup}
       />
 
-        <div
-          className={`pointer-events-none absolute inset-0 rounded-xl border-2 border-dashed transition-all duration-300 overflow-visible ${getContainerStyle()}`}
-        >
+      <div
+        className={`pointer-events-none absolute inset-0 rounded-xl border-2 border-dashed transition-all duration-300 overflow-visible ${getContainerStyle()}`}
+      >
         <VpcHeader
           label={data.label}
           isSuccessState={isSuccessState}

--- a/src/renderer/src/components/nodes/VpcNode.tsx
+++ b/src/renderer/src/components/nodes/VpcNode.tsx
@@ -37,15 +37,15 @@ const VpcNode = ({ id, data, selected }: NodeProps) => {
   }
 
   return (
-    <div
-      onContextMenu={(e) => {
-        e.preventDefault()
-        e.stopPropagation()
-        setIsMenuOpen(true)
-      }}
-      className="relative w-full h-full group transition-all duration-200 ease-in-out"
-      style={{ minWidth: minSize.width, minHeight: minSize.height }}
-    >
+      <div
+        onContextMenu={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          setIsMenuOpen(true)
+        }}
+        className="pointer-events-none relative w-full h-full group transition-all duration-200 ease-in-out"
+        style={{ minWidth: minSize.width, minHeight: minSize.height }}
+      >
       <VpcToolbar
         isVisible={selected}
         isUngrouped={isUngrouped}
@@ -53,9 +53,9 @@ const VpcNode = ({ id, data, selected }: NodeProps) => {
         onUngroup={handleUngroup}
       />
 
-      <div
-        className={`absolute inset-0 rounded-xl border-2 border-dashed transition-all duration-300 overflow-visible ${getContainerStyle()}`}
-      >
+        <div
+          className={`pointer-events-none absolute inset-0 rounded-xl border-2 border-dashed transition-all duration-300 overflow-visible ${getContainerStyle()}`}
+        >
         <VpcHeader
           label={data.label}
           isSuccessState={isSuccessState}
@@ -79,6 +79,8 @@ const VpcNode = ({ id, data, selected }: NodeProps) => {
         isVisible={selected}
         minWidth={minSize.width}
         minHeight={minSize.height}
+        lineClassName="pointer-events-auto"
+        handleClassName="pointer-events-auto"
         handleStyle={{ width: 12, height: 12, borderRadius: '50%' }}
       />
     </div>

--- a/src/renderer/src/components/nodes/nodePresentation.test.ts
+++ b/src/renderer/src/components/nodes/nodePresentation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildLatencyLensCard } from './nodePresentation'
+import { buildLatencyLensCard, getLensCard } from './nodePresentation'
 
 const EMPTY_LATENCY = {
   p50: null,
@@ -82,5 +82,38 @@ describe('buildLatencyLensCard', () => {
     expect(card?.why).toContain('success-only latency')
     expect(card?.why).toContain('88.0% failed')
     expect(card?.why).toContain('mostly Queue Full')
+  })
+})
+
+describe('getLensCard', () => {
+  it('treats timeouts as failures in the errors lens copy', () => {
+    const card = getLensCard(
+      'errors',
+      { componentType: 'compute-service' } as never,
+      {
+        errorRate: 100,
+        postWarmupRejected: 0,
+        postWarmupTimedOut: 38,
+        postWarmupConnectionReset: 0,
+        totalRejected: 0,
+        timeToErrorByCause: {
+          ...EMPTY_TTE,
+          timeout: { count: 38, errorRate: 1, shareOfErrors: 1, p50: 95, p95: 98, p99: 99 }
+        }
+      }
+    )
+
+    expect(card).toMatchObject({
+      value: '100.0%',
+      limit: '38 failed',
+      glyph: '✕',
+      tone: 'critical',
+      glyphTooltip: expect.objectContaining({
+        title: 'Errors: failure-heavy'
+      })
+    })
+    expect(card?.why).toContain('38 timed out')
+    expect(card?.why).toContain('mostly Timed Out')
+    expect(card?.why).not.toContain('no rejections')
   })
 })

--- a/src/renderer/src/components/nodes/nodePresentation.test.ts
+++ b/src/renderer/src/components/nodes/nodePresentation.test.ts
@@ -87,21 +87,17 @@ describe('buildLatencyLensCard', () => {
 
 describe('getLensCard', () => {
   it('treats timeouts as failures in the errors lens copy', () => {
-    const card = getLensCard(
-      'errors',
-      { componentType: 'compute-service' } as never,
-      {
-        errorRate: 100,
-        postWarmupRejected: 0,
-        postWarmupTimedOut: 38,
-        postWarmupConnectionReset: 0,
-        totalRejected: 0,
-        timeToErrorByCause: {
-          ...EMPTY_TTE,
-          timeout: { count: 38, errorRate: 1, shareOfErrors: 1, p50: 95, p95: 98, p99: 99 }
-        }
+    const card = getLensCard('errors', { componentType: 'compute-service' } as never, {
+      errorRate: 100,
+      postWarmupRejected: 0,
+      postWarmupTimedOut: 38,
+      postWarmupConnectionReset: 0,
+      totalRejected: 0,
+      timeToErrorByCause: {
+        ...EMPTY_TTE,
+        timeout: { count: 38, errorRate: 1, shareOfErrors: 1, p50: 95, p95: 98, p99: 99 }
       }
-    )
+    })
 
     expect(card).toMatchObject({
       value: '100.0%',

--- a/src/renderer/src/components/nodes/nodePresentation.ts
+++ b/src/renderer/src/components/nodes/nodePresentation.ts
@@ -454,17 +454,18 @@ function toneFromFailureRatio(value: number): NodeHealthStatus {
   return 'healthy'
 }
 
-function makeGlyphTooltip(label: string, title: string, detail: string): LensCardData['glyphTooltip'] {
+function makeGlyphTooltip(
+  label: string,
+  title: string,
+  detail: string
+): LensCardData['glyphTooltip'] {
   return { label, title, detail }
 }
 
 function summarizeNodeLocalFailures(
   metrics: Pick<
     NodeSimulationMetrics,
-    | 'postWarmupRejected'
-    | 'postWarmupTimedOut'
-    | 'postWarmupConnectionReset'
-    | 'timeToErrorByCause'
+    'postWarmupRejected' | 'postWarmupTimedOut' | 'postWarmupConnectionReset' | 'timeToErrorByCause'
   >
 ): { totalFailures: number; summary: string; dominantFailureText: string } {
   const rejected = metrics.postWarmupRejected ?? 0

--- a/src/renderer/src/components/nodes/nodePresentation.ts
+++ b/src/renderer/src/components/nodes/nodePresentation.ts
@@ -407,6 +407,11 @@ export interface LensCardData {
   glyph: '✓' | '⚠' | '✕'
   why: string
   tone: NodeHealthStatus
+  glyphTooltip: {
+    label: string
+    title: string
+    detail: string
+  }
 }
 
 const GLYPH_BY_TONE: Record<NodeHealthStatus, LensCardData['glyph']> = {
@@ -438,11 +443,53 @@ function formatWorkerLimit(workers: number): string {
   return `/ ${workers} worker${workers === 1 ? '' : 's'} avg`
 }
 
+function stripClickHint(text: string): string {
+  return text.replace(/\s*· click for detail$/, '')
+}
+
 function toneFromFailureRatio(value: number): NodeHealthStatus {
   const level = failureRateLevelFromRatio(value)
   if (level === 'crit') return 'critical'
   if (level === 'warn') return 'degraded'
   return 'healthy'
+}
+
+function makeGlyphTooltip(label: string, title: string, detail: string): LensCardData['glyphTooltip'] {
+  return { label, title, detail }
+}
+
+function summarizeNodeLocalFailures(
+  metrics: Pick<
+    NodeSimulationMetrics,
+    | 'postWarmupRejected'
+    | 'postWarmupTimedOut'
+    | 'postWarmupConnectionReset'
+    | 'timeToErrorByCause'
+  >
+): { totalFailures: number; summary: string; dominantFailureText: string } {
+  const rejected = metrics.postWarmupRejected ?? 0
+  const timedOut = metrics.postWarmupTimedOut ?? 0
+  const reset = metrics.postWarmupConnectionReset ?? 0
+  const totalFailures = rejected + timedOut + reset
+  const parts: string[] = []
+
+  if (rejected > 0) {
+    parts.push(`${rejected.toLocaleString()} rejected`)
+  }
+  if (timedOut > 0) {
+    parts.push(`${timedOut.toLocaleString()} timed out`)
+  }
+  if (reset > 0) {
+    parts.push(`${reset.toLocaleString()} reset`)
+  }
+
+  const dominantFailure = dominantTimeToErrorCause(metrics.timeToErrorByCause)
+
+  return {
+    totalFailures,
+    summary: parts.length > 0 ? parts.join(' · ') : 'no node-local failures',
+    dominantFailureText: dominantFailure ? ` · mostly ${ERROR_CAUSE_LABELS[dominantFailure]}` : ''
+  }
 }
 
 type LatencyLensMetrics = Pick<
@@ -532,7 +579,20 @@ export function buildLatencyLensCard(
     limit: 'p95',
     glyph: GLYPH_BY_TONE[tone],
     why,
-    tone
+    tone,
+    glyphTooltip: makeGlyphTooltip(
+      'Explain latency lens status',
+      tone === 'healthy'
+        ? 'Latency: within expectation'
+        : tone === 'degraded'
+          ? 'Latency: needs attention'
+          : 'Latency: breach or failure-heavy',
+      tone === 'healthy'
+        ? `✓ means this node looks healthy under the Latency lens. ${stripClickHint(why)}.`
+        : tone === 'degraded'
+          ? `⚠ means the Latency lens sees drift, partial breach, or enough failures to qualify this node as risky. ${stripClickHint(why)}.`
+          : `✕ means this node is either badly breaching latency expectations or failing so often that success-only latency is no longer representative. ${stripClickHint(why)}.`
+    )
   }
 }
 
@@ -565,7 +625,14 @@ export function getLensCard(
         limit: formatWorkerLimit(workers),
         glyph: capacity.level === 'headroom' ? '✓' : '⚠',
         why: `${capacity.utilizationPercent.toFixed(1)}% average utilization - ${capacity.label.toLowerCase()} · click for detail`,
-        tone
+        tone,
+        glyphTooltip: makeGlyphTooltip(
+          'Explain saturation lens status',
+          tone === 'healthy' ? 'Saturation: headroom' : 'Saturation: pressure building',
+          tone === 'healthy'
+            ? `✓ means this node kept enough worker headroom under the Saturation lens. ${capacity.utilizationPercent.toFixed(1)}% average utilization and ${capacity.label.toLowerCase()}.`
+            : `⚠ means this node is running warm or queueing under the Saturation lens. ${capacity.utilizationPercent.toFixed(1)}% average utilization and ${capacity.label.toLowerCase()}.`
+        )
       }
     }
     case 'latency': {
@@ -578,17 +645,30 @@ export function getLensCard(
       }
       const tone: NodeHealthStatus =
         metrics.errorRate >= 50 ? 'critical' : metrics.errorRate > 0 ? 'degraded' : 'healthy'
-      const reasons = Object.entries(metrics.rejectionsByReason ?? {}).sort((a, b) => b[1] - a[1])
+      const { totalFailures, summary, dominantFailureText } = summarizeNodeLocalFailures(metrics)
       const why =
-        reasons.length > 0
-          ? `${reasons[0][1]} rejected: ${reasons[0][0]} · click for detail`
-          : 'no rejections'
+        totalFailures > 0
+          ? `${summary}${dominantFailureText} · click for detail`
+          : 'no node-local failures'
       return {
         value: formatFailurePercentLabel(metrics.errorRate),
-        limit: `${metrics.totalRejected ?? 0} rejected`,
+        limit: `${totalFailures.toLocaleString()} failed`,
         glyph: GLYPH_BY_TONE[tone],
         why,
-        tone
+        tone,
+        glyphTooltip: makeGlyphTooltip(
+          'Explain errors lens status',
+          tone === 'healthy'
+            ? 'Errors: clean'
+            : tone === 'degraded'
+              ? 'Errors: some failures'
+              : 'Errors: failure-heavy',
+          tone === 'healthy'
+            ? '✓ means this node produced no node-local rejects, timeouts, or resets in the measured run.'
+            : tone === 'degraded'
+              ? `⚠ means some node-local requests failed here, but fewer than half. ${formatFailurePercentLabel(metrics.errorRate)} failed; ${summary}${dominantFailureText}.`
+              : `✕ means at least half of node-local requests failed here. ${formatFailurePercentLabel(metrics.errorRate)} failed; ${summary}${dominantFailureText}.`
+        )
       }
     }
     case 'throughput': {
@@ -608,7 +688,12 @@ export function getLensCard(
         limit: 'req/s',
         glyph: '✓',
         why,
-        tone: 'healthy'
+        tone: 'healthy',
+        glyphTooltip: makeGlyphTooltip(
+          'Explain throughput lens status',
+          'Throughput: informational',
+          `✓ here is informational, not a pass/fail verdict. The Throughput lens shows completed request rate for this node. ${stripClickHint(why)}.`
+        )
       }
     }
     default:

--- a/src/renderer/src/components/nodes/vpc/VpcHeader.tsx
+++ b/src/renderer/src/components/nodes/vpc/VpcHeader.tsx
@@ -14,7 +14,7 @@ export const VpcHeader = memo(
     return (
       <div
         className={`
-      absolute top-0 left-0 right-0 px-4 py-2 border-b border-dashed flex items-start gap-2
+      pointer-events-auto absolute top-0 left-0 right-0 px-4 py-2 border-b border-dashed flex items-start gap-2
       ${isSuccessState ? 'border-[rgb(var(--nss-success))]/30' : 'border-[var(--nss-vpc-border)]'}
         `}
       >

--- a/src/renderer/src/components/nodes/vpc/VpcToolbar.tsx
+++ b/src/renderer/src/components/nodes/vpc/VpcToolbar.tsx
@@ -19,6 +19,7 @@ export const VpcToolbar = memo(
           onClick={onUngroup}
           disabled={isUngrouped}
           className={`
+            pointer-events-auto
             flex items-center gap-1.5 px-2 py-1 rounded shadow-md text-[10px] font-bold uppercase tracking-wider transition-colors border
             ${
               isUngrouped

--- a/src/renderer/src/components/properties/FormField.tsx
+++ b/src/renderer/src/components/properties/FormField.tsx
@@ -78,6 +78,21 @@ export const FormField = ({
 
       case 'input':
       default:
+        if (config.inputType === 'text') {
+          return (
+            <Input
+              type="text"
+              value={String(normalizedValue)}
+              rightElement={config.unit}
+              placeholder={config.placeholder}
+              onChange={(e) => {
+                const val = e.target.value
+                onChange(val === '' ? undefined : val)
+              }}
+            />
+          )
+        }
+
         return (
           <Input
             type="number"

--- a/src/renderer/src/components/properties/PropertiesForm.tsx
+++ b/src/renderer/src/components/properties/PropertiesForm.tsx
@@ -18,6 +18,7 @@ import { Input } from '../ui/Input'
 import { Label } from '../ui/Label'
 import { Select } from '../ui/Select'
 import { FormField } from './FormField'
+import { RequestDistributionEditor } from './RequestDistributionEditor'
 import { RoutingRulesEditor } from './RoutingRulesEditor'
 import type { ContentRoutingRule } from '../../../../engine/traits/contentRouting'
 import {
@@ -273,6 +274,20 @@ export const PropertiesForm = ({ nodeId, data, onUpdate }: PropertiesFormProps) 
       )
     }
 
+    if (field.renderer === 'request-distribution') {
+      const entries = Array.isArray(data.source?.requestDistribution)
+        ? data.source.requestDistribution
+        : []
+
+      return (
+        <RequestDistributionEditor
+          key={field.path}
+          entries={entries}
+          onChange={(nextValue) => onUpdate(field.path, nextValue)}
+        />
+      )
+    }
+
     return (
       <FormField
         key={field.path}
@@ -315,7 +330,7 @@ export const PropertiesForm = ({ nodeId, data, onUpdate }: PropertiesFormProps) 
         />
       </div>
 
-      {data.profile === 'composite' ? (
+      {data.profile === 'composite' && sections.length === 0 ? (
         <div className="rounded-md border border-nss-border bg-nss-surface p-3 text-xs text-nss-muted">
           Composite nodes are canvas containers only. They are not serialized into the simulation
           engine.

--- a/src/renderer/src/components/properties/PropertiesPanel.tsx
+++ b/src/renderer/src/components/properties/PropertiesPanel.tsx
@@ -510,8 +510,11 @@ function RunInspector({
   onSelectNode: (id: string) => void
   onSelectEdge: (id: string) => void
 }) {
-  const nodeLabelsById = new Map(nodes.map((node) => [node.id, getNodeLabel(node)]))
-  const nodeById = new Map(nodes.map((node) => [node.id, node]))
+  const nodeLabelsById = useMemo(
+    () => new Map(nodes.map((node) => [node.id, getNodeLabel(node)])),
+    [nodes]
+  )
+  const nodeById = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes])
   const sourceNodeIds = useMemo(() => {
     const ids = new Set<string>()
     for (const node of nodes) {

--- a/src/renderer/src/components/properties/PropertiesPanel.tsx
+++ b/src/renderer/src/components/properties/PropertiesPanel.tsx
@@ -1,6 +1,13 @@
-import { useEffect, useState, type ReactNode } from 'react'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import { clsx } from 'clsx'
 import { Activity, ArrowLeft, GitBranch, ListTree, Settings, Server } from 'lucide-react'
+import type { SimulationOutput } from '../../../../engine/analysis/output'
+import {
+  REQUEST_OUTCOME_FAMILIES,
+  type RequestOutcomeFamily
+} from '../../../../engine/core/requestOutcomeSemantics'
+import { describeRequestOperation } from '../../../../engine/core/requestSemantics'
+import type { WorkloadProfile } from '../../../../engine/core/types'
 import type { FieldPath } from '@renderer/config/fieldConfig'
 import type { AnyNodeData, EdgeSimulationData, NodeSimulationMetrics } from '@renderer/types/ui'
 import { useNodeMetrics } from '@renderer/hooks/useNodeMetrics'
@@ -11,11 +18,37 @@ import { PropertiesForm } from './PropertiesForm'
 import { NodeMetricsDetail, SourceNodeMetricsDetail } from './NodeMetricsDetail'
 import { MetricItem } from './MetricItem'
 import { EdgePropertiesPanel, type EdgePropertiesPanelValue } from '../ui/EdgePropertiesPanel'
+import { TooltipInfo } from '../ui/Tooltip'
+import { LocationRollupsPanel } from '@renderer/components/location/LocationRollupsPanel'
+import {
+  buildEdgeLocalityRollups,
+  buildLocationTopology,
+  buildNodeLocationRollups,
+  describeEdgeLocality,
+  formatNodeLocation,
+  pathTypeFromContainers,
+  type LocationLevel
+} from '@renderer/utils/locationTopology'
+import { inferEdgeDefaults } from '../../../../engine/defaults/edgeDefaults'
 
 const EmptyState = () => (
   <div className="h-full bg-nss-panel border-l border-nss-border flex flex-col items-center justify-center text-nss-muted gap-2">
     <Settings size={24} className="opacity-20" />
     <p className="text-xs font-medium uppercase tracking-wide">No Selection</p>
+  </div>
+)
+
+const RUN_INSPECTOR_TOOLTIP = (
+  <div className="space-y-1 text-[11px] leading-relaxed">
+    <p className="font-semibold text-nss-text">Run Inspector</p>
+    <p className="text-nss-text/80">
+      A compact summary of the latest run. Use it to spot the slowest node or busiest link, then
+      open a node or link card for the detailed view.
+    </p>
+    <p className="text-nss-muted">
+      Deployment summaries below group runtime results by composite containers without treating
+      those containers as simulated hops.
+    </p>
   </div>
 )
 
@@ -76,7 +109,7 @@ function setPathValue(target: AnyNodeData, path: FieldPath, value: unknown): Par
 }
 
 type PanelTab = 'metrics' | 'config'
-type RunInspectorTab = 'nodes' | 'links'
+type RunInspectorTab = 'nodes' | 'links' | 'locality'
 
 const EDGE_FAILURE_LABELS = {
   connection_refused: 'Connection Refused',
@@ -84,6 +117,14 @@ const EDGE_FAILURE_LABELS = {
   packet_loss: 'Packet Loss',
   deadline_exceeded: 'Deadline Exceeded'
 } as const
+
+const RUN_INSPECTOR_LOCATION_LEVELS: readonly LocationLevel[] = ['region', 'az', 'subnet']
+
+const RUN_INSPECTOR_LOCATION_LEVEL_LABELS: Record<LocationLevel, string> = {
+  region: 'Regions',
+  az: 'Availability Zones',
+  subnet: 'Subnets'
+}
 
 function formatNumber(value: number): string {
   return Number.isFinite(value) ? value.toLocaleString() : '0'
@@ -105,6 +146,58 @@ function formatMs(value: number | null | undefined): string {
   return typeof value === 'number' && Number.isFinite(value) ? `${value.toFixed(1)}ms` : 'N/A'
 }
 
+function formatWeight(value: number): string {
+  return `${(value * 100).toFixed(value * 100 < 10 ? 1 : 0)}%`
+}
+
+function formatPathTypeLabel(pathType: NonNullable<EdgeSimulationData['pathType']>): string {
+  return pathType.replace(/-/g, ' ')
+}
+
+function outcomeFamilyLabel(family: RequestOutcomeFamily): string {
+  switch (family) {
+    case 'success_2xx':
+      return '2xx success'
+    case 'client_error_4xx':
+      return '4xx reject'
+    case 'server_error_5xx':
+      return '5xx failure'
+    case 'network_timeout':
+      return 'Timeout'
+    case 'network_drop':
+      return 'Network drop'
+    case 'connection_reset':
+      return 'Reset'
+    case 'in_flight':
+      return 'In flight'
+  }
+}
+
+function outcomeFamilyTone(family: RequestOutcomeFamily): string {
+  switch (family) {
+    case 'success_2xx':
+      return 'text-nss-success'
+    case 'client_error_4xx':
+      return 'text-nss-primary'
+    case 'network_timeout':
+    case 'in_flight':
+      return 'text-nss-warning'
+    case 'server_error_5xx':
+    case 'network_drop':
+    case 'connection_reset':
+      return 'text-nss-danger'
+  }
+}
+
+function requestMixPreviewEntries(workload: WorkloadProfile) {
+  return [...workload.requestDistribution]
+    .map((entry) => ({
+      ...describeRequestOperation({ type: entry.type, metadata: entry.metadata }),
+      weight: entry.weight
+    }))
+    .sort((a, b) => b.weight - a.weight)
+}
+
 function clampPercent(value: number): number {
   return Math.min(100, Math.max(0, value))
 }
@@ -123,6 +216,21 @@ function EdgeResultsSection({ title, children }: { title: string; children: Reac
       <h3 className="text-[10px] font-bold uppercase tracking-widest text-nss-muted">{title}</h3>
       <div className="rounded-lg border border-nss-border bg-nss-surface px-4 py-3">{children}</div>
     </section>
+  )
+}
+
+function CompactRunSummary({
+  title,
+  children
+}: {
+  title: string
+  children: ReactNode
+}) {
+  return (
+    <div className="rounded-lg border border-nss-border bg-nss-surface px-3 py-2">
+      <div className="text-[10px] font-semibold uppercase tracking-wide text-nss-muted">{title}</div>
+      <div className="mt-2 space-y-1.5">{children}</div>
+    </div>
   )
 }
 
@@ -305,6 +413,57 @@ function CardBadge({ label, className }: { label: string; className: string }) {
   )
 }
 
+function InspectorSection({
+  title,
+  description,
+  children
+}: {
+  title: string
+  description?: string
+  children: ReactNode
+}) {
+  return (
+    <section className="space-y-3 rounded-xl border border-nss-border bg-nss-surface p-4">
+      <div className="space-y-1">
+        <h3 className="text-[11px] font-semibold uppercase tracking-wide text-nss-muted">{title}</h3>
+        {description ? <p className="text-[11px] leading-relaxed text-nss-muted">{description}</p> : null}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+type ConfiguredLocationGroup = {
+  level: LocationLevel
+  containerId: string
+  label: string
+  parentLabel?: string
+  memberCount: number
+  runtimeNodeCount: number
+  sourceCount: number
+}
+
+type ConfiguredEdgeLocality = {
+  edgeId: string
+  label: string
+  protocol: string
+  mode: string
+  pathType: NonNullable<EdgeSimulationData['pathType']>
+  pathSource: 'Manual' | 'Auto from placement' | 'Auto from defaults'
+  localityDetail: string
+}
+
+function localityPathSourceBadgeClass(source: ConfiguredEdgeLocality['pathSource']): string {
+  switch (source) {
+    case 'Manual':
+      return 'border-nss-primary/30 bg-nss-primary/10 text-nss-primary'
+    case 'Auto from placement':
+      return 'border-nss-success/30 bg-nss-success/10 text-nss-success'
+    case 'Auto from defaults':
+      return 'border-nss-border bg-nss-panel text-nss-muted'
+  }
+}
+
 function RunInspectorHeaderAction({
   mode,
   onClick
@@ -334,6 +493,7 @@ function RunInspector({
   metricsByNode,
   edgeFlowById,
   runConfig,
+  results,
   activeTab,
   onTabChange,
   onSelectNode,
@@ -344,12 +504,25 @@ function RunInspector({
   metricsByNode: Record<string, NodeSimulationMetrics>
   edgeFlowById: Record<string, EdgeFlowState>
   runConfig: ReturnType<typeof useStore.getState>['edgeFlowRunConfig']
+  results?: SimulationOutput | null
   activeTab: RunInspectorTab
   onTabChange: (tab: RunInspectorTab) => void
   onSelectNode: (id: string) => void
   onSelectEdge: (id: string) => void
 }) {
   const nodeLabelsById = new Map(nodes.map((node) => [node.id, getNodeLabel(node)]))
+  const nodeById = new Map(nodes.map((node) => [node.id, node]))
+  const sourceNodeIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const node of nodes) {
+      const data = node.data as { structuralRole?: unknown; profile?: unknown } | undefined
+      if (data?.structuralRole === 'source' || data?.profile === 'source') {
+        ids.add(node.id)
+      }
+    }
+    return ids
+  }, [nodes])
+  const locationTopology = useMemo(() => buildLocationTopology(nodes), [nodes])
   const runtimeNodes = nodes
     .map((node) => ({ node, metrics: metricsByNode[node.id] }))
     .filter((entry): entry is { node: (typeof nodes)[number]; metrics: NodeSimulationMetrics } =>
@@ -386,6 +559,174 @@ function RunInspector({
     .map((entry) => entry.metrics.latencyNodeLocal?.p95 ?? entry.metrics.latencyP95)
     .filter((value): value is number => value !== undefined && value !== null)
   const worstP95 = p95Values.length > 0 ? Math.max(...p95Values) : null
+  const nodeLocationRollups = useMemo(
+    () =>
+      buildNodeLocationRollups(
+        locationTopology,
+        runtimeNodes.map(({ node, metrics }) => ({
+          nodeId: node.id,
+          postWarmupArrived: metrics.postWarmupArrived ?? 0,
+          postWarmupProcessed: metrics.postWarmupProcessed ?? 0,
+          totalFailures:
+            (metrics.postWarmupRejected ?? 0) +
+            (metrics.postWarmupTimedOut ?? 0) +
+            (metrics.postWarmupConnectionReset ?? 0),
+          throughput: metrics.throughput ?? 0,
+          utilization:
+            typeof metrics.utilization === 'number' && Number.isFinite(metrics.utilization)
+              ? metrics.utilization / 100
+              : null,
+          p95: metrics.latencyNodeLocal?.p95 ?? metrics.latencyP95 ?? null,
+          active:
+            (metrics.postWarmupArrived ?? 0) > 0 ||
+            (metrics.successLatencySamples ?? 0) > 0 ||
+            (metrics.timeToErrorSamples ?? 0) > 0,
+          isSource: sourceNodeIds.has(node.id)
+        }))
+      ),
+    [locationTopology, runtimeNodes, sourceNodeIds]
+  )
+  const edgeLocalityRollups = useMemo(
+    () =>
+      buildEdgeLocalityRollups(
+        locationTopology,
+        runtimeEdges.map(({ edge, flow }) => ({
+          edgeId: edge.id,
+          source: edge.source,
+          target: edge.target,
+          data: edge.data,
+          attempts: flow.totalAttempted,
+          failures: flow.totalFailed,
+          p95: percentile(
+            flow.recent
+              .filter((event) => event.status === 'success')
+              .map((event) => event.latencyMs),
+            0.95
+          )
+        }))
+      ),
+    [locationTopology, runtimeEdges]
+  )
+  const configuredLocationGroups = useMemo(() => {
+    const empty = {
+      region: [] as ConfiguredLocationGroup[],
+      az: [] as ConfiguredLocationGroup[],
+      subnet: [] as ConfiguredLocationGroup[]
+    }
+    const grouped = new Map<string, ConfiguredLocationGroup>()
+
+    for (const [containerId, level] of locationTopology.containerLevelById.entries()) {
+      const parentLocation = locationTopology.containerLocations.get(containerId)
+      const parentId =
+        level === 'subnet'
+          ? parentLocation?.az
+          : level === 'az'
+            ? parentLocation?.region
+            : undefined
+      grouped.set(`${level}:${containerId}`, {
+        level,
+        containerId,
+        label: locationTopology.containerLabelById.get(containerId) ?? containerId,
+        parentLabel: parentId ? locationTopology.containerLabelById.get(parentId) : undefined,
+        memberCount: 0,
+        runtimeNodeCount: 0,
+        sourceCount: 0
+      })
+    }
+
+    for (const node of nodes) {
+      if (locationTopology.containerLevelById.has(node.id)) continue
+      const location = locationTopology.nodeLocations.get(node.id)
+      if (!location) continue
+      const source = isSourceNode(node)
+
+      for (const level of RUN_INSPECTOR_LOCATION_LEVELS) {
+        const containerId =
+          level === 'region' ? location.regionId : level === 'az' ? location.azId : location.subnetId
+        if (!containerId) continue
+        const key = `${level}:${containerId}`
+        const current = grouped.get(key)
+        if (!current) continue
+        current.memberCount += 1
+        if (source) current.sourceCount += 1
+        else current.runtimeNodeCount += 1
+      }
+    }
+
+    for (const group of grouped.values()) {
+      empty[group.level].push(group)
+    }
+
+    for (const level of RUN_INSPECTOR_LOCATION_LEVELS) {
+      empty[level].sort(
+        (a, b) => b.memberCount - a.memberCount || a.label.localeCompare(b.label)
+      )
+    }
+
+    return empty
+  }, [locationTopology, nodes])
+  const configuredEdgeLocality = useMemo<ConfiguredEdgeLocality[]>(() => {
+    return edges
+      .map((edge) => {
+        const data = (edge.data as EdgeSimulationData | undefined) ?? {}
+        const sourceNodeData = nodeById.get(edge.source)?.data as CanvasNodeDataV2 | undefined
+        const targetNodeData = nodeById.get(edge.target)?.data as CanvasNodeDataV2 | undefined
+        const defaultPathType = inferEdgeDefaults(sourceNodeData, targetNodeData).pathType
+        const placementPathType = pathTypeFromContainers(
+          locationTopology.containerLocations,
+          edge.source,
+          edge.target
+        )?.pathType
+        const pathType = (data.pathType ??
+          placementPathType ??
+          defaultPathType) as NonNullable<EdgeSimulationData['pathType']>
+        const pathSource: ConfiguredEdgeLocality['pathSource'] = data.pathType
+          ? 'Manual'
+          : placementPathType
+            ? 'Auto from placement'
+            : 'Auto from defaults'
+        const sourceLocation = formatNodeLocation(locationTopology.nodeLocations.get(edge.source))
+        const targetLocation = formatNodeLocation(locationTopology.nodeLocations.get(edge.target))
+        const locality = describeEdgeLocality(locationTopology, edge)
+        const localityDetail =
+          sourceLocation && targetLocation
+            ? `${sourceLocation} -> ${targetLocation}`
+            : locality.detailLabel
+              ? locality.detailLabel
+              : pathSource === 'Auto from defaults'
+                ? 'Placement is incomplete, so this edge falls back to the generic default path class.'
+                : 'Placement is configured by composite ancestry.'
+
+        return {
+          edgeId: edge.id,
+          label: getEdgeLabel(edge, nodeLabelsById),
+          protocol: data.protocol ?? 'https',
+          mode: data.mode ?? 'synchronous',
+          pathType,
+          pathSource,
+          localityDetail
+        }
+      })
+      .sort((a, b) => a.label.localeCompare(b.label))
+  }, [edges, locationTopology, nodeById, nodeLabelsById])
+  const requestMix = useMemo(
+    () => (runConfig ? requestMixPreviewEntries(runConfig.workload).slice(0, 3) : []),
+    [runConfig]
+  )
+  const outcomeSplit = useMemo(
+    () =>
+      results
+        ? REQUEST_OUTCOME_FAMILIES.map((family) => ({
+            family,
+            count: results.requestOutcomeBreakdown[family] ?? 0
+          }))
+            .filter((entry) => entry.count > 0)
+            .sort((a, b) => b.count - a.count)
+            .slice(0, 4)
+        : [],
+    [results]
+  )
+  const outcomeTotal = results?.requestOutcomeTotal ?? 0
 
   return (
     <div className="h-full w-full bg-nss-panel border-l border-nss-border flex flex-col text-nss-text font-sans shadow-xl">
@@ -395,9 +736,16 @@ function RunInspector({
             <Activity size={24} />
           </div>
           <div className="min-w-0 flex-1">
-            <h2 className="truncate text-sm font-semibold leading-tight text-nss-text">
-              Run Inspector
-            </h2>
+            <div className="flex items-center gap-2">
+              <h2 className="truncate text-sm font-semibold leading-tight text-nss-text">
+                Run Inspector
+              </h2>
+              <TooltipInfo
+                label="Explain run inspector"
+                content={RUN_INSPECTOR_TOOLTIP}
+                width={320}
+              />
+            </div>
             <p className="mt-1 text-[10px] uppercase tracking-wide text-nss-muted">
               Live and post-run results
             </p>
@@ -406,22 +754,19 @@ function RunInspector({
 
         <div className="mt-4 grid grid-cols-2 gap-2">
           <div className="rounded-lg border border-nss-border bg-nss-surface px-3 py-2">
-            <MiniMetric
-              label="Node-Local Throughput"
-              value={`${formatRate(totalThroughput)} rps`}
-            />
+            <MiniMetric label="Runtime Throughput" value={`${formatRate(totalThroughput)} rps`} />
           </div>
           <div className="rounded-lg border border-nss-border bg-nss-surface px-3 py-2">
             <MiniMetric
-              label="Worst p95"
+              label="Slowest p95"
               value={worstP95 === null ? 'N/A' : `${worstP95.toFixed(1)}ms`}
             />
           </div>
           <div className="rounded-lg border border-nss-border bg-nss-surface px-3 py-2">
-            <MiniMetric label="Nodes" value={runtimeNodes.length.toLocaleString()} />
+            <MiniMetric label="Nodes in Run" value={runtimeNodes.length.toLocaleString()} />
           </div>
           <div className="rounded-lg border border-nss-border bg-nss-surface px-3 py-2">
-            <MiniMetric label="Links" value={runtimeEdges.length.toLocaleString()} />
+            <MiniMetric label="Traffic Links" value={runtimeEdges.length.toLocaleString()} />
           </div>
         </div>
 
@@ -444,10 +789,47 @@ function RunInspector({
             )}
           </div>
         )}
+
+        {(requestMix.length > 0 || outcomeSplit.length > 0) && (
+          <div className="mt-3 grid gap-2">
+            {requestMix.length > 0 && (
+              <CompactRunSummary title="Request Mix">
+                {requestMix.map((entry, index) => (
+                  <div
+                    key={`${entry.operationLabel}-${index}`}
+                    className="flex items-start justify-between gap-2 text-[11px]"
+                  >
+                    <span className="min-w-0 truncate text-nss-text">{entry.operationLabel}</span>
+                    <span className="shrink-0 text-nss-muted">{formatWeight(entry.weight)}</span>
+                  </div>
+                ))}
+              </CompactRunSummary>
+            )}
+
+            {outcomeSplit.length > 0 && (
+              <CompactRunSummary title="Outcome Split">
+                {outcomeSplit.map((entry) => (
+                  <div
+                    key={entry.family}
+                    className="flex items-start justify-between gap-2 text-[11px]"
+                  >
+                    <span className={clsx('min-w-0 truncate', outcomeFamilyTone(entry.family))}>
+                      {outcomeFamilyLabel(entry.family)}
+                    </span>
+                    <span className="shrink-0 text-nss-muted">
+                      {entry.count.toLocaleString()}
+                      {outcomeTotal > 0 ? ` · ${((entry.count / outcomeTotal) * 100).toFixed(0)}%` : ''}
+                    </span>
+                  </div>
+                ))}
+              </CompactRunSummary>
+            )}
+          </div>
+        )}
       </div>
 
       <div className="flex gap-1 border-b border-nss-border px-3 pt-3">
-        {(['nodes', 'links'] as const).map((option) => (
+        {(['nodes', 'links', 'locality'] as const).map((option) => (
           <button
             key={option}
             type="button"
@@ -459,7 +841,7 @@ function RunInspector({
                 : 'text-nss-muted hover:text-nss-text'
             )}
           >
-            {option === 'nodes' ? 'Nodes' : 'Links'}
+            {option === 'nodes' ? 'Nodes' : option === 'links' ? 'Links' : 'Locality'}
           </button>
         ))}
       </div>
@@ -503,6 +885,11 @@ function RunInspector({
                           <div className="truncate text-[10px] uppercase tracking-wide text-nss-muted">
                             {getNodeSubtitle(node)}
                           </div>
+                          {formatNodeLocation(locationTopology.nodeLocations.get(node.id)) && (
+                            <div className="truncate text-[10px] text-nss-muted">
+                              {formatNodeLocation(locationTopology.nodeLocations.get(node.id))}
+                            </div>
+                          )}
                         </div>
                         <CardBadge label={health.label} className={health.className} />
                       </div>
@@ -551,11 +938,12 @@ function RunInspector({
               )
             })}
           </div>
-        ) : (
+        ) : activeTab === 'links' ? (
           <div className="space-y-2">
             {runtimeEdges.map(({ edge, flow }) => {
               const health = edgeHealth(flow)
               const data = (edge.data as EdgeSimulationData | undefined) ?? {}
+              const locality = describeEdgeLocality(locationTopology, edge)
               const p95 = percentile(
                 flow.recent
                   .filter((event) => event.status === 'success')
@@ -583,6 +971,12 @@ function RunInspector({
                           <div className="truncate text-[10px] uppercase tracking-wide text-nss-muted">
                             {data.protocol ?? 'edge'} · {data.mode ?? 'synchronous'}
                           </div>
+                          {locality.pathType && (
+                            <div className="truncate text-[10px] text-nss-muted">
+                              {locality.pathType}
+                              {locality.detailLabel ? ` · ${locality.detailLabel}` : ''}
+                            </div>
+                          )}
                         </div>
                         <CardBadge label={health.label} className={health.className} />
                       </div>
@@ -607,6 +1001,131 @@ function RunInspector({
                 </button>
               )
             })}
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <InspectorSection
+              title="Runtime Deployment & Locality"
+              description="Actual run results grouped by composite placement and traffic path class. This is where region, AZ, subnet, and cross-location behavior show up after simulation."
+            >
+              <LocationRollupsPanel
+                nodeRollups={nodeLocationRollups}
+                edgeRollups={edgeLocalityRollups}
+                title="Deployment & Locality"
+              />
+            </InspectorSection>
+
+            <InspectorSection
+              title="Configured Placement"
+              description="Composite containers define locality. These groups show the configured deployment hierarchy, not just the parts that happened to carry traffic in the last run."
+            >
+              <div className="space-y-3">
+                {RUN_INSPECTOR_LOCATION_LEVELS.map((level) => {
+                  const groups = configuredLocationGroups[level]
+                  return (
+                    <div key={level} className="rounded-lg border border-nss-border bg-nss-panel p-3">
+                      <div className="mb-3 flex items-center justify-between gap-2">
+                        <div className="text-[11px] font-semibold uppercase tracking-wide text-nss-muted">
+                          {RUN_INSPECTOR_LOCATION_LEVEL_LABELS[level]}
+                        </div>
+                        <div className="text-[10px] text-nss-muted">{groups.length} configured</div>
+                      </div>
+                      {groups.length === 0 ? (
+                        <div className="text-[11px] text-nss-muted">
+                          No composite containers are configured at this level.
+                        </div>
+                      ) : (
+                        <div className="space-y-2">
+                          {groups.map((group) => (
+                            <div
+                              key={`${group.level}:${group.containerId}`}
+                              className="rounded border border-nss-border bg-nss-surface px-3 py-2"
+                            >
+                              <div className="flex items-start justify-between gap-2">
+                                <div className="min-w-0">
+                                  <div className="truncate text-xs font-medium text-nss-text">
+                                    {group.label}
+                                  </div>
+                                  {group.parentLabel ? (
+                                    <div className="truncate text-[10px] text-nss-muted">
+                                      under {group.parentLabel}
+                                    </div>
+                                  ) : null}
+                                </div>
+                                {group.memberCount === 0 ? (
+                                  <CardBadge
+                                    label="Empty"
+                                    className="border-nss-border bg-nss-panel text-nss-muted"
+                                  />
+                                ) : null}
+                              </div>
+                              <div className="mt-2 grid grid-cols-3 gap-3">
+                                <MiniMetric
+                                  label="Runtime Nodes"
+                                  value={group.runtimeNodeCount.toLocaleString()}
+                                />
+                                <MiniMetric
+                                  label="Sources"
+                                  value={group.sourceCount.toLocaleString()}
+                                />
+                                <MiniMetric
+                                  label="Members"
+                                  value={group.memberCount.toLocaleString()}
+                                />
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            </InspectorSection>
+
+            <InspectorSection
+              title="Configured Traffic Paths"
+              description="Each link resolves to a path class either from an explicit edge override, from composite placement, or from the generic default when placement is incomplete."
+            >
+              <div className="space-y-2">
+                {configuredEdgeLocality.map((entry) => (
+                  <div
+                    key={entry.edgeId}
+                    className="rounded-xl border border-nss-border bg-nss-panel p-3"
+                  >
+                    <div className="flex items-start gap-3">
+                      <div className="mt-0.5 shrink-0 rounded-lg bg-nss-surface p-2 text-nss-primary">
+                        <GitBranch size={16} />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-start justify-between gap-2">
+                          <div className="min-w-0">
+                            <div className="truncate text-sm font-semibold text-nss-text">
+                              {entry.label}
+                            </div>
+                            <div className="truncate text-[10px] uppercase tracking-wide text-nss-muted">
+                              {entry.protocol} · {entry.mode}
+                            </div>
+                          </div>
+                          <CardBadge
+                            label={entry.pathSource}
+                            className={localityPathSourceBadgeClass(entry.pathSource)}
+                          />
+                        </div>
+                        <div className="mt-2 flex items-center gap-2">
+                          <span className="text-xs font-semibold text-nss-text">
+                            {formatPathTypeLabel(entry.pathType)}
+                          </span>
+                        </div>
+                        <div className="mt-1 text-[10px] leading-relaxed text-nss-muted">
+                          {entry.localityDetail}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </InspectorSection>
           </div>
         )}
       </div>
@@ -718,7 +1237,7 @@ function EdgeMetricsDetail({ flow }: { flow: EdgeFlowState }) {
   )
 }
 
-export const PropertiesPanel = () => {
+export const PropertiesPanel = ({ results = null }: { results?: SimulationOutput | null }) => {
   const nodes = useStore((state) => state.nodes)
   const edges = useStore((state) => state.edges)
   const metricsByNode = useStore((state) => state.simulationMetricsByNode)
@@ -744,6 +1263,7 @@ export const PropertiesPanel = () => {
   const metrics = useNodeMetrics(selectedNode?.id ?? '')
   const [tab, setTab] = useState<PanelTab>('metrics')
   const [runInspectorTab, setRunInspectorTab] = useState<RunInspectorTab>('nodes')
+  const locationTopology = useMemo(() => buildLocationTopology(nodes), [nodes])
   const returnToRunInspector = () => {
     setRunInspectorPinned(true)
     selectGraphElements({})
@@ -786,6 +1306,7 @@ export const PropertiesPanel = () => {
         metricsByNode={metricsByNode}
         edgeFlowById={edgeFlowById}
         runConfig={edgeFlowRunConfig}
+        results={results}
         activeTab={runInspectorTab}
         onTabChange={setRunInspectorTab}
         onSelectNode={(id) => openRunInspectorDetail({ nodeId: id })}
@@ -885,6 +1406,11 @@ export const PropertiesPanel = () => {
     const targetNodeData = nodes.find((node) => node.id === selectedEdge.target)?.data as
       | CanvasNodeDataV2
       | undefined
+    const containerDerivedPath = pathTypeFromContainers(
+      locationTopology.containerLocations,
+      selectedEdge.source,
+      selectedEdge.target
+    )?.pathType
 
     const handleEdgeChange = (patch: Partial<EdgePropertiesPanelValue>) => {
       const { label, ...dataPatch } = patch
@@ -906,6 +1432,9 @@ export const PropertiesPanel = () => {
         }
         sourceNodeData={sourceNodeData}
         targetNodeData={targetNodeData}
+        sourceLocationLabel={formatNodeLocation(locationTopology.nodeLocations.get(selectedEdge.source))}
+        targetLocationLabel={formatNodeLocation(locationTopology.nodeLocations.get(selectedEdge.target))}
+        containerDerivedPathType={containerDerivedPath}
         value={{
           label: (selectedEdge.label as string) || '',
           ...(((selectedEdge.data as EdgeSimulationData | undefined) ?? {}) as EdgeSimulationData)
@@ -931,6 +1460,7 @@ export const PropertiesPanel = () => {
         metricsByNode={metricsByNode}
         edgeFlowById={edgeFlowById}
         runConfig={edgeFlowRunConfig}
+        results={results}
         activeTab={runInspectorTab}
         onTabChange={setRunInspectorTab}
         onSelectNode={(id) => openRunInspectorDetail({ nodeId: id })}

--- a/src/renderer/src/components/properties/PropertiesPanel.tsx
+++ b/src/renderer/src/components/properties/PropertiesPanel.tsx
@@ -219,16 +219,12 @@ function EdgeResultsSection({ title, children }: { title: string; children: Reac
   )
 }
 
-function CompactRunSummary({
-  title,
-  children
-}: {
-  title: string
-  children: ReactNode
-}) {
+function CompactRunSummary({ title, children }: { title: string; children: ReactNode }) {
   return (
     <div className="rounded-lg border border-nss-border bg-nss-surface px-3 py-2">
-      <div className="text-[10px] font-semibold uppercase tracking-wide text-nss-muted">{title}</div>
+      <div className="text-[10px] font-semibold uppercase tracking-wide text-nss-muted">
+        {title}
+      </div>
       <div className="mt-2 space-y-1.5">{children}</div>
     </div>
   )
@@ -425,8 +421,12 @@ function InspectorSection({
   return (
     <section className="space-y-3 rounded-xl border border-nss-border bg-nss-surface p-4">
       <div className="space-y-1">
-        <h3 className="text-[11px] font-semibold uppercase tracking-wide text-nss-muted">{title}</h3>
-        {description ? <p className="text-[11px] leading-relaxed text-nss-muted">{description}</p> : null}
+        <h3 className="text-[11px] font-semibold uppercase tracking-wide text-nss-muted">
+          {title}
+        </h3>
+        {description ? (
+          <p className="text-[11px] leading-relaxed text-nss-muted">{description}</p>
+        ) : null}
       </div>
       {children}
     </section>
@@ -642,7 +642,11 @@ function RunInspector({
 
       for (const level of RUN_INSPECTOR_LOCATION_LEVELS) {
         const containerId =
-          level === 'region' ? location.regionId : level === 'az' ? location.azId : location.subnetId
+          level === 'region'
+            ? location.regionId
+            : level === 'az'
+              ? location.azId
+              : location.subnetId
         if (!containerId) continue
         const key = `${level}:${containerId}`
         const current = grouped.get(key)
@@ -658,9 +662,7 @@ function RunInspector({
     }
 
     for (const level of RUN_INSPECTOR_LOCATION_LEVELS) {
-      empty[level].sort(
-        (a, b) => b.memberCount - a.memberCount || a.label.localeCompare(b.label)
-      )
+      empty[level].sort((a, b) => b.memberCount - a.memberCount || a.label.localeCompare(b.label))
     }
 
     return empty
@@ -677,9 +679,9 @@ function RunInspector({
           edge.source,
           edge.target
         )?.pathType
-        const pathType = (data.pathType ??
-          placementPathType ??
-          defaultPathType) as NonNullable<EdgeSimulationData['pathType']>
+        const pathType = (data.pathType ?? placementPathType ?? defaultPathType) as NonNullable<
+          EdgeSimulationData['pathType']
+        >
         const pathSource: ConfiguredEdgeLocality['pathSource'] = data.pathType
           ? 'Manual'
           : placementPathType
@@ -818,7 +820,9 @@ function RunInspector({
                     </span>
                     <span className="shrink-0 text-nss-muted">
                       {entry.count.toLocaleString()}
-                      {outcomeTotal > 0 ? ` · ${((entry.count / outcomeTotal) * 100).toFixed(0)}%` : ''}
+                      {outcomeTotal > 0
+                        ? ` · ${((entry.count / outcomeTotal) * 100).toFixed(0)}%`
+                        : ''}
                     </span>
                   </div>
                 ))}
@@ -1023,7 +1027,10 @@ function RunInspector({
                 {RUN_INSPECTOR_LOCATION_LEVELS.map((level) => {
                   const groups = configuredLocationGroups[level]
                   return (
-                    <div key={level} className="rounded-lg border border-nss-border bg-nss-panel p-3">
+                    <div
+                      key={level}
+                      className="rounded-lg border border-nss-border bg-nss-panel p-3"
+                    >
                       <div className="mb-3 flex items-center justify-between gap-2">
                         <div className="text-[11px] font-semibold uppercase tracking-wide text-nss-muted">
                           {RUN_INSPECTOR_LOCATION_LEVEL_LABELS[level]}
@@ -1432,8 +1439,12 @@ export const PropertiesPanel = ({ results = null }: { results?: SimulationOutput
         }
         sourceNodeData={sourceNodeData}
         targetNodeData={targetNodeData}
-        sourceLocationLabel={formatNodeLocation(locationTopology.nodeLocations.get(selectedEdge.source))}
-        targetLocationLabel={formatNodeLocation(locationTopology.nodeLocations.get(selectedEdge.target))}
+        sourceLocationLabel={formatNodeLocation(
+          locationTopology.nodeLocations.get(selectedEdge.source)
+        )}
+        targetLocationLabel={formatNodeLocation(
+          locationTopology.nodeLocations.get(selectedEdge.target)
+        )}
         containerDerivedPathType={containerDerivedPath}
         value={{
           label: (selectedEdge.label as string) || '',

--- a/src/renderer/src/components/properties/RequestDistributionEditor.tsx
+++ b/src/renderer/src/components/properties/RequestDistributionEditor.tsx
@@ -1,0 +1,207 @@
+import {
+  HTTP_METHODS,
+  inferHttpMethodFromRequestType,
+  type HttpMethod
+} from '../../../../engine/core/requestSemantics'
+import type { WorkloadProfile } from '../../../../engine/core/types'
+import { Input } from '../ui/Input'
+import { Label } from '../ui/Label'
+import { Select } from '../ui/Select'
+
+type RequestDistributionEntry = WorkloadProfile['requestDistribution'][number]
+
+type EditableMetadataField = 'method' | 'host' | 'path'
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined
+}
+
+function cloneMetadata(entry: RequestDistributionEntry): Record<string, unknown> {
+  return entry.metadata && typeof entry.metadata === 'object' ? { ...entry.metadata } : {}
+}
+
+function readMetadataField(entry: RequestDistributionEntry, field: EditableMetadataField): string {
+  if (field === 'method') {
+    return (
+      asNonEmptyString(entry.metadata?.method)?.toUpperCase() ??
+      inferHttpMethodFromRequestType(entry.type) ??
+      ''
+    )
+  }
+
+  return asNonEmptyString(entry.metadata?.[field]) ?? ''
+}
+
+function writeMetadataField(
+  entry: RequestDistributionEntry,
+  field: EditableMetadataField,
+  rawValue: string
+): RequestDistributionEntry {
+  const metadata = cloneMetadata(entry)
+  const normalized =
+    field === 'method' ? asNonEmptyString(rawValue)?.toUpperCase() : asNonEmptyString(rawValue)
+
+  if (normalized) {
+    metadata[field] = normalized
+  } else {
+    delete metadata[field]
+  }
+
+  return {
+    ...entry,
+    metadata: Object.keys(metadata).length > 0 ? metadata : undefined
+  }
+}
+
+interface RequestDistributionEditorProps {
+  entries: RequestDistributionEntry[]
+  onChange: (entries: RequestDistributionEntry[]) => void
+}
+
+export const RequestDistributionEditor = ({
+  entries,
+  onChange
+}: RequestDistributionEditorProps) => {
+  const totalWeightPct = entries.reduce((sum, entry) => sum + entry.weight * 100, 0)
+
+  const updateEntry = (index: number, nextEntry: RequestDistributionEntry) => {
+    onChange(entries.map((entry, currentIndex) => (currentIndex === index ? nextEntry : entry)))
+  }
+
+  const updateField = <K extends keyof RequestDistributionEntry>(
+    index: number,
+    field: K,
+    value: RequestDistributionEntry[K]
+  ) => {
+    updateEntry(index, {
+      ...entries[index],
+      [field]: value
+    })
+  }
+
+  const updateMetadataField = (index: number, field: EditableMetadataField, value: string) => {
+    updateEntry(index, writeMetadataField(entries[index], field, value))
+  }
+
+  const addEntry = () => {
+    onChange([
+      ...entries,
+      {
+        type: `request-${entries.length + 1}`,
+        weight: 0,
+        sizeBytes: 1024
+      }
+    ])
+  }
+
+  const removeEntry = (index: number) => {
+    onChange(entries.filter((_, currentIndex) => currentIndex !== index))
+  }
+
+  return (
+    <div className="mb-5" data-field-path="source.requestDistribution">
+      <Label>Requests</Label>
+      <p className="mb-2 text-[10px] leading-relaxed text-nss-muted">
+        Each entry is a request template. Type is the simulator&apos;s coarse request class; method,
+        host, and path add HTTP-aware routing context without dropping custom metadata.
+      </p>
+
+      <div className="space-y-2">
+        {entries.map((entry, index) => (
+          <div
+            key={index}
+            className="space-y-2 rounded border border-nss-border bg-nss-surface p-3"
+          >
+            <div className="grid gap-2 md:grid-cols-[minmax(0,1.4fr)_7rem_8rem_auto]">
+              <Input
+                type="text"
+                value={entry.type}
+                placeholder="e.g. create-order"
+                onChange={(event) => updateField(index, 'type', event.target.value)}
+              />
+              <Input
+                type="number"
+                min={0}
+                max={100}
+                step={0.1}
+                value={Number((entry.weight * 100).toFixed(3))}
+                rightElement="%"
+                className="pr-8"
+                onChange={(event) => {
+                  const parsed = Number(event.target.value)
+                  updateField(index, 'weight', Number.isFinite(parsed) ? parsed / 100 : 0)
+                }}
+              />
+              <Input
+                type="number"
+                min={1}
+                step={1}
+                value={entry.sizeBytes}
+                rightElement="B"
+                className="pr-8"
+                onChange={(event) => {
+                  const parsed = Number(event.target.value)
+                  updateField(index, 'sizeBytes', Number.isFinite(parsed) ? parsed : 1024)
+                }}
+              />
+              <button
+                type="button"
+                onClick={() => removeEntry(index)}
+                aria-label={`Remove request template ${index + 1}`}
+                className="shrink-0 rounded border border-nss-border px-2 py-2 text-xs text-nss-muted transition-colors hover:border-nss-danger hover:text-nss-danger"
+              >
+                ✕
+              </button>
+            </div>
+
+            <div className="grid gap-2 md:grid-cols-[10rem_minmax(0,1fr)_minmax(0,1.2fr)]">
+              <Select
+                value={readMetadataField(entry, 'method')}
+                onChange={(event) =>
+                  updateMetadataField(index, 'method', event.target.value as HttpMethod | '')
+                }
+              >
+                <option value="">Method</option>
+                {HTTP_METHODS.map((method) => (
+                  <option key={method} value={method}>
+                    {method}
+                  </option>
+                ))}
+              </Select>
+              <Input
+                type="text"
+                value={readMetadataField(entry, 'host')}
+                placeholder="Host, e.g. api.internal"
+                onChange={(event) => updateMetadataField(index, 'host', event.target.value)}
+              />
+              <Input
+                type="text"
+                value={readMetadataField(entry, 'path')}
+                placeholder="Path, e.g. /checkout"
+                onChange={(event) => updateMetadataField(index, 'path', event.target.value)}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-2 flex items-center justify-between gap-3">
+        <button
+          type="button"
+          onClick={addEntry}
+          className="rounded border border-dashed border-nss-border px-3 py-1.5 text-[11px] font-semibold text-nss-muted transition-colors hover:border-nss-primary hover:text-nss-primary"
+        >
+          + Add request
+        </button>
+        <div
+          className={[
+            'text-[10px] font-semibold tabular-nums',
+            Math.abs(totalWeightPct - 100) < 0.01 ? 'text-nss-muted' : 'text-nss-warning'
+          ].join(' ')}
+        >
+          Total weight {totalWeightPct.toFixed(1)}%
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/properties/RoutingRulesEditor.tsx
+++ b/src/renderer/src/components/properties/RoutingRulesEditor.tsx
@@ -1,12 +1,29 @@
 import { useShallow } from 'zustand/react/shallow'
-import type { ContentRoutingRule } from '../../../../engine/traits/contentRouting'
+import {
+  CONTENT_ROUTING_MATCH_FIELDS,
+  type ContentRoutingRule
+} from '../../../../engine/traits/contentRouting'
 import type { AnyNodeData } from '@renderer/types/ui'
 import useStore from '@renderer/store/useStore'
 import { Input } from '../ui/Input'
 import { Label } from '../ui/Label'
 import { Select } from '../ui/Select'
 
-const MATCH_FIELDS: ContentRoutingRule['matchField'][] = ['type', 'path', 'host']
+const MATCH_FIELDS: ContentRoutingRule['matchField'][] = [...CONTENT_ROUTING_MATCH_FIELDS]
+
+function placeholderForField(field: ContentRoutingRule['matchField']): string {
+  switch (field) {
+    case 'method':
+      return 'e.g. POST'
+    case 'host':
+      return 'e.g. api.internal'
+    case 'path':
+      return 'e.g. /checkout'
+    case 'type':
+    default:
+      return 'e.g. create-order'
+  }
+}
 
 interface RoutingRulesEditorProps {
   nodeId: string
@@ -80,7 +97,7 @@ export const RoutingRulesEditor = ({ nodeId, rules, onChange }: RoutingRulesEdit
               <Input
                 type="text"
                 value={rule.matchValue}
-                placeholder="e.g. write"
+                placeholder={placeholderForField(rule.matchField)}
                 onChange={(event) => updateRule(index, { matchValue: event.target.value })}
               />
             </div>

--- a/src/renderer/src/components/simulation/ResultsTray.tsx
+++ b/src/renderer/src/components/simulation/ResultsTray.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import type { ButtonHTMLAttributes, CSSProperties, HTMLAttributes } from 'react'
+import { clsx } from 'clsx'
 import {
   ChevronLeft,
   ChevronRight,
@@ -21,8 +22,14 @@ import type {
   DebugEvent,
   RequestOutcomeRecord
 } from '../../../../engine/core/event-stream'
+import type { CanvasNodeDataV2 } from '../../../../engine/catalog/nodeSpecTypes'
+import {
+  REQUEST_OUTCOME_FAMILIES,
+  type RequestOutcomeFamily
+} from '../../../../engine/core/requestOutcomeSemantics'
+import { describeRequestOperation } from '../../../../engine/core/requestSemantics'
 import type { SimulationStatus } from '../../hooks/useSimulation'
-import useStore, { type EdgeFlowRenderEvent } from '../../store/useStore'
+import useStore, { type EdgeFlowRenderEvent, type EdgeFlowState } from '../../store/useStore'
 import { HoverTooltip, TooltipInfo } from '@renderer/components/ui/Tooltip'
 import {
   RESULTS_CONTEXTUAL_TOOLTIPS,
@@ -38,6 +45,15 @@ import {
   dominantTimeToErrorCause
 } from '@renderer/utils/errorCausePresentation'
 import { failureRateLevelFromRatio } from '@renderer/utils/failureRatePresentation'
+import { LocationRollupsPanel } from '@renderer/components/location/LocationRollupsPanel'
+import {
+  buildEdgeLocalityRollups,
+  buildEdgeRollupInputsFromResults,
+  buildLocationTopology,
+  buildNodeLocationRollups,
+  buildNodeRollupInputsFromResults,
+  formatNodeLocation
+} from '@renderer/utils/locationTopology'
 import {
   capacityRank,
   deriveCapacityStatus,
@@ -106,6 +122,16 @@ function fmtCv(value: number | null): string {
   return value === null ? 'N/A' : value.toFixed(2)
 }
 
+function fmtWeight(weight: number): string {
+  return `${(weight * 100).toFixed(weight * 100 < 10 ? 1 : 0)}%`
+}
+
+function fmtBytes(bytes: number): string {
+  if (bytes >= 1_000_000) return `${(bytes / 1_000_000).toFixed(1)} MB`
+  if (bytes >= 1_000) return `${(bytes / 1_000).toFixed(1)} KB`
+  return `${bytes} B`
+}
+
 function fmtLambda(lambda: number): string {
   return lambda === 0 ? '-' : `${lambda.toFixed(2)}`
 }
@@ -122,6 +148,51 @@ function totalReplayEventCount(output: SimulationOutput): number {
   return Object.values(output.eventCountsByType).reduce((sum, count) => sum + count, 0)
 }
 
+function outcomeFamilyLabel(family: RequestOutcomeFamily): string {
+  switch (family) {
+    case 'success_2xx':
+      return '2xx success'
+    case 'client_error_4xx':
+      return '4xx reject'
+    case 'server_error_5xx':
+      return '5xx failure'
+    case 'network_timeout':
+      return 'Timeout'
+    case 'network_drop':
+      return 'Network drop'
+    case 'connection_reset':
+      return 'Reset'
+    case 'in_flight':
+      return 'In flight'
+  }
+}
+
+function outcomeFamilyBadgeClass(family: RequestOutcomeFamily): string {
+  switch (family) {
+    case 'success_2xx':
+      return 'text-nss-success bg-nss-success/10 border-nss-success/20'
+    case 'network_timeout':
+    case 'in_flight':
+      return 'text-nss-warning bg-nss-warning/10 border-nss-warning/20'
+    case 'client_error_4xx':
+      return 'text-nss-primary bg-nss-primary/10 border-nss-primary/20'
+    case 'server_error_5xx':
+    case 'network_drop':
+    case 'connection_reset':
+      return 'text-nss-danger bg-nss-danger/10 border-nss-danger/20'
+  }
+}
+
+function requestMixEntries(workload: ScenarioRunContext['workload']) {
+  return [...workload.requestDistribution]
+    .map((entry) => ({
+      ...describeRequestOperation({ type: entry.type, metadata: entry.metadata }),
+      weight: entry.weight,
+      sizeBytes: entry.sizeBytes
+    }))
+    .sort((a, b) => b.weight - a.weight)
+}
+
 const SECTION_TITLE = 'text-[11px] font-semibold text-nss-muted uppercase tracking-wider'
 const SURFACE_CARD = 'bg-nss-surface border border-nss-border rounded-md'
 const TRAFFIC_EVENT_LOG_SIZE = 24
@@ -133,6 +204,11 @@ const RESULTS_TABS: Array<{ id: ResultsTab; label: string }> = [
 ]
 
 const LIVE_PATTERN_BAR_COUNT = 24
+const RUNTIME_NODE_METRICS_TOOLTIP =
+  'Queueing, service, and error metrics for runtime nodes that actually received post-warmup traffic. Sources are shown separately because they generate offered load instead of receiving arrivals.'
+const SOURCE_DRIVERS_TOOLTIP =
+  'Source nodes define the offered workload. They emit traffic into the graph, so queueing and arrival-based node-local metrics start on the first downstream runtime node instead.'
+
 type TrafficStatusFilter = 'all' | EdgeFlowRenderEvent['status']
 const TRAFFIC_STATUS_FILTERS: Array<{ id: TrafficStatusFilter; label: string }> = [
   { id: 'all', label: 'All' },
@@ -158,6 +234,16 @@ function eventStatusClass(status: DebugEvent['status']): string {
 
 function labelForNode(nodeId: string | undefined, lookup: EventGraphLookup): string | undefined {
   return nodeId ? lookup.nodeLabelById.get(nodeId) : undefined
+}
+
+function sourceEmittedCount(
+  nodeId: string,
+  edges: ReturnType<typeof useStore.getState>['edges'],
+  edgeFlowById: Record<string, EdgeFlowState>
+): number {
+  return edges
+    .filter((edge) => edge.source === nodeId)
+    .reduce((sum, edge) => sum + (edgeFlowById[edge.id]?.totalAttempted ?? 0), 0)
 }
 
 function workloadPatternDetails(workload: ScenarioRunContext['workload']): string[] {
@@ -854,10 +940,8 @@ function RequestOutcomeLog({
 
   const outcomes = output.requestOutcomes
 
-  // Per-request terminal reason (e.g. queue_full, node_error_rate, policy). It is
-  // not on the outcome row — it lives as reasonCode on the request's events — so
-  // we fold the stream into requestId → last reasonCode (highest sequence wins,
-  // which is the terminal one). Empty when the stream was capped for a large run.
+  // Legacy fallback for older retained outcome rows that did not yet carry the
+  // terminal reason inline.
   const reasonByRequestId = useMemo(() => {
     const map = new Map<string, { sequence: number; reason: string }>()
     for (const event of output.eventStream) {
@@ -885,7 +969,7 @@ function RequestOutcomeLog({
     return counts
   }, [outcomes])
 
-  // Chip filter, then free-text search over request id / node label / status.
+  // Chip filter, then free-text search over request id / operation / node / outcome.
   const trimmedQuery = query.trim().toLowerCase()
   const visibleRows = useMemo(() => {
     const byStatus =
@@ -893,9 +977,11 @@ function RequestOutcomeLog({
     if (trimmedQuery === '') return byStatus
     return byStatus.filter((row) => {
       const nodeLabel = row.nodeId ? (labelForNode(row.nodeId, graphLookup) ?? row.nodeId) : ''
-      const reason = reasonByRequestId.get(row.requestId)?.reason ?? ''
+      const reason = row.reasonCode ?? reasonByRequestId.get(row.requestId)?.reason ?? ''
+      const operationLabel = row.operationLabel ?? row.requestType ?? row.requestId
+      const statusFamily = outcomeFamilyLabel(row.outcomeFamily)
       const haystack =
-        `${row.requestId} ${nodeLabel} ${OUTCOME_STATUS_LABEL[row.status]} ${reason}`.toLowerCase()
+        `${row.requestId} ${operationLabel} ${nodeLabel} ${OUTCOME_STATUS_LABEL[row.status]} ${statusFamily} ${row.statusClass} ${reason}`.toLowerCase()
       return haystack.includes(trimmedQuery)
     })
   }, [outcomes, statusFilter, trimmedQuery, graphLookup, reasonByRequestId])
@@ -958,6 +1044,10 @@ function RequestOutcomeLog({
               ? `Showing a sampled request-outcome ledger. ${outcomes.length.toLocaleString()} outcomes are retained from ${totalOutcomeCount.toLocaleString()} total; aggregate metrics above remain exact. Search and pagination only cover retained rows.`
               : 'Final fate of every request this run. Click a row for its lifecycle.'}
           </div>
+          <div className="mt-1 text-[10px] text-nss-muted">
+            Operation labels come from the workload request mix. 4xx and 5xx classes are inferred
+            from current simulator reasons; exact endpoint-specific HTTP codes are not yet modeled.
+          </div>
         </div>
         <span className="text-[10px] text-nss-muted tabular-nums">
           {outcomesSampled
@@ -997,7 +1087,7 @@ function RequestOutcomeLog({
           type="text"
           value={query}
           onChange={(event) => setQuery(event.target.value)}
-          placeholder="Search by request id, node, or status…"
+          placeholder="Search by request id, endpoint, node, or outcome…"
           aria-label="Search request outcomes"
           className="w-full rounded-md border border-nss-border bg-nss-bg py-1.5 pl-8 pr-8 text-[11px] text-nss-text placeholder:text-nss-muted focus:border-nss-primary/50 focus:outline-none focus:ring-1 focus:ring-nss-primary/40"
         />
@@ -1022,7 +1112,7 @@ function RequestOutcomeLog({
                   <th className="px-2 py-1.5 text-left">Request</th>
                   <th className="px-2 py-1.5 text-left">Terminal</th>
                   <th className="px-2 py-1.5 text-left">Node</th>
-                  <th className="px-2 py-1.5 text-left">Status</th>
+                  <th className="px-2 py-1.5 text-left">Outcome</th>
                   <th className="px-2 py-1.5 text-right">Attempts</th>
                   <th className="px-2 py-1.5 text-right">Latency</th>
                 </tr>
@@ -1033,10 +1123,10 @@ function RequestOutcomeLog({
                     ? (labelForNode(row.nodeId, graphLookup) ?? row.nodeId)
                     : '-'
                   const isExpanded = expandedRequestId === row.requestId
-                  // Only failed terminals have a "why"; success and in-flight do not.
+                  const operationLabel = row.operationLabel ?? row.requestType ?? row.requestId
                   const failureReason =
                     row.status !== 'success' && row.status !== 'in-flight'
-                      ? (reasonByRequestId.get(row.requestId)?.reason ?? null)
+                      ? (row.reasonCode ?? reasonByRequestId.get(row.requestId)?.reason ?? null)
                       : null
 
                   return (
@@ -1067,9 +1157,14 @@ function RequestOutcomeLog({
                         }`}
                       >
                         <td className="px-2 py-1 text-nss-text">
-                          <div className="flex items-center gap-1 truncate">
-                            <span className="text-nss-muted">{isExpanded ? '▾' : '▸'}</span>
-                            <span className="truncate">{row.requestId}</span>
+                          <div className="flex items-start gap-1">
+                            <span className="pt-0.5 text-nss-muted">{isExpanded ? '▾' : '▸'}</span>
+                            <div className="min-w-0">
+                              <span className="block truncate">{row.requestId}</span>
+                              <span className="block truncate text-[9px] text-nss-muted">
+                                {operationLabel}
+                              </span>
+                            </div>
                           </div>
                         </td>
                         <td className="px-2 py-1 text-nss-muted">
@@ -1081,15 +1176,15 @@ function RequestOutcomeLog({
                         <td className="px-2 py-1">
                           <div className="flex flex-col items-start gap-0.5">
                             <span
-                              className={`rounded-full border px-1.5 py-0.5 text-[10px] font-medium ${outcomeStatusBadgeClass(row.status)}`}
+                              className={`rounded-full border px-1.5 py-0.5 text-[10px] font-medium ${outcomeFamilyBadgeClass(row.outcomeFamily)}`}
                             >
-                              {OUTCOME_STATUS_LABEL[row.status]}
+                              {outcomeFamilyLabel(row.outcomeFamily)}
                             </span>
-                            {failureReason && (
-                              <span className="text-[9px] text-nss-muted" title={failureReason}>
-                                {failureReason}
-                              </span>
-                            )}
+                            <span className="text-[9px] text-nss-muted">
+                              {OUTCOME_STATUS_LABEL[row.status]}
+                              {row.statusCodeHint ? ` · ${row.statusCodeHint} hint` : ''}
+                              {failureReason ? ` · ${failureReason}` : ''}
+                            </span>
                           </div>
                         </td>
                         <td className="px-2 py-1 text-right text-nss-muted">
@@ -1725,6 +1820,7 @@ function ReplayMonitorPanel({
   const buttonClass =
     'h-7 w-7 inline-flex items-center justify-center rounded border border-nss-border text-nss-muted hover:text-nss-text hover:bg-nss-surface transition-colors disabled:opacity-40 disabled:hover:bg-transparent'
   const patternDetails = workloadPatternDetails(runContext.workload)
+  const requestMix = requestMixEntries(runContext.workload)
 
   return (
     <div className="space-y-3">
@@ -1865,6 +1961,18 @@ function ReplayMonitorPanel({
         {patternDetails.length > 0 && (
           <div className="text-xs text-nss-muted">{patternDetails.join(' • ')}</div>
         )}
+
+        <div className="flex flex-wrap gap-1.5">
+          {requestMix.map((entry, index) => (
+            <span
+              key={`${entry.operationLabel}-${index}`}
+              className="rounded-full border border-nss-border bg-nss-panel px-2 py-1 text-[10px] text-nss-muted"
+            >
+              <span className="font-medium text-nss-text">{entry.operationLabel}</span>{' '}
+              <span>{fmtWeight(entry.weight)}</span>
+            </span>
+          ))}
+        </div>
       </div>
 
       <div className="grid grid-cols-2 gap-2 text-sm xl:grid-cols-4">
@@ -2046,9 +2154,99 @@ function TimeToErrorCard({
   )
 }
 
+function RequestMixPanel({ runContext }: { runContext: ScenarioRunContext }) {
+  const mix = requestMixEntries(runContext.workload)
+
+  return (
+    <div className={`${SURFACE_CARD} p-3`}>
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs font-semibold uppercase tracking-wider text-nss-muted">
+          Request Mix
+        </span>
+        <TooltipInfo
+          label="About request mix"
+          content="Each entry is a request template emitted by the selected source. Method, host, and path are configured at the workload layer, not on an edge, because they describe the operation being sent through the graph."
+        />
+      </div>
+      <div className="mt-3 space-y-2">
+        {mix.map((entry, index) => (
+          <div
+            key={`${entry.operationLabel}-${index}`}
+            className="rounded border border-nss-border bg-nss-panel px-2.5 py-2"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="truncate text-xs font-medium text-nss-text">
+                  {entry.operationLabel}
+                </div>
+                <div className="truncate text-[10px] text-nss-muted">
+                  {entry.requestType ?? 'request'} · {fmtBytes(entry.sizeBytes)}
+                </div>
+              </div>
+              <span className="shrink-0 rounded-full border border-nss-primary/20 bg-nss-primary/10 px-2 py-0.5 text-[10px] font-medium text-nss-primary">
+                {fmtWeight(entry.weight)}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function OutcomeBreakdownPanel({ output }: { output: SimulationOutput }) {
+  const total = Math.max(1, output.requestOutcomeTotal)
+  const entries = REQUEST_OUTCOME_FAMILIES.map((family) => ({
+    family,
+    count: output.requestOutcomeBreakdown[family] ?? 0
+  })).filter((entry) => entry.count > 0)
+
+  return (
+    <div className={`${SURFACE_CARD} p-3`}>
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs font-semibold uppercase tracking-wider text-nss-muted">
+          Outcome Classes
+        </span>
+        <TooltipInfo
+          label="About outcome classes"
+          content="This split is exact for the whole run, even when the per-request ledger below is sampled. 4xx and 5xx are current simulator inferences from rejection reasons; exact endpoint-specific codes such as 201 or 404 are not yet modeled."
+        />
+      </div>
+      <div className="mt-3 space-y-2">
+        {entries.map(({ family, count }) => (
+          <div
+            key={family}
+            className="flex items-center justify-between gap-3 rounded border border-nss-border bg-nss-panel px-2.5 py-2"
+          >
+            <div className="flex items-center gap-2">
+              <span
+                className={`rounded-full border px-1.5 py-0.5 text-[10px] font-medium ${outcomeFamilyBadgeClass(family)}`}
+              >
+                {outcomeFamilyLabel(family)}
+              </span>
+            </div>
+            <div className="text-right">
+              <div className="text-xs font-medium tabular-nums text-nss-text">
+                {count.toLocaleString()}
+              </div>
+              <div className="text-[10px] text-nss-muted">{fmtPct(count / total)}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 // ─── Summary Panel ────────────────────────────────────────────────────────────
 
-function SummaryPanel({ output }: { output: SimulationOutput }) {
+function SummaryPanel({
+  output,
+  runContext
+}: {
+  output: SimulationOutput
+  runContext: ScenarioRunContext | null
+}) {
   const { summary } = output
   const l = summary.latency
   // Only show causes that actually fired — a "Node Failed" card appearing while
@@ -2152,6 +2350,11 @@ function SummaryPanel({ output }: { output: SimulationOutput }) {
         </div>
       )}
 
+      <div className={clsx('grid gap-2', runContext ? 'xl:grid-cols-2' : 'xl:grid-cols-1')}>
+        {runContext && <RequestMixPanel runContext={runContext} />}
+        <OutcomeBreakdownPanel output={output} />
+      </div>
+
       <LatencyPopulationSection
         title="Success Latency"
         subtitle="Successful requests only. Read these percentiles together with the paired error rate for the same steady-state window."
@@ -2181,27 +2384,29 @@ function SummaryPanel({ output }: { output: SimulationOutput }) {
         </div>
       </LatencyPopulationSection>
 
-      <LatencyPopulationSection
-        title="Time-to-Error"
-        subtitle="Failed requests only, split by cause so instant rejects, silent timeouts, and connection resets do not blend into one fake latency distribution."
-        sampleCount={summary.timeToErrorSamples}
-        errorRate={summary.latencyWindowErrorRate}
-      >
-        <div className="grid gap-2 md:grid-cols-3">
-          {timeToErrorEntries.map(([cause, metrics]) => (
-            <TimeToErrorCard
-              key={cause}
-              title={ERROR_CAUSE_LABELS[cause]}
-              count={metrics.count}
-              errorRate={metrics.errorRate}
-              shareOfErrors={metrics.shareOfErrors}
-              p50={metrics.p50}
-              p95={metrics.p95}
-              p99={metrics.p99}
-            />
-          ))}
-        </div>
-      </LatencyPopulationSection>
+      {summary.timeToErrorSamples > 0 && (
+        <LatencyPopulationSection
+          title="Time-to-Error"
+          subtitle="Failed requests only, split by cause so instant rejects, silent timeouts, and connection resets do not blend into one fake latency distribution."
+          sampleCount={summary.timeToErrorSamples}
+          errorRate={summary.latencyWindowErrorRate}
+        >
+          <div className="grid gap-2 md:grid-cols-3">
+            {timeToErrorEntries.map(([cause, metrics]) => (
+              <TimeToErrorCard
+                key={cause}
+                title={ERROR_CAUSE_LABELS[cause]}
+                count={metrics.count}
+                errorRate={metrics.errorRate}
+                shareOfErrors={metrics.shareOfErrors}
+                p50={metrics.p50}
+                p95={metrics.p95}
+                p99={metrics.p99}
+              />
+            ))}
+          </div>
+        </LatencyPopulationSection>
+      )}
     </div>
   )
 }
@@ -3823,9 +4028,77 @@ function buildPerNodeFindings(
   return findings
 }
 
-function PerNodeTable({ output }: { output: SimulationOutput }) {
+function SourceDriverCard({
+  label,
+  location,
+  offeredRps,
+  pattern,
+  emitted
+}: {
+  label: string
+  location: string | null
+  offeredRps?: number
+  pattern?: string
+  emitted: number
+}) {
+  return (
+    <div className="rounded-lg border border-nss-border bg-nss-panel p-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="truncate text-xs font-semibold text-nss-text">{label}</div>
+          {location && <div className="truncate text-[10px] text-nss-muted">{location}</div>}
+        </div>
+        <span className="shrink-0 rounded-full border border-nss-primary/20 bg-nss-primary/10 px-2 py-0.5 text-[9px] font-bold uppercase tracking-wide text-nss-primary">
+          Source
+        </span>
+      </div>
+
+      <div className="mt-3 grid grid-cols-3 gap-3">
+        <div className="min-w-0">
+          <div className="text-[9px] font-semibold uppercase tracking-wide text-nss-muted">
+            Offered
+          </div>
+          <div className="truncate text-xs font-semibold tabular-nums text-nss-text">
+            {offeredRps === undefined ? 'N/A' : fmtRps(offeredRps)}
+          </div>
+        </div>
+        <div className="min-w-0">
+          <div className="text-[9px] font-semibold uppercase tracking-wide text-nss-muted">
+            Pattern
+          </div>
+          <div className="truncate text-xs font-semibold text-nss-text">{pattern ?? 'N/A'}</div>
+        </div>
+        <div className="min-w-0">
+          <div className="text-[9px] font-semibold uppercase tracking-wide text-nss-muted">
+            Emitted
+          </div>
+          <div className="truncate text-xs font-semibold tabular-nums text-nss-text">
+            {emitted.toLocaleString()}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-2 text-[10px] leading-snug text-nss-muted">
+        Sources generate load. Queueing, arrivals, and node-local latency begin on the first
+        downstream runtime node.
+      </div>
+    </div>
+  )
+}
+
+function PerNodeTable({
+  output,
+  locationTopology,
+  runContext
+}: {
+  output: SimulationOutput
+  locationTopology: ReturnType<typeof buildLocationTopology>
+  runContext: ScenarioRunContext | null
+}) {
   const [showInactive, setShowInactive] = useState(false)
   const nodes = useStore((state) => state.nodes)
+  const edges = useStore((state) => state.edges)
+  const edgeFlowById = useStore((state) => state.edgeFlowById)
   const entries = Object.entries(output.perNode)
 
   // Source nodes emit traffic rather than receive it, so their `postWarmupArrived`
@@ -3841,6 +4114,7 @@ function PerNodeTable({ output }: { output: SimulationOutput }) {
     }
     return ids
   }, [nodes])
+  const nodeById = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes])
 
   if (entries.length === 0) return null
 
@@ -3849,15 +4123,29 @@ function PerNodeTable({ output }: { output: SimulationOutput }) {
     output.conservationCheck.map((result) => [result.nodeId, result])
   )
 
-  const activeEntries = entries.filter(([, m]) => m.postWarmupArrived > 0)
+  const activeEntries = entries.filter(
+    ([nodeId, m]) => m.postWarmupArrived > 0 && !sourceNodeIds.has(nodeId)
+  )
   const idleEntries = entries.filter(([, m]) => m.postWarmupArrived === 0)
   const sourceEntries = idleEntries.filter(([nodeId]) => sourceNodeIds.has(nodeId))
   const inactiveEntries = idleEntries.filter(([nodeId]) => !sourceNodeIds.has(nodeId))
   const findings = buildPerNodeFindings(entries)
 
   return (
-    <div className="space-y-2">
-      <h3 className={SECTION_TITLE}>Per-node Metrics</h3>
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <h3 className={SECTION_TITLE}>Runtime Node Metrics</h3>
+        <TooltipInfo
+          label="Explain runtime node metrics"
+          content={RUNTIME_NODE_METRICS_TOOLTIP}
+          width={320}
+          className="h-4 w-4 text-[9px]"
+        />
+      </div>
+      <p className="text-[10px] text-nss-muted">
+        Arrivals, queueing, node-local latency, and errors for nodes that processed post-warmup
+        traffic.
+      </p>
       <div className={`${SURFACE_CARD} p-3`}>
         <div className="mb-2 text-[10px] font-bold uppercase tracking-widest text-nss-muted">
           Top Findings
@@ -3873,145 +4161,186 @@ function PerNodeTable({ output }: { output: SimulationOutput }) {
           ))}
         </div>
       </div>
-      <div className="overflow-x-auto">
-        <table className="w-full text-xs tabular-nums">
-          <thead>
-            <tr className="text-nss-muted border-b border-nss-border">
-              <th className="text-left pb-1 pr-2">Node</th>
-              <MetricHeaderCell
-                label="Arrived"
-                tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.arrived}
-              />
-              <MetricHeaderCell label="Done" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.done} />
-              <MetricHeaderCell label="Reject" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.reject} />
-              <MetricHeaderCell label="T.O." tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.timedOut} />
-              <MetricHeaderCell label="Reset" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.reset} />
-              <MetricHeaderCell
-                label="In Flight"
-                tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.inFlight}
-              />
-              <MetricHeaderCell label="Avg Q" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.avgQueue} />
-              <MetricHeaderCell label="Util" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.util} />
-              <MetricHeaderCell
-                label="Err %"
-                tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.errorRate}
-              />
-              <MetricHeaderCell
-                label="Arr CV"
-                tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.arrivalCV}
-              />
-              <MetricHeaderCell label="p50" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.p50} />
-              <MetricHeaderCell label="p95" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.p95} />
-              <MetricHeaderCell label="p99" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.p99} />
-              <MetricHeaderCell label="λ" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.lambda} />
-              <MetricHeaderCell label="W" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.w} />
-              <MetricHeaderCell
-                label="L"
-                tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.l}
-                className="text-right pb-1"
-              />
-            </tr>
-          </thead>
-          <tbody>
-            {activeEntries.map(([nodeId, m]) => {
-              const ll = llByNode.get(nodeId)
-              const conservation = conservationByNode.get(nodeId)
-              const inFlight = conservation?.inFlight ?? 0
-              const utilPct = (m.utilization * 100).toFixed(1)
-              const utilColour =
-                m.utilization > 0.9
-                  ? 'text-nss-danger'
-                  : m.utilization > 0.7
-                    ? 'text-nss-warning'
-                    : 'text-nss-success'
-              const arrivalCvWarn =
-                m.arrivalCV !== null &&
-                output.summary.offeredArrivalCV !== null &&
-                m.arrivalCV > output.summary.offeredArrivalCV + 0.05
-              const llViolation = ll && !ll.withinTolerance
+      {sourceEntries.length > 0 && (
+        <div className={`${SURFACE_CARD} p-3`}>
+          <div className="mb-2 flex items-center gap-2">
+            <div className="text-[10px] font-bold uppercase tracking-widest text-nss-muted">
+              Source Drivers
+            </div>
+            <TooltipInfo
+              label="Explain source drivers"
+              content={SOURCE_DRIVERS_TOOLTIP}
+              width={320}
+              className="h-4 w-4 text-[9px]"
+            />
+          </div>
+          <div className="grid gap-2 md:grid-cols-2">
+            {sourceEntries.map(([nodeId, m]) => {
+              const node = nodeById.get(nodeId)
+              const data = node?.data as Partial<CanvasNodeDataV2> | undefined
+              const staticWorkload = data?.source?.defaultWorkload
+              const isRunSource = runContext?.sourceNodeId === nodeId
+              const offeredRps = isRunSource ? runContext?.workload.baseRps : staticWorkload?.baseRps
+              const pattern = isRunSource ? runContext?.workload.pattern : staticWorkload?.pattern
 
               return (
-                <tr key={nodeId} className="border-b border-nss-border hover:bg-nss-surface/70">
-                  <td className="py-1 pr-2 text-nss-text truncate max-w-[100px]">
-                    {m.nodeLabel ?? nodeId}
-                  </td>
-                  <td className="text-right pr-2 text-nss-text">
-                    {m.postWarmupArrived.toLocaleString()}
-                  </td>
-                  <td className="text-right pr-2 text-nss-text">
-                    {m.postWarmupProcessed.toLocaleString()}
-                  </td>
-                  <td className="text-right pr-2 text-nss-muted">
-                    {m.postWarmupRejected.toLocaleString()}
-                  </td>
-                  <td className="text-right pr-2 text-nss-muted">
-                    {m.postWarmupTimedOut.toLocaleString()}
-                  </td>
-                  <td className="text-right pr-2 text-nss-muted">
-                    {m.postWarmupConnectionReset.toLocaleString()}
-                  </td>
-                  <td
-                    className={`text-right pr-2 ${inFlight > 0 ? 'text-nss-warning' : 'text-nss-muted'}`}
-                  >
-                    {inFlight.toLocaleString()}
-                  </td>
-                  <td className="text-right pr-2 text-nss-muted">{m.avgQueueLength.toFixed(1)}</td>
-                  <td className={`text-right pr-2 ${utilColour}`}>{utilPct}%</td>
-                  <td
-                    className={`text-right pr-2 ${
-                      m.errorRate > 0.05
-                        ? 'text-nss-danger'
-                        : m.errorRate > 0.01
-                          ? 'text-nss-warning'
-                          : 'text-nss-muted'
-                    }`}
-                  >
-                    {fmtPct(m.errorRate)}
-                  </td>
-                  <td
-                    className={`text-right pr-2 ${
-                      arrivalCvWarn ? 'text-nss-warning' : 'text-nss-muted'
-                    }`}
-                  >
-                    {fmtCv(m.arrivalCV)}
-                  </td>
-                  <td className="text-right pr-2 text-nss-text">{fmtMs(m.latencyP50)}</td>
-                  <td className="text-right pr-2 text-nss-text">{fmtMs(m.latencyP95)}</td>
-                  <td className="text-right pr-2 text-nss-text">{fmtMs(m.latencyP99)}</td>
-                  <td className="text-right pr-2 text-nss-muted">
-                    {ll ? fmtLambda(ll.lambda) : '-'}
-                  </td>
-                  <td className="text-right pr-2 text-nss-muted">{ll ? fmtW(ll.wSeconds) : '-'}</td>
-                  <td
-                    className={`text-right ${llViolation ? 'text-nss-warning font-medium' : 'text-nss-muted'}`}
-                    title={
-                      llViolation ? `Little's Law: expected ${fmtL(ll!.expectedL)}` : undefined
-                    }
-                  >
-                    {ll ? fmtL(ll.observedL) : '-'}
-                    {llViolation && <span className="ml-0.5">⚠</span>}
-                  </td>
-                </tr>
+                <SourceDriverCard
+                  key={nodeId}
+                  label={m.nodeLabel ?? nodeId}
+                  location={formatNodeLocation(locationTopology.nodeLocations.get(nodeId))}
+                  offeredRps={offeredRps}
+                  pattern={pattern}
+                  emitted={sourceEmittedCount(nodeId, edges, edgeFlowById)}
+                />
               )
             })}
-          </tbody>
-        </table>
-      </div>
-
-      {sourceEntries.length > 0 && (
-        <table className="w-full text-xs tabular-nums mt-1 opacity-60">
-          <tbody>
-            {sourceEntries.map(([nodeId, m]) => (
-              <tr key={nodeId} className="border-b border-nss-border">
-                <td className="py-0.5 pr-2 text-nss-muted">{m.nodeLabel ?? nodeId}</td>
-                <td className="text-right text-nss-muted text-[10px] italic" colSpan={16}>
-                  source · emits traffic (not measured by arrivals)
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+          </div>
+        </div>
       )}
+
+      {activeEntries.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs tabular-nums">
+            <thead>
+              <tr className="text-nss-muted border-b border-nss-border">
+                <th className="text-left pb-1 pr-2">Node</th>
+                <MetricHeaderCell
+                  label="Arrived"
+                  tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.arrived}
+                />
+                <MetricHeaderCell label="Done" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.done} />
+                <MetricHeaderCell label="Reject" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.reject} />
+                <MetricHeaderCell label="T.O." tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.timedOut} />
+                <MetricHeaderCell label="Reset" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.reset} />
+                <MetricHeaderCell
+                  label="In Flight"
+                  tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.inFlight}
+                />
+                <MetricHeaderCell
+                  label="Avg Q"
+                  tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.avgQueue}
+                />
+                <MetricHeaderCell label="Util" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.util} />
+                <MetricHeaderCell
+                  label="Err %"
+                  tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.errorRate}
+                />
+                <MetricHeaderCell
+                  label="Arr CV"
+                  tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.arrivalCV}
+                />
+                <MetricHeaderCell label="p50" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.p50} />
+                <MetricHeaderCell label="p95" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.p95} />
+                <MetricHeaderCell label="p99" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.p99} />
+                <MetricHeaderCell label="λ" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.lambda} />
+                <MetricHeaderCell label="W" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.w} />
+                <MetricHeaderCell
+                  label="L"
+                  tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.l}
+                  className="text-right pb-1"
+                />
+              </tr>
+            </thead>
+            <tbody>
+              {activeEntries.map(([nodeId, m]) => {
+                const ll = llByNode.get(nodeId)
+                const conservation = conservationByNode.get(nodeId)
+                const inFlight = conservation?.inFlight ?? 0
+                const utilPct = (m.utilization * 100).toFixed(1)
+                const utilColour =
+                  m.utilization > 0.9
+                    ? 'text-nss-danger'
+                    : m.utilization > 0.7
+                      ? 'text-nss-warning'
+                      : 'text-nss-success'
+                const arrivalCvWarn =
+                  m.arrivalCV !== null &&
+                  output.summary.offeredArrivalCV !== null &&
+                  m.arrivalCV > output.summary.offeredArrivalCV + 0.05
+                const llViolation = ll && !ll.withinTolerance
+
+                return (
+                  <tr key={nodeId} className="border-b border-nss-border hover:bg-nss-surface/70">
+                    <td className="py-1 pr-2 text-nss-text max-w-[180px]">
+                      <div className="truncate">{m.nodeLabel ?? nodeId}</div>
+                      {formatNodeLocation(locationTopology.nodeLocations.get(nodeId)) && (
+                        <div className="truncate text-[10px] text-nss-muted">
+                          {formatNodeLocation(locationTopology.nodeLocations.get(nodeId))}
+                        </div>
+                      )}
+                    </td>
+                    <td className="text-right pr-2 text-nss-text">
+                      {m.postWarmupArrived.toLocaleString()}
+                    </td>
+                    <td className="text-right pr-2 text-nss-text">
+                      {m.postWarmupProcessed.toLocaleString()}
+                    </td>
+                    <td className="text-right pr-2 text-nss-muted">
+                      {m.postWarmupRejected.toLocaleString()}
+                    </td>
+                    <td className="text-right pr-2 text-nss-muted">
+                      {m.postWarmupTimedOut.toLocaleString()}
+                    </td>
+                    <td className="text-right pr-2 text-nss-muted">
+                      {m.postWarmupConnectionReset.toLocaleString()}
+                    </td>
+                    <td
+                      className={`text-right pr-2 ${inFlight > 0 ? 'text-nss-warning' : 'text-nss-muted'}`}
+                    >
+                      {inFlight.toLocaleString()}
+                    </td>
+                    <td className="text-right pr-2 text-nss-muted">
+                      {m.avgQueueLength.toFixed(1)}
+                    </td>
+                    <td className={`text-right pr-2 ${utilColour}`}>{utilPct}%</td>
+                    <td
+                      className={`text-right pr-2 ${
+                        m.errorRate > 0.05
+                          ? 'text-nss-danger'
+                          : m.errorRate > 0.01
+                            ? 'text-nss-warning'
+                            : 'text-nss-muted'
+                      }`}
+                    >
+                      {fmtPct(m.errorRate)}
+                    </td>
+                    <td
+                      className={`text-right pr-2 ${
+                        arrivalCvWarn ? 'text-nss-warning' : 'text-nss-muted'
+                      }`}
+                    >
+                      {fmtCv(m.arrivalCV)}
+                    </td>
+                    <td className="text-right pr-2 text-nss-text">{fmtMs(m.latencyP50)}</td>
+                    <td className="text-right pr-2 text-nss-text">{fmtMs(m.latencyP95)}</td>
+                    <td className="text-right pr-2 text-nss-text">{fmtMs(m.latencyP99)}</td>
+                    <td className="text-right pr-2 text-nss-muted">
+                      {ll ? fmtLambda(ll.lambda) : '-'}
+                    </td>
+                    <td className="text-right pr-2 text-nss-muted">
+                      {ll ? fmtW(ll.wSeconds) : '-'}
+                    </td>
+                    <td
+                      className={`text-right ${llViolation ? 'text-nss-warning font-medium' : 'text-nss-muted'}`}
+                      title={
+                        llViolation ? `Little's Law: expected ${fmtL(ll!.expectedL)}` : undefined
+                      }
+                    >
+                      {ll ? fmtL(ll.observedL) : '-'}
+                      {llViolation && <span className="ml-0.5">⚠</span>}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <div className={`${SURFACE_CARD} p-4 text-sm text-nss-muted`}>
+          No runtime node received post-warmup traffic in this run.
+        </div>
+      )}
+
       {inactiveEntries.length > 0 && (
         <div>
           <button
@@ -4019,14 +4348,21 @@ function PerNodeTable({ output }: { output: SimulationOutput }) {
             onClick={() => setShowInactive((s) => !s)}
             className="text-[10px] text-nss-muted hover:text-nss-text transition-colors"
           >
-            {showInactive ? '▲' : '▼'} Inactive nodes ({inactiveEntries.length}) - post-warmup
+            {showInactive ? '▲' : '▼'} Inactive runtime nodes ({inactiveEntries.length})
           </button>
           {showInactive && (
             <table className="w-full text-xs tabular-nums mt-1 opacity-50">
               <tbody>
                 {inactiveEntries.map(([nodeId, m]) => (
                   <tr key={nodeId} className="border-b border-nss-border">
-                    <td className="py-0.5 pr-2 text-nss-muted">{m.nodeLabel ?? nodeId}</td>
+                    <td className="py-0.5 pr-2 text-nss-muted">
+                      <div className="truncate">{m.nodeLabel ?? nodeId}</div>
+                      {formatNodeLocation(locationTopology.nodeLocations.get(nodeId)) && (
+                        <div className="truncate text-[10px]">
+                          {formatNodeLocation(locationTopology.nodeLocations.get(nodeId))}
+                        </div>
+                      )}
+                    </td>
                     <td className="text-right text-nss-muted text-[10px] italic" colSpan={16}>
                       no post-warmup traffic
                     </td>
@@ -4100,6 +4436,17 @@ export function ResultsTray({
   const [selectedComponent, setSelectedComponent] = useState<SelectedComponent | null>(null)
   const nodes = useStore((state) => state.nodes)
   const edges = useStore((state) => state.edges)
+  const sourceNodeIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const node of nodes) {
+      const data = node.data as { structuralRole?: unknown; profile?: unknown } | undefined
+      if (data?.structuralRole === 'source' || data?.profile === 'source') {
+        ids.add(node.id)
+      }
+    }
+    return ids
+  }, [nodes])
+  const locationTopology = useMemo(() => buildLocationTopology(nodes), [nodes])
   const graphLookup = useMemo<EventGraphLookup>(() => {
     const nodeLabelById = new Map<string, string>()
     const edgeById = new Map<string, EventEdgeDisplayInfo>()
@@ -4124,6 +4471,26 @@ export function ResultsTray({
 
     return { nodeLabelById, edgeById }
   }, [nodes, edges])
+  const nodeLocationRollups = useMemo(
+    () =>
+      results
+        ? buildNodeLocationRollups(
+            locationTopology,
+            buildNodeRollupInputsFromResults(results.perNode, sourceNodeIds)
+          )
+        : { region: [], az: [], subnet: [] },
+    [locationTopology, results, sourceNodeIds]
+  )
+  const edgeLocalityRollups = useMemo(
+    () =>
+      results
+        ? buildEdgeLocalityRollups(
+            locationTopology,
+            buildEdgeRollupInputsFromResults(edges, results.perEdge)
+          )
+        : [],
+    [edges, locationTopology, results]
+  )
 
   useEffect(() => {
     if (results) {
@@ -4225,7 +4592,12 @@ export function ResultsTray({
             {activeTab === 'overview' && (
               <>
                 {runContext && <RunContextPanel runContext={runContext} />}
-                <SummaryPanel output={results} />
+                <SummaryPanel output={results} runContext={runContext} />
+                <LocationRollupsPanel
+                  nodeRollups={nodeLocationRollups}
+                  edgeRollups={edgeLocalityRollups}
+                  title="Deployment & Locality"
+                />
                 <SystemWindowCharts output={results} />
               </>
             )}
@@ -4248,7 +4620,11 @@ export function ResultsTray({
 
             {activeTab === 'nodes' && (
               <div className="space-y-4">
-                <PerNodeTable output={results} />
+                <PerNodeTable
+                  output={results}
+                  locationTopology={locationTopology}
+                  runContext={runContext}
+                />
               </div>
             )}
 

--- a/src/renderer/src/components/simulation/ResultsTray.tsx
+++ b/src/renderer/src/components/simulation/ResultsTray.tsx
@@ -4180,7 +4180,9 @@ function PerNodeTable({
               const data = node?.data as Partial<CanvasNodeDataV2> | undefined
               const staticWorkload = data?.source?.defaultWorkload
               const isRunSource = runContext?.sourceNodeId === nodeId
-              const offeredRps = isRunSource ? runContext?.workload.baseRps : staticWorkload?.baseRps
+              const offeredRps = isRunSource
+                ? runContext?.workload.baseRps
+                : staticWorkload?.baseRps
               const pattern = isRunSource ? runContext?.workload.pattern : staticWorkload?.pattern
 
               return (
@@ -4209,8 +4211,14 @@ function PerNodeTable({
                   tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.arrived}
                 />
                 <MetricHeaderCell label="Done" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.done} />
-                <MetricHeaderCell label="Reject" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.reject} />
-                <MetricHeaderCell label="T.O." tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.timedOut} />
+                <MetricHeaderCell
+                  label="Reject"
+                  tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.reject}
+                />
+                <MetricHeaderCell
+                  label="T.O."
+                  tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.timedOut}
+                />
                 <MetricHeaderCell label="Reset" tooltip={RESULTS_PER_NODE_COLUMN_TOOLTIPS.reset} />
                 <MetricHeaderCell
                   label="In Flight"

--- a/src/renderer/src/components/ui/EdgePropertiesPanel.tsx
+++ b/src/renderer/src/components/ui/EdgePropertiesPanel.tsx
@@ -9,7 +9,10 @@ import {
 } from '@renderer/config/edgeSemantics'
 import type { CanvasNodeDataV2 } from '../../../../engine/catalog/nodeSpecTypes'
 import { getEdgeConstraints } from '../../../../engine/defaults/edgeConstraints'
-import { getPathTypeLatencyProfile, inferEdgeDefaults } from '../../../../engine/defaults/edgeDefaults'
+import {
+  getPathTypeLatencyProfile,
+  inferEdgeDefaults
+} from '../../../../engine/defaults/edgeDefaults'
 
 export interface EdgePropertiesPanelValue extends EdgeSimulationData {
   label?: string

--- a/src/renderer/src/components/ui/EdgePropertiesPanel.tsx
+++ b/src/renderer/src/components/ui/EdgePropertiesPanel.tsx
@@ -9,7 +9,7 @@ import {
 } from '@renderer/config/edgeSemantics'
 import type { CanvasNodeDataV2 } from '../../../../engine/catalog/nodeSpecTypes'
 import { getEdgeConstraints } from '../../../../engine/defaults/edgeConstraints'
-import { inferEdgeDefaults } from '../../../../engine/defaults/edgeDefaults'
+import { getPathTypeLatencyProfile, inferEdgeDefaults } from '../../../../engine/defaults/edgeDefaults'
 
 export interface EdgePropertiesPanelValue extends EdgeSimulationData {
   label?: string
@@ -19,6 +19,9 @@ export interface EdgePropertiesPanelProps {
   value: EdgePropertiesPanelValue
   sourceNodeData?: CanvasNodeDataV2
   targetNodeData?: CanvasNodeDataV2
+  sourceLocationLabel?: string | null
+  targetLocationLabel?: string | null
+  containerDerivedPathType?: EdgeSimulationData['pathType']
   title?: string
   leadingAction?: ReactNode
   tabs?: ReactNode
@@ -52,6 +55,10 @@ function logNormalJitterCv(sigma: number): number {
   return Math.sqrt(Math.max(0, Math.exp(sigma * sigma) - 1))
 }
 
+function formatPathTypeLabel(pathType: NonNullable<EdgeSimulationData['pathType']>): string {
+  return pathType.replace(/-/g, ' ')
+}
+
 function EdgeTooltipContent({ entry }: { entry: EdgeHelpEntry }) {
   return (
     <div className="space-y-1 text-[11px] leading-relaxed">
@@ -80,6 +87,9 @@ export const EdgePropertiesPanel = ({
   value,
   sourceNodeData,
   targetNodeData,
+  sourceLocationLabel,
+  targetLocationLabel,
+  containerDerivedPathType,
   title = 'Edge Properties',
   leadingAction,
   tabs,
@@ -105,6 +115,8 @@ export const EdgePropertiesPanel = ({
   const defaultConstantLatencyMs = Number(Math.exp(defaults.latencyDistribution.mu).toFixed(2))
   const selectedLatencyValue = value.latencyValue ?? defaultConstantLatencyMs
   const jitterCv = logNormalJitterCv(selectedLatencySigma)
+  const sourceLabel = sourceNodeData?.label
+  const targetLabel = targetNodeData?.label
   const protocolWarning = !constraints.allowedProtocols.includes(selectedProtocol)
     ? constraints.reasons.protocol[selectedProtocol]
     : null
@@ -115,9 +127,46 @@ export const EdgePropertiesPanel = ({
     selectedLatencyDistributionType === 'constant'
       ? `Constant transit: ${selectedLatencyValue.toFixed(2)}ms on every hop. Use this for a clean, no-jitter edge.`
       : `Log-normal transit: median hop ≈ ${Math.exp(selectedLatencyMu).toFixed(2)}ms, jitter CV ≈ ${jitterCv.toFixed(2)}. Mu is log-space; sigma controls spread.`
-  const selectedPathType = value.pathType ?? defaults.pathType
-  const sourceLabel = sourceNodeData?.label
-  const targetLabel = targetNodeData?.label
+  const autoPathType = (containerDerivedPathType ?? defaults.pathType) as NonNullable<
+    EdgeSimulationData['pathType']
+  >
+  const selectedPathType = (value.pathType ?? autoPathType) as NonNullable<
+    EdgeSimulationData['pathType']
+  >
+  const autoPathSource = containerDerivedPathType ? 'placement' : 'defaults'
+  const autoPathOptionLabel =
+    autoPathSource === 'placement' ? 'Auto (from placement)' : 'Auto (from defaults)'
+  const locationSentence =
+    sourceLocationLabel && targetLocationLabel
+      ? `${sourceLabel || 'Source'} is in ${sourceLocationLabel}; ${targetLabel || 'Target'} is in ${targetLocationLabel}.`
+      : null
+  const pathTypeHelpText =
+    value.pathType === undefined
+      ? autoPathSource === 'placement'
+        ? `Auto selected ${formatPathTypeLabel(selectedPathType)} from composite placement. ${locationSentence ?? ''}`.trim()
+        : `Auto is using the generic ${formatPathTypeLabel(selectedPathType)} default because both endpoints are not fully placed inside region / AZ / subnet containers.`
+      : autoPathSource === 'placement'
+        ? `Manual override. Composite placement would resolve this edge as ${formatPathTypeLabel(containerDerivedPathType!)}. ${locationSentence ?? ''} Switch back to Auto to follow placement again.`
+        : `Manual override. Auto would fall back to the generic ${formatPathTypeLabel(defaults.pathType)} default because placement does not fully resolve this hop.`
+  // "Auto" latency = no explicit latency fields at all, so the serializer derives
+  // it from the (possibly location-derived) path type. This is always reachable
+  // from the toggle below, which is what makes a manual override reversible.
+  const isLatencyAuto =
+    value.latencyMu === undefined &&
+    value.latencySigma === undefined &&
+    value.latencyValue === undefined &&
+    value.latencyDistributionType === undefined
+  const derivedLatencyMedianMs = Math.exp(getPathTypeLatencyProfile(selectedPathType).mu)
+  const autoLatencyText = (() => {
+    if (!isLatencyAuto) return null
+    if (value.pathType !== undefined) {
+      return `Auto latency is using the ${formatPathTypeLabel(selectedPathType)} profile from the edge path type. Median transit ≈ ${derivedLatencyMedianMs.toFixed(2)}ms.`
+    }
+    if (autoPathSource === 'placement') {
+      return `Auto latency is using the ${formatPathTypeLabel(selectedPathType)} profile derived from composite placement. ${locationSentence ?? ''} Median transit ≈ ${derivedLatencyMedianMs.toFixed(2)}ms.`
+    }
+    return `Auto latency is using the ${formatPathTypeLabel(selectedPathType)} profile from the generic edge default because placement does not resolve this hop. Median transit ≈ ${derivedLatencyMedianMs.toFixed(2)}ms.`
+  })()
 
   return (
     <div className="h-full w-full bg-nss-panel border-l border-nss-border flex flex-col text-nss-text font-sans">
@@ -225,12 +274,18 @@ export const EdgePropertiesPanel = ({
             <div className="space-y-1">
               <FieldLabel label="Path Type" help={EDGE_PROPERTY_HELP.pathType} />
               <select
-                value={selectedPathType}
+                value={value.pathType ?? 'auto'}
                 onChange={(e) =>
-                  onChange({ pathType: e.target.value as EdgeSimulationData['pathType'] })
+                  onChange({
+                    pathType:
+                      e.target.value === 'auto'
+                        ? undefined
+                        : (e.target.value as EdgeSimulationData['pathType'])
+                  })
                 }
                 className={CONTROL_CLASS}
               >
+                <option value="auto">{autoPathOptionLabel}</option>
                 {['same-rack', 'same-dc', 'cross-zone', 'cross-region', 'internet'].map(
                   (option) => (
                     <option key={option} value={option}>
@@ -239,6 +294,7 @@ export const EdgePropertiesPanel = ({
                   )
                 )}
               </select>
+              <p className="text-[10px] leading-relaxed text-nss-muted">{pathTypeHelpText}</p>
             </div>
             <div className="space-y-1">
               <FieldLabel label="Condition" help={EDGE_PROPERTY_HELP.condition} />
@@ -253,61 +309,100 @@ export const EdgePropertiesPanel = ({
           </div>
 
           <div className="space-y-1">
-            <FieldLabel label="Latency Model" help={EDGE_PROPERTY_HELP.latencyModel} />
+            <FieldLabel label="Latency" help={EDGE_PROPERTY_HELP.latencyModel} />
             <select
-              value={selectedLatencyDistributionType}
+              value={isLatencyAuto ? 'auto' : 'manual'}
               onChange={(e) =>
-                onChange({
-                  latencyDistributionType: e.target
-                    .value as EdgeSimulationData['latencyDistributionType'],
-                  ...(e.target.value === 'constant' && value.latencyValue === undefined
-                    ? { latencyValue: defaultConstantLatencyMs }
-                    : {})
-                })
+                onChange(
+                  e.target.value === 'auto'
+                    ? {
+                        latencyDistributionType: undefined,
+                        latencyValue: undefined,
+                        latencyMu: undefined,
+                        latencySigma: undefined
+                      }
+                    : {
+                        latencyDistributionType: 'log-normal',
+                        latencyMu: selectedLatencyMu,
+                        latencySigma: selectedLatencySigma
+                      }
+                )
               }
               className={CONTROL_CLASS}
             >
-              <option value="log-normal">Log-normal (jittered)</option>
-              <option value="constant">Constant (no jitter)</option>
+              <option value="auto">Auto (from path type)</option>
+              <option value="manual">Manual</option>
             </select>
           </div>
 
-          {selectedLatencyDistributionType === 'constant' ? (
-            <div className="space-y-1">
-              <FieldLabel label="Latency (ms)" help={EDGE_PROPERTY_HELP.latencyValue} />
-              <input
-                type="number"
-                min={0}
-                step={0.01}
-                value={selectedLatencyValue}
-                onChange={(e) => onChange({ latencyValue: Number(e.target.value) })}
-                className={CONTROL_CLASS}
-              />
-            </div>
+          {isLatencyAuto ? (
+            <p className="text-[10px] leading-relaxed text-nss-muted">
+              {autoLatencyText} Switch to Manual to set an explicit latency; you can switch back to
+              Auto at any time.
+            </p>
           ) : (
-            <div className="grid grid-cols-2 gap-2">
+            <>
               <div className="space-y-1">
-                <FieldLabel label="Latency Mu (log-space)" help={EDGE_PROPERTY_HELP.latencyMu} />
-                <input
-                  type="number"
-                  step={0.01}
-                  value={selectedLatencyMu}
-                  onChange={(e) => onChange({ latencyMu: Number(e.target.value) })}
+                <FieldLabel label="Latency Model" help={EDGE_PROPERTY_HELP.latencyModel} />
+                <select
+                  value={selectedLatencyDistributionType}
+                  onChange={(e) =>
+                    onChange({
+                      latencyDistributionType: e.target
+                        .value as EdgeSimulationData['latencyDistributionType'],
+                      ...(e.target.value === 'constant' && value.latencyValue === undefined
+                        ? { latencyValue: defaultConstantLatencyMs }
+                        : {})
+                    })
+                  }
                   className={CONTROL_CLASS}
-                />
+                >
+                  <option value="log-normal">Log-normal (jittered)</option>
+                  <option value="constant">Constant (no jitter)</option>
+                </select>
               </div>
-              <div className="space-y-1">
-                <FieldLabel label="Jitter Sigma" help={EDGE_PROPERTY_HELP.latencySigma} />
-                <input
-                  type="number"
-                  min={0.01}
-                  step={0.01}
-                  value={selectedLatencySigma}
-                  onChange={(e) => onChange({ latencySigma: Number(e.target.value) })}
-                  className={CONTROL_CLASS}
-                />
-              </div>
-            </div>
+
+              {selectedLatencyDistributionType === 'constant' ? (
+                <div className="space-y-1">
+                  <FieldLabel label="Latency (ms)" help={EDGE_PROPERTY_HELP.latencyValue} />
+                  <input
+                    type="number"
+                    min={0}
+                    step={0.01}
+                    value={selectedLatencyValue}
+                    onChange={(e) => onChange({ latencyValue: Number(e.target.value) })}
+                    className={CONTROL_CLASS}
+                  />
+                </div>
+              ) : (
+                <div className="grid grid-cols-2 gap-2">
+                  <div className="space-y-1">
+                    <FieldLabel
+                      label="Latency Mu (log-space)"
+                      help={EDGE_PROPERTY_HELP.latencyMu}
+                    />
+                    <input
+                      type="number"
+                      step={0.01}
+                      value={selectedLatencyMu}
+                      onChange={(e) => onChange({ latencyMu: Number(e.target.value) })}
+                      className={CONTROL_CLASS}
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <FieldLabel label="Jitter Sigma" help={EDGE_PROPERTY_HELP.latencySigma} />
+                    <input
+                      type="number"
+                      min={0.01}
+                      step={0.01}
+                      value={selectedLatencySigma}
+                      onChange={(e) => onChange({ latencySigma: Number(e.target.value) })}
+                      className={CONTROL_CLASS}
+                    />
+                  </div>
+                </div>
+              )}
+            </>
           )}
 
           <div className="grid grid-cols-2 gap-2">
@@ -362,9 +457,11 @@ export const EdgePropertiesPanel = ({
             </div>
           </div>
 
-          <div className="rounded border border-nss-border bg-nss-surface px-2 py-2 text-[10px] leading-relaxed text-nss-muted">
-            {latencySummary}
-          </div>
+          {!isLatencyAuto && (
+            <div className="rounded border border-nss-border bg-nss-surface px-2 py-2 text-[10px] leading-relaxed text-nss-muted">
+              {latencySummary}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/renderer/src/components/ui/Tooltip.tsx
+++ b/src/renderer/src/components/ui/Tooltip.tsx
@@ -1,5 +1,6 @@
 import type { FocusEvent, MouseEvent, ReactNode } from 'react'
 import { useEffect, useId, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { clsx } from 'clsx'
 
 interface TooltipPosition {
@@ -91,19 +92,22 @@ export function HoverTooltip({
         'aria-describedby': position ? tooltipId : undefined
       })}
 
-      {position && (
-        <div
-          id={tooltipId}
-          role="tooltip"
-          style={{ top: position.top, left: position.left, width }}
-          className={clsx(
-            'fixed z-[80] rounded-md border border-nss-border bg-nss-panel shadow-2xl p-3 text-left pointer-events-none',
-            className
-          )}
-        >
-          {content}
-        </div>
-      )}
+      {position && typeof document !== 'undefined'
+        ? createPortal(
+            <div
+              id={tooltipId}
+              role="tooltip"
+              style={{ top: position.top, left: position.left, width }}
+              className={clsx(
+                'fixed z-[80] rounded-md border border-nss-border bg-nss-panel shadow-2xl p-3 text-left pointer-events-none',
+                className
+              )}
+            >
+              {content}
+            </div>,
+            document.body
+          )
+        : null}
     </>
   )
 }

--- a/src/renderer/src/config/fieldConfig.test.ts
+++ b/src/renderer/src/config/fieldConfig.test.ts
@@ -30,6 +30,25 @@ function makeRuntimeNode(
   }
 }
 
+function makeCompositeNode(
+  overrides: Partial<CanvasNodeDataV2> & Pick<CanvasNodeDataV2, 'templateId' | 'label' | 'iconKey'>
+): CanvasNodeDataV2 {
+  return {
+    schemaVersion: 2,
+    templateId: overrides.templateId,
+    structuralRole: 'composite',
+    profile: 'composite',
+    rendererType: 'vpcNode',
+    label: overrides.label,
+    subLabel: overrides.subLabel,
+    iconKey: overrides.iconKey,
+    sim: overrides.sim,
+    source: overrides.source,
+    routingStrategy: overrides.routingStrategy,
+    ui: overrides.ui
+  }
+}
+
 describe('getNodeConfigSections', () => {
   it('composes L4 config from modules with relabeled queue fields and a locked content-routing note', () => {
     const data = makeRuntimeNode({
@@ -116,5 +135,77 @@ describe('getNodeConfigSections', () => {
     expect(availabilityTarget?.optional).toBe(true)
     expect(availabilityTarget?.displayAs?.toDisplay(0.999, data)).toBe(99.9)
     expect(availabilityTarget?.displayAs?.fromDisplay(99.9, data)).toBeCloseTo(0.999, 6)
+  })
+
+  it('marks free-form metadata fields as text inputs', () => {
+    const composite = makeCompositeNode({
+      templateId: 'availability-zone',
+      label: 'AZ A',
+      iconKey: 'az',
+      sim: { locationId: 'us-east-1a' }
+    })
+    const keyRouter = makeRuntimeNode({
+      templateId: 'sharding',
+      componentType: 'sharding',
+      structuralRole: 'router',
+      profile: 'router',
+      label: 'Shard Router',
+      sim: {
+        queue: { workers: 8, capacity: 10, discipline: 'fifo' },
+        processing: {
+          distribution: { type: 'exponential', lambda: 0.125 },
+          timeout: 100
+        },
+        routingKeyField: 'tenantId'
+      }
+    })
+
+    const compositeSections = getNodeConfigSections(composite)
+    const locationField = compositeSections
+      .find((section) => section.id === 'location')
+      ?.fields.find((field) => field.path === 'sim.locationId')
+    const routingKeyField = getNodeConfigSections(keyRouter)
+      .find((section) => section.id === 'key-routing')
+      ?.fields.find((field) => field.path === 'sim.routingKeyField')
+
+    expect(locationField?.inputType).toBe('text')
+    expect(routingKeyField?.inputType).toBe('text')
+    expect(compositeSections.find((section) => section.id === 'location')?.note?.text).toContain(
+      'renderer-side location rollups'
+    )
+  })
+
+  it('adds a structured request-template editor for source nodes', () => {
+    const source = makeRuntimeNode({
+      templateId: 'client-user',
+      componentType: 'api-endpoint',
+      structuralRole: 'source',
+      profile: 'source',
+      label: 'Client App',
+      source: {
+        requestDistribution: [{ type: 'GET', weight: 1, sizeBytes: 1024 }],
+        defaultWorkload: {
+          pattern: 'poisson',
+          baseRps: 100,
+          bursty: { burstRps: 500, burstDuration: 2000, normalDuration: 8000 },
+          spike: { spikeTime: 30000, spikeRps: 1000, spikeDuration: 5000 },
+          sawtooth: { peakRps: 300, rampDuration: 10000 },
+          diurnal: {
+            peakMultiplier: 1,
+            hourlyMultipliers: [
+              0.6, 0.5, 0.45, 0.4, 0.4, 0.5, 0.7, 0.9, 1.1, 1.2, 1.15, 1.05, 1, 1.05, 1.1, 1.2,
+              1.25, 1.3, 1.2, 1.05, 0.95, 0.85, 0.75, 0.65
+            ]
+          }
+        }
+      }
+    })
+
+    const requestTemplatesField = getNodeConfigSections(source)
+      .find((section) => section.id === 'request-templates')
+      ?.fields.find((field) => field.path === 'source.requestDistribution')
+
+    expect(requestTemplatesField?.renderer).toBe('request-distribution')
+    expect(requestTemplatesField?.inputType).toBe('text')
   })
 })

--- a/src/renderer/src/config/fieldConfig.ts
+++ b/src/renderer/src/config/fieldConfig.ts
@@ -5,6 +5,7 @@ import type {
   ConfigCustomRenderer,
   ConfigDisplayTransform,
   ConfigField,
+  ConfigInputType,
   ConfigNoteTone,
   FieldPath
 } from '../../../engine/traits/types'
@@ -28,6 +29,7 @@ export interface ResolvedFieldDefinition {
   renderer: ConfigCustomRenderer
   displayAs?: ConfigDisplayTransform
   placeholder?: string
+  inputType?: ConfigInputType
 }
 
 export interface ResolvedConfigSection {
@@ -79,7 +81,10 @@ function resolveField(field: ConfigField, data: AnyNodeData): ResolvedFieldDefin
     renderer: field.renderer ?? 'default',
     displayAs: field.displayAs,
     placeholder: resolveText(field.placeholder, data)
-  } satisfies Omit<ResolvedFieldDefinition, 'options' | 'min' | 'max' | 'step' | 'defaultValue'>
+  } satisfies Omit<
+    ResolvedFieldDefinition,
+    'options' | 'min' | 'max' | 'step' | 'defaultValue' | 'inputType'
+  >
 
   switch (field.type) {
     case 'slider':
@@ -102,7 +107,8 @@ function resolveField(field: ConfigField, data: AnyNodeData): ResolvedFieldDefin
     default:
       return {
         ...base,
-        step: field.step
+        step: field.step,
+        inputType: field.inputType ?? 'number'
       }
   }
 }

--- a/src/renderer/src/config/sampleScenarios.test.ts
+++ b/src/renderer/src/config/sampleScenarios.test.ts
@@ -23,7 +23,9 @@ describe('SAMPLE_SCENARIOS composite examples', () => {
     expect(multiAz).toBeDefined()
     expect(crossRegion).toBeDefined()
 
-    const multiAzData = JSON.parse(multiAz!.raw) as { nodes: Array<{ type: string; nodes?: unknown[] }> }
+    const multiAzData = JSON.parse(multiAz!.raw) as {
+      nodes: Array<{ type: string; nodes?: unknown[] }>
+    }
     const crossRegionData = JSON.parse(crossRegion!.raw) as {
       nodes: Array<{ type: string; data?: { sim?: { locationId?: string } }; nodes?: unknown[] }>
     }
@@ -72,8 +74,8 @@ describe('SAMPLE_SCENARIOS composite examples', () => {
       )
     ).toBe(true)
     expect(gatewayNode?.data?.sim?.routingRules).toHaveLength(3)
-    expect(
-      gatewayNode?.data?.sim?.routingRules?.every((rule) => rule.matchField === 'path')
-    ).toBe(true)
+    expect(gatewayNode?.data?.sim?.routingRules?.every((rule) => rule.matchField === 'path')).toBe(
+      true
+    )
   })
 })

--- a/src/renderer/src/config/sampleScenarios.test.ts
+++ b/src/renderer/src/config/sampleScenarios.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { SAMPLE_SCENARIOS } from './sampleScenarios'
+
+function collectLocationIds(
+  nodes: Array<{ data?: { sim?: { locationId?: string } }; nodes?: unknown[] }>
+): string[] {
+  return nodes.flatMap((node) => {
+    const own = node.data?.sim?.locationId ? [node.data.sim.locationId] : []
+    const children = Array.isArray(node.nodes)
+      ? collectLocationIds(
+          node.nodes as Array<{ data?: { sim?: { locationId?: string } }; nodes?: unknown[] }>
+        )
+      : []
+    return [...own, ...children]
+  })
+}
+
+describe('SAMPLE_SCENARIOS composite examples', () => {
+  it('includes canvas-backed composite-node samples in the scenarios catalog', () => {
+    const multiAz = SAMPLE_SCENARIOS.find((sample) => sample.id === 'multi-az-auto-latency')
+    const crossRegion = SAMPLE_SCENARIOS.find((sample) => sample.id === 'cross-region-auto-latency')
+
+    expect(multiAz).toBeDefined()
+    expect(crossRegion).toBeDefined()
+
+    const multiAzData = JSON.parse(multiAz!.raw) as { nodes: Array<{ type: string; nodes?: unknown[] }> }
+    const crossRegionData = JSON.parse(crossRegion!.raw) as {
+      nodes: Array<{ type: string; data?: { sim?: { locationId?: string } }; nodes?: unknown[] }>
+    }
+    const crossRegionLocationIds = collectLocationIds(crossRegionData.nodes)
+
+    expect(multiAzData.nodes[0]?.type).toBe('vpcNode')
+    expect(Array.isArray(multiAzData.nodes[0]?.nodes)).toBe(true)
+    expect(crossRegionLocationIds.length).toBeGreaterThanOrEqual(3)
+    expect(crossRegionLocationIds.some((value) => value.includes('us-east'))).toBe(true)
+  })
+
+  it('includes the endpoint-aware routing sample with HTTP metadata and L7 rules', () => {
+    const endpointMix = SAMPLE_SCENARIOS.find(
+      (sample) => sample.id === 'endpoint-routing-request-mix'
+    )
+
+    expect(endpointMix).toBeDefined()
+
+    const sampleData = JSON.parse(endpointMix!.raw) as {
+      nodes: Array<{
+        id: string
+        data?: {
+          source?: {
+            requestDistribution?: Array<{
+              metadata?: { method?: string; host?: string; path?: string }
+            }>
+          }
+          sim?: {
+            routingRules?: Array<{
+              matchField?: string
+              matchValue?: string
+              targetNodeId?: string
+            }>
+          }
+        }
+      }>
+    }
+
+    const sourceNode = sampleData.nodes.find((node) => node.id === 'client')
+    const gatewayNode = sampleData.nodes.find((node) => node.id === 'api-gateway')
+
+    expect(sourceNode?.data?.source?.requestDistribution).toHaveLength(3)
+    expect(
+      sourceNode?.data?.source?.requestDistribution?.every(
+        (entry) => entry.metadata?.method && entry.metadata?.host && entry.metadata?.path
+      )
+    ).toBe(true)
+    expect(gatewayNode?.data?.sim?.routingRules).toHaveLength(3)
+    expect(
+      gatewayNode?.data?.sim?.routingRules?.every((rule) => rule.matchField === 'path')
+    ).toBe(true)
+  })
+})

--- a/src/renderer/src/config/sampleScenarios.ts
+++ b/src/renderer/src/config/sampleScenarios.ts
@@ -1,6 +1,9 @@
 import directClientServerRaw from '../../../engine/__samples__/direct-client-server.json?raw'
 import directClientServerCleanRaw from '../../../engine/__samples__/direct-client-server-clean.json?raw'
 import directClientServerJitterRaw from '../../../engine/__samples__/direct-client-server-jitter.json?raw'
+import multiAzAutoLatencyRaw from '../../../engine/__samples__/multi-az-auto-latency.json?raw'
+import crossRegionAutoLatencyRaw from '../../../engine/__samples__/cross-region-auto-latency.json?raw'
+import endpointRoutingRequestMixRaw from '../../../engine/__samples__/endpoint-routing-request-mix.json?raw'
 import monolithStackRaw from '../../../engine/__samples__/traditional-single-instance-stack.json?raw'
 import proxyEdgeRaw from '../../../engine/__samples__/proxy-edge.json?raw'
 import l7ScaleOutRaw from '../../../engine/__samples__/horizontal-compute-scaling-l7.json?raw'
@@ -57,6 +60,42 @@ export const SAMPLE_SCENARIOS: SampleScenario[] = [
       'Identical to the clean baseline except the edge is log-normal - now capacity_exceeded rejects appear below nominal capacity. Compare offered vs arrival CV to see why.',
     difficulty: 'starter',
     raw: directClientServerJitterRaw
+  },
+  {
+    id: 'multi-az-auto-latency',
+    name: 'Multi-AZ Auto Latency',
+    subtitle: 'Same Region, Different AZs',
+    diagram: 'Orders Web (AZ A) -> Orders API (AZ B)',
+    primaryUseCase:
+      'Shows that container placement alone resolves the edge to the cross-zone latency profile.',
+    simulatorValue:
+      'Select the edge and keep Path Type plus Latency on Auto. Then move a node into the same subnet or another region to watch the derived path class change without editing the edge.',
+    difficulty: 'intro',
+    raw: multiAzAutoLatencyRaw
+  },
+  {
+    id: 'cross-region-auto-latency',
+    name: 'Cross-Region Auto Latency',
+    subtitle: 'Two Regions, One Edge',
+    diagram: 'Checkout Web (us-east-1) -> Fraud API (eu-west-1)',
+    primaryUseCase:
+      'Shows that nodes in different region containers resolve the edge to the cross-region latency profile.',
+    simulatorValue:
+      'Run it, then inspect the edge. Auto mode keeps the edge configuration minimal while still producing the longer-haul RTT profile; switch to Manual and back to verify reversibility.',
+    difficulty: 'intro',
+    raw: crossRegionAutoLatencyRaw
+  },
+  {
+    id: 'endpoint-routing-request-mix',
+    name: 'Endpoint Routing Mix',
+    subtitle: 'Path-Aware Gateway',
+    diagram: 'Storefront -> API Gateway -> Catalog / Checkout / Fraud',
+    primaryUseCase:
+      'Shows endpoint-aware traffic mix, path-based L7 routing, and outcome classes in one run.',
+    simulatorValue:
+      'Run it, then open Overview and Traffic. You should see real request labels like GET catalog.internal/catalog and POST api.internal/checkout, plus visible 2xx, 4xx, 5xx, and timeout rollups.',
+    difficulty: 'intermediate',
+    raw: endpointRoutingRequestMixRaw
   },
   {
     id: 'traditional-single-instance-stack',

--- a/src/renderer/src/hooks/useTopologySerializer.test.ts
+++ b/src/renderer/src/hooks/useTopologySerializer.test.ts
@@ -1,5 +1,60 @@
 import { describe, expect, it } from 'vitest'
-import { resolveEdgeLatencyDistribution } from './useTopologySerializer'
+import {
+  buildContainerLocations,
+  pathTypeFromContainers,
+  resolveEdgeLatencyDistribution
+} from './useTopologySerializer'
+
+describe('container-derived edge pathType', () => {
+  // region > az(a|b) > subnet(1|2); plus a bare node outside any container
+  const nodes = [
+    { id: 'region', parentNode: undefined, data: { templateId: 'vpc-region' } },
+    { id: 'azA', parentNode: 'region', data: { templateId: 'availability-zone' } },
+    { id: 'azB', parentNode: 'region', data: { templateId: 'availability-zone' } },
+    { id: 'sub1', parentNode: 'azA', data: { templateId: 'subnet' } },
+    { id: 'sub2', parentNode: 'azA', data: { templateId: 'subnet' } },
+    { id: 'app1', parentNode: 'sub1', data: { templateId: 'backend-server' } },
+    { id: 'app1b', parentNode: 'sub1', data: { templateId: 'backend-server' } },
+    { id: 'app2', parentNode: 'sub2', data: { templateId: 'backend-server' } },
+    { id: 'appB', parentNode: 'azB', data: { templateId: 'backend-server' } },
+    { id: 'outside', parentNode: undefined, data: { templateId: 'client-user' } }
+  ]
+  const loc = buildContainerLocations(nodes)
+
+  it('resolves full ancestry (subnet → az → region)', () => {
+    expect(loc.get('app1')).toEqual({ region: 'region', az: 'azA', subnet: 'sub1' })
+  })
+
+  it('same subnet → same-rack', () => {
+    expect(pathTypeFromContainers(loc, 'app1', 'app1b')).toEqual({ pathType: 'same-rack' })
+  })
+
+  it('same AZ, different subnet → same-dc', () => {
+    expect(pathTypeFromContainers(loc, 'app1', 'app2')).toEqual({ pathType: 'same-dc' })
+  })
+
+  it('same region, different AZ → cross-zone', () => {
+    expect(pathTypeFromContainers(loc, 'app1', 'appB')).toEqual({ pathType: 'cross-zone' })
+  })
+
+  it('endpoint outside all containers → null (leave pathType untouched)', () => {
+    expect(pathTypeFromContainers(loc, 'app1', 'outside')).toBeNull()
+  })
+
+  it('different regions → cross-region, carrying the region-pair hint for future distance-awareness', () => {
+    const twoRegions = [
+      { id: 'us', parentNode: undefined, data: { templateId: 'vpc-region' } },
+      { id: 'ap', parentNode: undefined, data: { templateId: 'vpc-region' } },
+      { id: 'a', parentNode: 'us', data: { templateId: 'backend-server' } },
+      { id: 'b', parentNode: 'ap', data: { templateId: 'backend-server' } }
+    ]
+    const twoLoc = buildContainerLocations(twoRegions)
+    expect(pathTypeFromContainers(twoLoc, 'a', 'b')).toEqual({
+      pathType: 'cross-region',
+      regionPair: ['us', 'ap']
+    })
+  })
+})
 
 const SAME_DC_PROFILE = { type: 'log-normal' as const, mu: 0, sigma: 0.4 }
 

--- a/src/renderer/src/hooks/useTopologySerializer.ts
+++ b/src/renderer/src/hooks/useTopologySerializer.ts
@@ -164,10 +164,88 @@ function buildScenarioGlobal(global: ScenarioState['global']): GlobalConfig {
   }
 }
 
+type EdgePathType = EdgeDefinition['latency']['pathType']
+type ContainerLocation = { region?: string; az?: string; subnet?: string }
+
+const CONTAINER_LEVEL_BY_TEMPLATE: Record<string, keyof ContainerLocation> = {
+  'vpc-region': 'region',
+  'availability-zone': 'az',
+  subnet: 'subnet'
+}
+
+/**
+ * Maps each node to the Region/AZ/Subnet container ids it is nested inside, by
+ * walking the React Flow parent chain. Composite containers are not simulated
+ * themselves; this membership is what lets an edge's pathType be derived from
+ * where its endpoints physically sit.
+ */
+export function buildContainerLocations(
+  rfNodes: readonly { id: string; parentNode?: string; data?: unknown }[]
+): Map<string, ContainerLocation> {
+  const byId = new Map(rfNodes.map((node) => [node.id, node]))
+  const levelOf = (node: { data?: unknown }): keyof ContainerLocation | undefined => {
+    const templateId = (node.data as { templateId?: unknown } | undefined)?.templateId
+    return typeof templateId === 'string' ? CONTAINER_LEVEL_BY_TEMPLATE[templateId] : undefined
+  }
+
+  const locations = new Map<string, ContainerLocation>()
+  for (const node of rfNodes) {
+    const location: ContainerLocation = {}
+    let parentId = node.parentNode
+    const seen = new Set<string>()
+    while (parentId && !seen.has(parentId)) {
+      seen.add(parentId)
+      const parent = byId.get(parentId)
+      if (!parent) break
+      const level = levelOf(parent)
+      if (level && !location[level]) location[level] = parent.id
+      parentId = parent.parentNode
+    }
+    locations.set(node.id, location)
+  }
+  return locations
+}
+
+export interface ContainerPathResolution {
+  pathType: EdgePathType
+  /**
+   * For cross-region hops, the ordered [sourceRegion, targetRegion] container
+   * ids. Populated so a future distance-aware model can look up a per-pair RTT
+   * (e.g. us-east↔ap-south costs more than us-east↔us-west) without re-threading
+   * the serializer. v1 ignores it — cross-region uses the flat profile.
+   */
+  regionPair?: readonly [string, string]
+}
+
+/**
+ * Derives an edge's pathType from where its endpoints sit in the container
+ * hierarchy: same subnet → same-rack, same AZ → same-dc, same region →
+ * cross-zone, different region → cross-region. Returns null when membership
+ * doesn't determine it (e.g. an endpoint outside all containers), leaving the
+ * edge's existing/inferred pathType untouched.
+ */
+export function pathTypeFromContainers(
+  locations: Map<string, ContainerLocation>,
+  source: string,
+  target: string
+): ContainerPathResolution | null {
+  const a = locations.get(source)
+  const b = locations.get(target)
+  if (!a || !b) return null
+  if (a.subnet && a.subnet === b.subnet) return { pathType: 'same-rack' }
+  if (a.az && a.az === b.az) return { pathType: 'same-dc' }
+  if (a.region && a.region === b.region) return { pathType: 'cross-zone' }
+  if (a.region && b.region && a.region !== b.region) {
+    return { pathType: 'cross-region', regionPair: [a.region, b.region] }
+  }
+  return null
+}
+
 function serializeEdge(
   rfEdge: Edge,
   serializedNodeIds: Set<string>,
-  dataByNodeId: Map<string, CanvasNodeDataV2>
+  dataByNodeId: Map<string, CanvasNodeDataV2>,
+  containerPath: ContainerPathResolution | null
 ): EdgeDefinition | null {
   const { id, source, target } = rfEdge
   if (!serializedNodeIds.has(source) || !serializedNodeIds.has(target)) {
@@ -178,7 +256,12 @@ function serializeEdge(
   const sourceData = dataByNodeId.get(source)
   const edgeData = (rfEdge.data ?? {}) as EdgeRuntimeData
   const inferredDefaults = inferEdgeDefaults(sourceData, targetData)
-  const pathType = asPathType(edgeData.pathType) ?? inferredDefaults.pathType
+  // Priority: an explicit pathType the user set on the edge wins; otherwise the
+  // location-derived pathType (Region/AZ/Subnet membership); otherwise the
+  // generic inferred default. Explicit latency (mu/sigma/value) still overrides
+  // inside resolveEdgeLatencyDistribution, so manual tuning is never lost.
+  const pathType =
+    asPathType(edgeData.pathType) ?? containerPath?.pathType ?? inferredDefaults.pathType
   const pathLatencyProfile = getPathTypeLatencyProfile(pathType)
   const { distribution, derivedFromPathType } = resolveEdgeLatencyDistribution(
     edgeData,
@@ -315,8 +398,16 @@ export function useTopologySerializer() {
       }
 
       const serializedNodeIds = new Set(engineNodes.map((node) => node.id))
+      const containerLocations = buildContainerLocations(nodes)
       const engineEdges = edges
-        .map((edge) => serializeEdge(edge, serializedNodeIds, dataByNodeId))
+        .map((edge) =>
+          serializeEdge(
+            edge,
+            serializedNodeIds,
+            dataByNodeId,
+            pathTypeFromContainers(containerLocations, edge.source, edge.target)
+          )
+        )
         .filter((edge): edge is EdgeDefinition => edge !== null)
 
       // Only forward faults that target a serializable node in this topology.

--- a/src/renderer/src/utils/locationTopology.test.ts
+++ b/src/renderer/src/utils/locationTopology.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildEdgeLocalityRollups,
+  buildLocationTopology,
+  buildNodeLocationRollups,
+  describeEdgeLocality,
+  formatNodeLocation,
+  type EdgeRollupInput,
+  type NodeRollupInput
+} from './locationTopology'
+
+const nodes = [
+  {
+    id: 'region-us',
+    data: { templateId: 'vpc-region', label: 'US East', sim: { locationId: 'us-east-1' } }
+  },
+  {
+    id: 'az-a',
+    parentNode: 'region-us',
+    data: { templateId: 'availability-zone', label: 'AZ A', sim: { locationId: 'us-east-1a' } }
+  },
+  {
+    id: 'subnet-a',
+    parentNode: 'az-a',
+    data: { templateId: 'subnet', label: 'Subnet A', sim: { locationId: '10.0.1.0/24' } }
+  },
+  {
+    id: 'az-b',
+    parentNode: 'region-us',
+    data: { templateId: 'availability-zone', label: 'AZ B', sim: { locationId: 'us-east-1b' } }
+  },
+  {
+    id: 'subnet-b',
+    parentNode: 'az-b',
+    data: { templateId: 'subnet', label: 'Subnet B', sim: { locationId: '10.0.2.0/24' } }
+  },
+  {
+    id: 'region-eu',
+    data: { templateId: 'vpc-region', label: 'EU West', sim: { locationId: 'eu-west-1' } }
+  },
+  {
+    id: 'az-eu',
+    parentNode: 'region-eu',
+    data: { templateId: 'availability-zone', label: 'AZ EU', sim: { locationId: 'eu-west-1a' } }
+  },
+  {
+    id: 'subnet-eu',
+    parentNode: 'az-eu',
+    data: { templateId: 'subnet', label: 'Subnet EU', sim: { locationId: '10.1.1.0/24' } }
+  },
+  { id: 'web', parentNode: 'subnet-a', data: { templateId: 'client-user', label: 'Web' } },
+  { id: 'api', parentNode: 'subnet-b', data: { templateId: 'backend-server', label: 'API' } },
+  { id: 'fraud', parentNode: 'subnet-eu', data: { templateId: 'backend-server', label: 'Fraud' } }
+]
+
+describe('locationTopology', () => {
+  it('resolves node ancestry labels and rollups', () => {
+    const topology = buildLocationTopology(nodes)
+    const nodeRollups = buildNodeLocationRollups(topology, [
+      {
+        nodeId: 'web',
+        postWarmupArrived: 0,
+        postWarmupProcessed: 0,
+        totalFailures: 0,
+        throughput: 0,
+        utilization: null,
+        p95: null,
+        active: false,
+        isSource: true
+      },
+      {
+        nodeId: 'api',
+        postWarmupArrived: 120,
+        postWarmupProcessed: 118,
+        totalFailures: 2,
+        throughput: 58,
+        utilization: 0.72,
+        p95: 95,
+        active: true
+      },
+      {
+        nodeId: 'fraud',
+        postWarmupArrived: 40,
+        postWarmupProcessed: 38,
+        totalFailures: 2,
+        throughput: 19,
+        utilization: 0.44,
+        p95: 180,
+        active: true
+      }
+    ] satisfies NodeRollupInput[])
+
+    expect(formatNodeLocation(topology.nodeLocations.get('api'))).toBe(
+      'us-east-1 / us-east-1b / 10.0.2.0/24'
+    )
+    expect(nodeRollups.region[0]).toMatchObject({
+      label: 'us-east-1',
+      nodeCount: 2,
+      activeNodeCount: 1,
+      sourceCount: 1
+    })
+    expect(nodeRollups.region[1]).toMatchObject({
+      label: 'eu-west-1',
+      totalArrived: 40,
+      worstP95: 180
+    })
+  })
+
+  it('describes edge locality and aggregates traffic by locality group', () => {
+    const topology = buildLocationTopology(nodes)
+    const sameRegion = describeEdgeLocality(topology, {
+      source: 'web',
+      target: 'api',
+      data: {}
+    })
+    const crossRegion = describeEdgeLocality(topology, {
+      source: 'web',
+      target: 'fraud',
+      data: {}
+    })
+    const rollups = buildEdgeLocalityRollups(topology, [
+      {
+        edgeId: 'web-api',
+        source: 'web',
+        target: 'api',
+        data: {},
+        attempts: 120,
+        failures: 2,
+        p95: 96
+      },
+      {
+        edgeId: 'web-fraud',
+        source: 'web',
+        target: 'fraud',
+        data: {},
+        attempts: 40,
+        failures: 4,
+        p95: 182
+      }
+    ] satisfies EdgeRollupInput[])
+
+    expect(sameRegion).toMatchObject({
+      pathType: 'cross-zone',
+      detailLabel: 'us-east-1a -> us-east-1b'
+    })
+    expect(crossRegion).toMatchObject({
+      pathType: 'cross-region',
+      detailLabel: 'us-east-1 -> eu-west-1'
+    })
+    expect(rollups[0]).toMatchObject({
+      pathType: 'cross-zone',
+      attempts: 120
+    })
+    expect(rollups[1]).toMatchObject({
+      pathType: 'cross-region',
+      failures: 4
+    })
+  })
+})

--- a/src/renderer/src/utils/locationTopology.ts
+++ b/src/renderer/src/utils/locationTopology.ts
@@ -1,0 +1,426 @@
+import type { Edge, Node } from 'reactflow'
+import type { PerEdgeMetrics, PerNodeMetrics } from '../../../engine/metrics'
+import type { CanvasNodeDataV2 } from '../../../engine/catalog/nodeSpecTypes'
+import type { EdgeSimulationData } from '@renderer/types/ui'
+
+export type LocationLevel = 'region' | 'az' | 'subnet'
+export type EdgePathType = NonNullable<EdgeSimulationData['pathType']>
+
+type ContainerLocation = Partial<Record<LocationLevel, string>>
+
+const CONTAINER_LEVEL_BY_TEMPLATE: Record<string, LocationLevel> = {
+  'vpc-region': 'region',
+  'availability-zone': 'az',
+  subnet: 'subnet'
+}
+
+const EDGE_PATH_TYPES = new Set<EdgePathType>([
+  'same-rack',
+  'same-dc',
+  'cross-zone',
+  'cross-region',
+  'internet'
+])
+
+function asCanvasNodeData(data: unknown): Partial<CanvasNodeDataV2> {
+  return typeof data === 'object' && data !== null ? (data as Partial<CanvasNodeDataV2>) : {}
+}
+
+function cleanLabel(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined
+}
+
+function asEdgePathType(value: unknown): EdgePathType | undefined {
+  return typeof value === 'string' && EDGE_PATH_TYPES.has(value as EdgePathType)
+    ? (value as EdgePathType)
+    : undefined
+}
+
+function parentLevel(node: { data?: unknown }): LocationLevel | undefined {
+  const templateId = asCanvasNodeData(node.data).templateId
+  return typeof templateId === 'string' ? CONTAINER_LEVEL_BY_TEMPLATE[templateId] : undefined
+}
+
+function containerDisplayName(node: { id: string; data?: unknown }): string {
+  const data = asCanvasNodeData(node.data)
+  return cleanLabel(data.sim?.locationId) ?? cleanLabel(data.label) ?? node.id
+}
+
+export interface ContainerPathResolution {
+  pathType: EdgePathType
+  regionPair?: readonly [string, string]
+}
+
+export interface NodeLocationSummary {
+  nodeId: string
+  regionId?: string
+  azId?: string
+  subnetId?: string
+  regionLabel?: string
+  azLabel?: string
+  subnetLabel?: string
+}
+
+export interface LocationTopology {
+  containerLocations: Map<string, ContainerLocation>
+  containerLevelById: Map<string, LocationLevel>
+  containerLabelById: Map<string, string>
+  nodeLocations: Map<string, NodeLocationSummary>
+}
+
+export function buildContainerLocations(
+  rfNodes: readonly { id: string; parentNode?: string; data?: unknown }[]
+): Map<string, ContainerLocation> {
+  const byId = new Map(rfNodes.map((node) => [node.id, node]))
+  const locations = new Map<string, ContainerLocation>()
+
+  for (const node of rfNodes) {
+    const location: ContainerLocation = {}
+    const seen = new Set<string>()
+    let parentId = node.parentNode
+
+    while (parentId && !seen.has(parentId)) {
+      seen.add(parentId)
+      const parent = byId.get(parentId)
+      if (!parent) break
+      const level = parentLevel(parent)
+      if (level && !location[level]) location[level] = parent.id
+      parentId = parent.parentNode
+    }
+
+    locations.set(node.id, location)
+  }
+
+  return locations
+}
+
+export function pathTypeFromContainers(
+  locations: Map<string, ContainerLocation>,
+  source: string,
+  target: string
+): ContainerPathResolution | null {
+  const a = locations.get(source)
+  const b = locations.get(target)
+  if (!a || !b) return null
+  if (a.subnet && a.subnet === b.subnet) return { pathType: 'same-rack' }
+  if (a.az && a.az === b.az) return { pathType: 'same-dc' }
+  if (a.region && a.region === b.region) return { pathType: 'cross-zone' }
+  if (a.region && b.region && a.region !== b.region) {
+    return { pathType: 'cross-region', regionPair: [a.region, b.region] }
+  }
+  return null
+}
+
+export function buildLocationTopology(
+  rfNodes: readonly Pick<Node, 'id' | 'parentNode' | 'data'>[]
+): LocationTopology {
+  const containerLevelById = new Map<string, LocationLevel>()
+  const containerLabelById = new Map<string, string>()
+
+  for (const node of rfNodes) {
+    const level = parentLevel(node)
+    if (!level) continue
+    containerLevelById.set(node.id, level)
+    containerLabelById.set(node.id, containerDisplayName(node))
+  }
+
+  const containerLocations = buildContainerLocations(rfNodes)
+  const nodeLocations = new Map<string, NodeLocationSummary>()
+
+  for (const node of rfNodes) {
+    const location = containerLocations.get(node.id) ?? {}
+    nodeLocations.set(node.id, {
+      nodeId: node.id,
+      regionId: location.region,
+      azId: location.az,
+      subnetId: location.subnet,
+      regionLabel: location.region ? containerLabelById.get(location.region) : undefined,
+      azLabel: location.az ? containerLabelById.get(location.az) : undefined,
+      subnetLabel: location.subnet ? containerLabelById.get(location.subnet) : undefined
+    })
+  }
+
+  return {
+    containerLocations,
+    containerLevelById,
+    containerLabelById,
+    nodeLocations
+  }
+}
+
+export function formatNodeLocation(meta?: NodeLocationSummary | null): string | null {
+  if (!meta) return null
+  const labels = [meta.regionLabel, meta.azLabel, meta.subnetLabel].filter(
+    (value): value is string => Boolean(value)
+  )
+  return labels.length > 0 ? labels.join(' / ') : null
+}
+
+export interface EdgeLocalityDescriptor {
+  pathType?: EdgePathType
+  scopeLabel?: string
+  detailLabel?: string
+}
+
+export function describeEdgeLocality(
+  topology: LocationTopology,
+  edge: Pick<Edge, 'source' | 'target' | 'data'>
+): EdgeLocalityDescriptor {
+  const explicitPathType = asEdgePathType((edge.data as EdgeSimulationData | undefined)?.pathType)
+  const derived = explicitPathType
+    ? { pathType: explicitPathType }
+    : pathTypeFromContainers(topology.containerLocations, edge.source, edge.target) ?? undefined
+  if (!derived) return {}
+
+  const sourceMeta = topology.nodeLocations.get(edge.source)
+  const targetMeta = topology.nodeLocations.get(edge.target)
+
+  switch (derived.pathType) {
+    case 'same-rack': {
+      const label = sourceMeta?.subnetLabel ?? targetMeta?.subnetLabel
+      return { pathType: derived.pathType, scopeLabel: label, detailLabel: label }
+    }
+    case 'same-dc': {
+      const label = sourceMeta?.azLabel ?? targetMeta?.azLabel
+      return { pathType: derived.pathType, scopeLabel: label, detailLabel: label }
+    }
+    case 'cross-zone': {
+      const sourceLabel = sourceMeta?.azLabel
+      const targetLabel = targetMeta?.azLabel
+      const detailLabel =
+        sourceLabel && targetLabel && sourceLabel !== targetLabel
+          ? `${sourceLabel} -> ${targetLabel}`
+          : sourceMeta?.regionLabel ?? targetMeta?.regionLabel
+      return {
+        pathType: derived.pathType,
+        scopeLabel: sourceMeta?.regionLabel ?? targetMeta?.regionLabel,
+        detailLabel
+      }
+    }
+    case 'cross-region': {
+      const sourceLabel = sourceMeta?.regionLabel
+      const targetLabel = targetMeta?.regionLabel
+      const detailLabel =
+        sourceLabel && targetLabel ? `${sourceLabel} -> ${targetLabel}` : sourceLabel ?? targetLabel
+      return {
+        pathType: derived.pathType,
+        scopeLabel: detailLabel,
+        detailLabel
+      }
+    }
+    case 'internet':
+      return { pathType: derived.pathType, scopeLabel: 'internet', detailLabel: 'internet' }
+  }
+}
+
+export interface NodeRollupInput {
+  nodeId: string
+  postWarmupArrived: number
+  postWarmupProcessed: number
+  totalFailures: number
+  throughput: number
+  utilization?: number | null
+  p95?: number | null
+  active: boolean
+  isSource?: boolean
+}
+
+export interface NodeLocationRollup {
+  level: LocationLevel
+  containerId: string
+  label: string
+  nodeCount: number
+  activeNodeCount: number
+  sourceCount: number
+  totalArrived: number
+  totalProcessed: number
+  totalFailures: number
+  totalThroughput: number
+  errorRate: number | null
+  avgUtilization: number | null
+  worstP95: number | null
+}
+
+export type NodeLocationRollups = Record<LocationLevel, NodeLocationRollup[]>
+
+export function buildNodeLocationRollups(
+  topology: LocationTopology,
+  inputs: readonly NodeRollupInput[]
+): NodeLocationRollups {
+  const grouped = new Map<string, NodeLocationRollup & { utilizationSum: number; utilizationCount: number }>()
+
+  for (const input of inputs) {
+    const location = topology.nodeLocations.get(input.nodeId)
+    if (!location) continue
+
+    for (const level of ['region', 'az', 'subnet'] as const) {
+      const containerId = location[`${level}Id`]
+      const label = location[`${level}Label`]
+      if (!containerId || !label) continue
+
+      const key = `${level}:${containerId}`
+      const current =
+        grouped.get(key) ??
+        {
+          level,
+          containerId,
+          label,
+          nodeCount: 0,
+          activeNodeCount: 0,
+          sourceCount: 0,
+          totalArrived: 0,
+          totalProcessed: 0,
+          totalFailures: 0,
+          totalThroughput: 0,
+          errorRate: null,
+          avgUtilization: null,
+          worstP95: null,
+          utilizationSum: 0,
+          utilizationCount: 0
+        }
+
+      current.nodeCount += 1
+      if (input.active) current.activeNodeCount += 1
+      if (input.isSource) current.sourceCount += 1
+      current.totalArrived += input.postWarmupArrived
+      current.totalProcessed += input.postWarmupProcessed
+      current.totalFailures += input.totalFailures
+      current.totalThroughput += input.throughput
+      if (typeof input.utilization === 'number' && Number.isFinite(input.utilization)) {
+        current.utilizationSum += input.utilization
+        current.utilizationCount += 1
+      }
+      if (typeof input.p95 === 'number' && Number.isFinite(input.p95)) {
+        current.worstP95 =
+          current.worstP95 === null ? input.p95 : Math.max(current.worstP95, input.p95)
+      }
+
+      grouped.set(key, current)
+    }
+  }
+
+  const toArray = (level: LocationLevel): NodeLocationRollup[] =>
+    [...grouped.values()]
+      .filter((rollup) => rollup.level === level)
+      .map(({ utilizationSum, utilizationCount, ...rollup }) => ({
+        ...rollup,
+        errorRate: rollup.totalArrived > 0 ? rollup.totalFailures / rollup.totalArrived : null,
+        avgUtilization: utilizationCount > 0 ? utilizationSum / utilizationCount : null
+      }))
+      .sort(
+        (a, b) =>
+          b.totalArrived - a.totalArrived ||
+          b.totalThroughput - a.totalThroughput ||
+          a.label.localeCompare(b.label)
+      )
+
+  return {
+    region: toArray('region'),
+    az: toArray('az'),
+    subnet: toArray('subnet')
+  }
+}
+
+export interface EdgeRollupInput {
+  edgeId: string
+  source: string
+  target: string
+  data?: unknown
+  attempts: number
+  failures: number
+  p95?: number | null
+}
+
+export interface EdgeLocalityRollup {
+  key: string
+  pathType: EdgePathType
+  label: string
+  edgeCount: number
+  attempts: number
+  failures: number
+  errorRate: number | null
+  worstP95: number | null
+}
+
+export function buildEdgeLocalityRollups(
+  topology: LocationTopology,
+  inputs: readonly EdgeRollupInput[]
+): EdgeLocalityRollup[] {
+  const grouped = new Map<string, EdgeLocalityRollup>()
+
+  for (const input of inputs) {
+    const locality = describeEdgeLocality(topology, input)
+    if (!locality.pathType) continue
+    const label = locality.detailLabel ?? locality.scopeLabel ?? locality.pathType
+    const key = `${locality.pathType}:${label}`
+    const current =
+      grouped.get(key) ??
+      {
+        key,
+        pathType: locality.pathType,
+        label,
+        edgeCount: 0,
+        attempts: 0,
+        failures: 0,
+        errorRate: null,
+        worstP95: null
+      }
+
+    current.edgeCount += 1
+    current.attempts += input.attempts
+    current.failures += input.failures
+    if (typeof input.p95 === 'number' && Number.isFinite(input.p95)) {
+      current.worstP95 = current.worstP95 === null ? input.p95 : Math.max(current.worstP95, input.p95)
+    }
+    grouped.set(key, current)
+  }
+
+  return [...grouped.values()]
+    .map((rollup) => ({
+      ...rollup,
+      errorRate: rollup.attempts > 0 ? rollup.failures / rollup.attempts : null
+    }))
+    .sort(
+      (a, b) =>
+        b.attempts - a.attempts || b.edgeCount - a.edgeCount || a.pathType.localeCompare(b.pathType)
+    )
+}
+
+export function buildNodeRollupInputsFromResults(
+  perNode: Record<string, PerNodeMetrics>,
+  sourceNodeIds: ReadonlySet<string>
+): NodeRollupInput[] {
+  return Object.entries(perNode).map(([nodeId, metric]) => ({
+    nodeId,
+    postWarmupArrived: metric.postWarmupArrived,
+    postWarmupProcessed: metric.postWarmupProcessed,
+    totalFailures:
+      metric.postWarmupRejected + metric.postWarmupTimedOut + metric.postWarmupConnectionReset,
+    throughput: metric.throughput,
+    utilization: metric.utilization,
+    p95: metric.latencyNodeLocal.p95 ?? metric.latencyP95,
+    active:
+      metric.postWarmupArrived > 0 || metric.successLatencySamples > 0 || metric.timeToErrorSamples > 0,
+    isSource: sourceNodeIds.has(nodeId)
+  }))
+}
+
+export function buildEdgeRollupInputsFromResults(
+  edges: readonly Pick<Edge, 'id' | 'source' | 'target' | 'data'>[],
+  perEdge: Record<string, PerEdgeMetrics>
+): EdgeRollupInput[] {
+  const inputs: Array<EdgeRollupInput | null> = edges.map((edge) => {
+      const metric = perEdge[edge.id]
+      if (!metric) return null
+      return {
+        edgeId: edge.id,
+        source: edge.source,
+        target: edge.target,
+        data: edge.data,
+        attempts: metric.totalSuccessfulTransits + metric.totalFailedTerminals,
+        failures: metric.totalFailedTerminals,
+        p95: metric.transitLatency.p95
+      }
+    })
+  return inputs.filter((value): value is EdgeRollupInput => value !== null)
+}

--- a/src/renderer/src/utils/locationTopology.ts
+++ b/src/renderer/src/utils/locationTopology.ts
@@ -169,7 +169,7 @@ export function describeEdgeLocality(
   const explicitPathType = asEdgePathType((edge.data as EdgeSimulationData | undefined)?.pathType)
   const derived = explicitPathType
     ? { pathType: explicitPathType }
-    : pathTypeFromContainers(topology.containerLocations, edge.source, edge.target) ?? undefined
+    : (pathTypeFromContainers(topology.containerLocations, edge.source, edge.target) ?? undefined)
   if (!derived) return {}
 
   const sourceMeta = topology.nodeLocations.get(edge.source)
@@ -190,7 +190,7 @@ export function describeEdgeLocality(
       const detailLabel =
         sourceLabel && targetLabel && sourceLabel !== targetLabel
           ? `${sourceLabel} -> ${targetLabel}`
-          : sourceMeta?.regionLabel ?? targetMeta?.regionLabel
+          : (sourceMeta?.regionLabel ?? targetMeta?.regionLabel)
       return {
         pathType: derived.pathType,
         scopeLabel: sourceMeta?.regionLabel ?? targetMeta?.regionLabel,
@@ -201,7 +201,9 @@ export function describeEdgeLocality(
       const sourceLabel = sourceMeta?.regionLabel
       const targetLabel = targetMeta?.regionLabel
       const detailLabel =
-        sourceLabel && targetLabel ? `${sourceLabel} -> ${targetLabel}` : sourceLabel ?? targetLabel
+        sourceLabel && targetLabel
+          ? `${sourceLabel} -> ${targetLabel}`
+          : (sourceLabel ?? targetLabel)
       return {
         pathType: derived.pathType,
         scopeLabel: detailLabel,
@@ -247,7 +249,10 @@ export function buildNodeLocationRollups(
   topology: LocationTopology,
   inputs: readonly NodeRollupInput[]
 ): NodeLocationRollups {
-  const grouped = new Map<string, NodeLocationRollup & { utilizationSum: number; utilizationCount: number }>()
+  const grouped = new Map<
+    string,
+    NodeLocationRollup & { utilizationSum: number; utilizationCount: number }
+  >()
 
   for (const input of inputs) {
     const location = topology.nodeLocations.get(input.nodeId)
@@ -259,25 +264,23 @@ export function buildNodeLocationRollups(
       if (!containerId || !label) continue
 
       const key = `${level}:${containerId}`
-      const current =
-        grouped.get(key) ??
-        {
-          level,
-          containerId,
-          label,
-          nodeCount: 0,
-          activeNodeCount: 0,
-          sourceCount: 0,
-          totalArrived: 0,
-          totalProcessed: 0,
-          totalFailures: 0,
-          totalThroughput: 0,
-          errorRate: null,
-          avgUtilization: null,
-          worstP95: null,
-          utilizationSum: 0,
-          utilizationCount: 0
-        }
+      const current = grouped.get(key) ?? {
+        level,
+        containerId,
+        label,
+        nodeCount: 0,
+        activeNodeCount: 0,
+        sourceCount: 0,
+        totalArrived: 0,
+        totalProcessed: 0,
+        totalFailures: 0,
+        totalThroughput: 0,
+        errorRate: null,
+        avgUtilization: null,
+        worstP95: null,
+        utilizationSum: 0,
+        utilizationCount: 0
+      }
 
       current.nodeCount += 1
       if (input.active) current.activeNodeCount += 1
@@ -353,24 +356,23 @@ export function buildEdgeLocalityRollups(
     if (!locality.pathType) continue
     const label = locality.detailLabel ?? locality.scopeLabel ?? locality.pathType
     const key = `${locality.pathType}:${label}`
-    const current =
-      grouped.get(key) ??
-      {
-        key,
-        pathType: locality.pathType,
-        label,
-        edgeCount: 0,
-        attempts: 0,
-        failures: 0,
-        errorRate: null,
-        worstP95: null
-      }
+    const current = grouped.get(key) ?? {
+      key,
+      pathType: locality.pathType,
+      label,
+      edgeCount: 0,
+      attempts: 0,
+      failures: 0,
+      errorRate: null,
+      worstP95: null
+    }
 
     current.edgeCount += 1
     current.attempts += input.attempts
     current.failures += input.failures
     if (typeof input.p95 === 'number' && Number.isFinite(input.p95)) {
-      current.worstP95 = current.worstP95 === null ? input.p95 : Math.max(current.worstP95, input.p95)
+      current.worstP95 =
+        current.worstP95 === null ? input.p95 : Math.max(current.worstP95, input.p95)
     }
     grouped.set(key, current)
   }
@@ -400,7 +402,9 @@ export function buildNodeRollupInputsFromResults(
     utilization: metric.utilization,
     p95: metric.latencyNodeLocal.p95 ?? metric.latencyP95,
     active:
-      metric.postWarmupArrived > 0 || metric.successLatencySamples > 0 || metric.timeToErrorSamples > 0,
+      metric.postWarmupArrived > 0 ||
+      metric.successLatencySamples > 0 ||
+      metric.timeToErrorSamples > 0,
     isSource: sourceNodeIds.has(nodeId)
   }))
 }
@@ -410,17 +414,17 @@ export function buildEdgeRollupInputsFromResults(
   perEdge: Record<string, PerEdgeMetrics>
 ): EdgeRollupInput[] {
   const inputs: Array<EdgeRollupInput | null> = edges.map((edge) => {
-      const metric = perEdge[edge.id]
-      if (!metric) return null
-      return {
-        edgeId: edge.id,
-        source: edge.source,
-        target: edge.target,
-        data: edge.data,
-        attempts: metric.totalSuccessfulTransits + metric.totalFailedTerminals,
-        failures: metric.totalFailedTerminals,
-        p95: metric.transitLatency.p95
-      }
-    })
+    const metric = perEdge[edge.id]
+    if (!metric) return null
+    return {
+      edgeId: edge.id,
+      source: edge.source,
+      target: edge.target,
+      data: edge.data,
+      attempts: metric.totalSuccessfulTransits + metric.totalFailedTerminals,
+      failures: metric.totalFailedTerminals,
+      p95: metric.transitLatency.p95
+    }
+  })
   return inputs.filter((value): value is EdgeRollupInput => value !== null)
 }


### PR DESCRIPTION
## Summary

This PR expands the simulator in three connected areas:

1. It makes request routing and request outcomes more explicit and analyzable.
2. It adds first-class locality modeling and locality rollups across the canvas, results, and inspector.
3. It improves the post-run UX so edge behavior, node status, request mix, and deployment placement are easier to understand.

It also updates the `ns-simulator-docs` submodule with a simulator feature reference and supporting design/spec notes.

## What changed

### 1. Request-aware routing and outcome modeling

This PR adds a stronger request semantics layer so the simulator can reason about more than a generic request type.

Changes include:
- Added request operation semantics with support for `type`, `method`, `host`, and `path`.
- Expanded content-routing rules so L7 routing can match on HTTP method in addition to existing request metadata.
- Added richer request outcome classification:
  - `2xx success`
  - `4xx reject`
  - `5xx failure`
  - `timeout`
  - `network drop`
  - `connection reset`
  - `in flight`
- Added outcome-family breakdowns to simulation output.
- Added operation labels and request metadata to retained request outcomes so the UI can show real request shapes rather than anonymous traffic.

This makes endpoint-aware scenarios much more legible in both engine output and UI analysis.

### 2. Routing strategy fidelity

The engine and UI are now more aligned around actual routing behavior.

Changes include:
- Implemented `least-conn` using live in-flight counts from runtime node state.
- Added `passthrough` support as an explicit strategy.
- Preserved weighted fallback behavior when no explicit strategy is set.
- Added tests for least-connection routing, tie-breaking, and passthrough behavior.

This matters because the routing strategy a user configures is now more directly reflected in actual simulation behavior and downstream traffic distribution.

### 3. Request mix authoring

This PR adds request-mix editing to the node configuration flow.

Changes include:
- Added a custom request-distribution editor for source nodes.
- Exposed request templates in node capability modules.
- Added text-input support in the form system where needed for request metadata and location metadata.
- Improved routing-rule editing with field-specific placeholders.

This makes it practical to author mixed workloads such as:
- `GET catalog`
- `POST checkout`
- `POST fraud check`

without dropping down to raw JSON.

### 4. Locality modeling and auto edge behavior

This PR introduces a proper locality layer that connects composite placement to edge defaults and results analysis.

Changes include:
- Added location topology utilities to derive:
  - region
  - availability zone
  - subnet
  - edge locality paths
- Added `locationId` support to node simulation config for composite metadata.
- Added a composite location config module so region/AZ/subnet containers can carry human-readable location identifiers.
- Added placement-derived edge path resolution:
  - same subnet → same-rack
  - same AZ → same-dc
  - same region → cross-zone
  - different regions → cross-region
- Preserved manual edge settings while supporting automatic path-type and latency derivation.

This makes edge `Auto` behavior understandable and grounded in actual canvas placement rather than opaque defaults alone.

### 5. Results tray locality rollups

The results experience now includes deployment-aware rollups instead of only flat per-node or per-edge summaries.

Changes include:
- Added `LocationRollupsPanel`.
- Added rollups for:
  - regions
  - availability zones
  - subnets
  - traffic locality
- Added rollup input builders from simulation results.
- Clarified that composite containers are grouping metadata, not simulated hops.

This helps answer questions like:
- Which region carried the load?
- Which AZ saw the worst p95?
- Which cross-zone or cross-region path dominated latency?

### 6. Run Inspector improvements

The right-side post-run inspector is now much more useful as a compact operational summary.

Changes include:
- Added richer run summary cards.
- Added request-mix preview.
- Added outcome split summary.
- Added a dedicated `Locality` tab alongside `Nodes` and `Links`.
- Added configured placement summaries and configured traffic-path summaries.
- Improved edge results/config presentation.
- Added clearer inspector help text.

This makes the inspector a practical “what should I look at first?” surface instead of only a basic stats sidebar.

### 7. Node and edge UX clarity

This PR also improves several confusing UI details.

Changes include:
- Added glyph tooltips for lens status icons on nodes.
- Improved lens-specific explanations for latency, errors, saturation, and throughput.
- Improved edge properties explanations for auto path type and derived latency.
- Added better copy around locality-derived behavior.

This reduces ambiguity around checks, warnings, crosses, and edge “Auto” behavior.

### 8. Composite canvas behavior and edge clickability

This PR fixes a usability issue with composite containers and nested interactions.

Changes include:
- Reworked containment recomputation based on node geometry.
- Improved nesting behavior when dragging nodes or containers.
- Updated VPC/composite pointer-event behavior so edges inside composites remain clickable.
- Added tests around containment recomputation.

This addresses the canvas interaction issue where edges inside composite nodes were difficult or impossible to select reliably.

### 9. New sample scenarios

This PR adds new guided scenarios to demonstrate the new capabilities:

- `Multi-AZ Auto Latency`
- `Cross-Region Auto Latency`
- `Endpoint Routing Mix`

These scenarios make it easier to validate:
- placement-driven edge defaults
- auto/manual edge reversibility
- endpoint-aware routing behavior
- request-mix analysis in results

### 10. Documentation updates

The PR also bumps the `ns-simulator-docs` submodule to include:
- a simulator feature reference
- an ADR on live-simulation event streaming performance
- a UI spec for indicator grammar, tooltips, and rollups
- a Game Playground integration gap analysis

## Why

The main goal of this PR is to make the simulator more explainable without flattening its behavior model.

Before this change:
- endpoint routing was harder to inspect clearly
- request outcomes were not grouped in a user-friendly way
- locality behavior was present but not surfaced cleanly
- edge `Auto` semantics were not obvious
- composite placement was not fully connected to inspector and rollup UX
- node/edge status icons could be ambiguous

After this change:
- routing decisions are easier to author and inspect
- outcomes are visible in meaningful operational buckets
- deployment placement has first-class analysis surfaces
- auto locality and auto latency are more understandable
- the Run Inspector provides a much better post-run narrative

## Scope / compatibility notes

- Existing scenarios remain compatible.
- Manual edge settings still win over auto-derived defaults.
- Composite location metadata is additive and primarily used for labeling, export context, and rollups.
- The locality model improves default path inference, but does not yet attempt provider-specific or geography-precise latency modeling.

## Validation

Ran:
- `npm run lint`

## Commits

Parent repo:
- `feat(engine): add request semantics and routing outcome modeling`
- `feat(ui): add locality rollups and request-mix inspection`
- `chore: bump ns-simulator-docs submodule`
- `style: format simulator follow-up changes`

Docs submodule:
- `docs: add simulator feature reference`
- `docs: add simulator ADR and UX analysis notes`