### PR TITLE
feat: add canvas auto layout action

### DIFF
--- a/src/renderer/src/components/canvas/FlowCanvas.tsx
+++ b/src/renderer/src/components/canvas/FlowCanvas.tsx
@@ -40,6 +40,7 @@ const FlowCanvasInternal = ({ showMetricLens = false, onNodeDoubleClick }: FlowC
     useFlowStore()
 
   const selectGraphElements = useStore((state) => state.selectGraphElements)
+  const viewportFitVersion = useStore((state) => state.viewportFitVersion)
 
   const { edgeTypes, defaultEdgeOptions } = useFlowConfig()
 
@@ -79,6 +80,20 @@ const FlowCanvasInternal = ({ showMetricLens = false, onNodeDoubleClick }: FlowC
 
     prevNodeCount.current = nodes.length
   }, [nodes.length, reactFlowInstance])
+
+  useEffect(() => {
+    if (!reactFlowInstance) {
+      return
+    }
+
+    window.requestAnimationFrame(() => {
+      reactFlowInstance.fitView({
+        padding: 0.2,
+        maxZoom: 1.2,
+        duration: 500
+      })
+    })
+  }, [reactFlowInstance, viewportFitVersion])
 
   // Edge selection lives in the shared store so the right-hand inspector
   // (PropertiesPanel) can render its properties, exactly like node config.

--- a/src/renderer/src/components/layout/Header.tsx
+++ b/src/renderer/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react'
-import { FolderOpen, Save, Sidebar } from 'lucide-react'
+import { FolderOpen, Save, Sidebar, Workflow } from 'lucide-react'
 
 import { Divider } from '../ui/Divider'
 import { IconButton } from '../ui/IconButton'
@@ -20,6 +20,7 @@ interface HeaderProps {
   // File
   onSave: () => void
   onOpen: () => void
+  onAutoLayout: () => void
   fileName: string | null
   isUnsaved: boolean
 
@@ -47,6 +48,7 @@ export const Header = memo(
     isRightOpen,
     onSave,
     onOpen,
+    onAutoLayout,
     fileName,
     isUnsaved,
     onRun,
@@ -84,6 +86,11 @@ export const Header = memo(
           <div className="flex items-center gap-1">
             <IconButton onClick={onOpen} icon={<FolderOpen size={18} />} label="Open (Ctrl+O)" />
             <IconButton onClick={onSave} icon={<Save size={18} />} label="Save (Ctrl+S)" />
+            <IconButton
+              onClick={onAutoLayout}
+              icon={<Workflow size={18} />}
+              label="Auto Layout"
+            />
           </div>
 
           <Divider />

--- a/src/renderer/src/components/layout/WorkspaceLayout.tsx
+++ b/src/renderer/src/components/layout/WorkspaceLayout.tsx
@@ -9,6 +9,7 @@ import { useFlowPersistence } from '@renderer/hooks/useFlowPersistence'
 import { useConfirmDialog } from '@renderer/hooks/useConfirmDialog'
 import { useSimulation } from '@renderer/hooks/useSimulation'
 import { useTopologySerializer } from '@renderer/hooks/useTopologySerializer'
+import { applyAutoLayout } from '@renderer/utils/autoLayout'
 import { validateTopology } from '../../../../engine/validation/validator'
 import type { LatencyPercentiles } from '../../../../engine/metrics'
 import type { TimeSeriesSnapshot } from '../../../../engine/analysis/output'
@@ -293,9 +294,11 @@ export const WorkspaceLayout = () => {
   const edges = useStore((s) => s.edges)
   const scenario = useStore((s) => s.scenario)
   const updateScenario = useStore((s) => s.updateScenario)
+  const setNodes = useStore((s) => s.setNodes)
   const setSimulationMetrics = useStore((s) => s.setSimulationMetrics)
   const clearSimulationMetrics = useStore((s) => s.clearSimulationMetrics)
   const selectGraphElements = useStore((s) => s.selectGraphElements)
+  const requestViewportFit = useStore((s) => s.requestViewportFit)
   const runInspectorPinned = useStore((s) => s.runInspectorPinned)
   const setRunInspectorPinned = useStore((s) => s.setRunInspectorPinned)
   const routingVisualization = useStore((s) => s.routingStrategyVisualization)
@@ -412,6 +415,15 @@ export const WorkspaceLayout = () => {
     },
     [clearSimulationMetrics, loadFromData, selectGraphElements, setRoutingVisualization, sim]
   )
+
+  const handleAutoLayout = useCallback(() => {
+    if (nodes.length === 0) {
+      return
+    }
+
+    setNodes(applyAutoLayout(nodes, edges))
+    requestViewportFit()
+  }, [edges, nodes, requestViewportFit, setNodes])
 
   useEffect(() => {
     if (sim.results || !sim.snapshot || (sim.status !== 'running' && sim.status !== 'paused')) {
@@ -615,6 +627,7 @@ export const WorkspaceLayout = () => {
         isRightOpen={isRightOpen}
         onSave={handleSave}
         onOpen={handleOpen}
+        onAutoLayout={handleAutoLayout}
         fileName={fileName}
         isUnsaved={isUnsaved}
         onRun={handleRun}

--- a/src/renderer/src/store/useStore.ts
+++ b/src/renderer/src/store/useStore.ts
@@ -260,6 +260,7 @@ type RFState = {
   fileName: string | null
   isUnsaved: boolean
   scenario: ScenarioState
+  viewportFitVersion: number
 
   // --- Actions ---
   onNodesChange: OnNodesChange
@@ -290,6 +291,7 @@ type RFState = {
   setFileName: (name: string | null) => void
   setUnsaved: (unsaved: boolean) => void
   setScenario: (scenario: ScenarioState) => void
+  requestViewportFit: () => void
   updateScenario: (updater: (scenario: ScenarioState) => ScenarioState) => void
 }
 
@@ -311,6 +313,7 @@ const useStore = create<RFState>((set, get) => ({
   fileName: 'Untitled',
   isUnsaved: false,
   scenario: DEFAULT_SCENARIO_STATE,
+  viewportFitVersion: 0,
 
   onNodesChange: (changes: NodeChange[]) => {
     set({
@@ -569,6 +572,10 @@ const useStore = create<RFState>((set, get) => ({
   setFileName: (fileName) => set({ fileName }),
   setUnsaved: (isUnsaved) => set({ isUnsaved }),
   setScenario: (scenario) => set({ scenario }),
+  requestViewportFit: () =>
+    set((state) => ({
+      viewportFitVersion: state.viewportFitVersion + 1
+    })),
   updateScenario: (updater) => set((state) => ({ scenario: updater(state.scenario) }))
 }))
 

--- a/src/renderer/src/utils/autoLayout.test.ts
+++ b/src/renderer/src/utils/autoLayout.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import type { Edge, Node } from 'reactflow'
+import { applyAutoLayout } from './autoLayout'
+
+function buildNode(id: string, x = 0, y = 0): Node {
+  return {
+    id,
+    position: { x, y },
+    data: { label: id },
+    width: 180,
+    height: 100
+  } as Node
+}
+
+function buildEdge(source: string, target: string): Edge {
+  return {
+    id: `${source}-${target}`,
+    source,
+    target
+  } as Edge
+}
+
+describe('applyAutoLayout', () => {
+  it('places downstream nodes to the right of their sources', () => {
+    const nodes = [buildNode('client'), buildNode('gateway'), buildNode('service'), buildNode('db')]
+    const edges = [
+      buildEdge('client', 'gateway'),
+      buildEdge('gateway', 'service'),
+      buildEdge('service', 'db')
+    ]
+
+    const laidOut = applyAutoLayout(nodes, edges)
+    const byId = new Map(laidOut.map((node) => [node.id, node]))
+
+    expect((byId.get('gateway')?.position.x ?? 0) > (byId.get('client')?.position.x ?? 0)).toBe(
+      true
+    )
+    expect((byId.get('service')?.position.x ?? 0) > (byId.get('gateway')?.position.x ?? 0)).toBe(
+      true
+    )
+    expect((byId.get('db')?.position.x ?? 0) > (byId.get('service')?.position.x ?? 0)).toBe(
+      true
+    )
+  })
+
+  it('stacks sibling nodes vertically in the same layer', () => {
+    const nodes = [buildNode('lb'), buildNode('svc-a'), buildNode('svc-b')]
+    const edges = [buildEdge('lb', 'svc-a'), buildEdge('lb', 'svc-b')]
+
+    const laidOut = applyAutoLayout(nodes, edges)
+    const byId = new Map(laidOut.map((node) => [node.id, node]))
+
+    expect(byId.get('svc-a')?.position.x).toBe(byId.get('svc-b')?.position.x)
+    expect(byId.get('svc-a')?.position.y).not.toBe(byId.get('svc-b')?.position.y)
+  })
+
+  it('lays out nested child nodes relative to their parent container', () => {
+    const nodes = [
+      buildNode('vpc', 400, 200),
+      { ...buildNode('child-a'), parentNode: 'vpc', position: { x: 300, y: 300 } } as Node,
+      { ...buildNode('child-b'), parentNode: 'vpc', position: { x: 600, y: 300 } } as Node
+    ]
+    const edges = [buildEdge('child-a', 'child-b')]
+
+    const laidOut = applyAutoLayout(nodes, edges)
+    const byId = new Map(laidOut.map((node) => [node.id, node]))
+    const parentPosition = byId.get('vpc')?.position ?? { x: 0, y: 0 }
+
+    expect((byId.get('child-a')?.position.x ?? 0) >= 0).toBe(true)
+    expect((byId.get('child-b')?.position.x ?? 0) > (byId.get('child-a')?.position.x ?? 0)).toBe(
+      true
+    )
+    expect(parentPosition.x).toBeGreaterThanOrEqual(0)
+    expect(parentPosition.y).toBeGreaterThanOrEqual(0)
+  })
+})

--- a/src/renderer/src/utils/autoLayout.ts
+++ b/src/renderer/src/utils/autoLayout.ts
@@ -1,0 +1,214 @@
+import type { Edge, Node } from 'reactflow'
+
+const ROOT_GROUP = '__root__'
+const ROOT_MARGIN_X = 80
+const ROOT_MARGIN_Y = 80
+const CHILD_MARGIN_X = 40
+const CHILD_MARGIN_Y = 40
+const COLUMN_GAP = 200
+const ROW_GAP = 80
+const DEFAULT_NODE_WIDTH = 220
+const DEFAULT_NODE_HEIGHT = 140
+
+type GroupKey = string
+
+function getNodeWidth(node: Node): number {
+  return node.width ?? DEFAULT_NODE_WIDTH
+}
+
+function getNodeHeight(node: Node): number {
+  return node.height ?? DEFAULT_NODE_HEIGHT
+}
+
+function compareNodes(a: Node, b: Node): number {
+  if (a.position.y !== b.position.y) {
+    return a.position.y - b.position.y
+  }
+  if (a.position.x !== b.position.x) {
+    return a.position.x - b.position.x
+  }
+
+  const aLabel =
+    typeof (a.data as { label?: unknown } | undefined)?.label === 'string'
+      ? ((a.data as { label?: string }).label ?? '')
+      : ''
+  const bLabel =
+    typeof (b.data as { label?: unknown } | undefined)?.label === 'string'
+      ? ((b.data as { label?: string }).label ?? '')
+      : ''
+
+  return aLabel.localeCompare(bLabel) || a.id.localeCompare(b.id)
+}
+
+function buildLevels(nodes: Node[], edges: Edge[]): string[][] {
+  const nodeIds = new Set(nodes.map((node) => node.id))
+  const indegree = new Map<string, number>()
+  const outgoing = new Map<string, string[]>()
+  const incomingParents = new Map<string, string[]>()
+  const levelById = new Map<string, number>()
+
+  for (const node of nodes) {
+    indegree.set(node.id, 0)
+    outgoing.set(node.id, [])
+    incomingParents.set(node.id, [])
+    levelById.set(node.id, 0)
+  }
+
+  for (const edge of edges) {
+    if (!nodeIds.has(edge.source) || !nodeIds.has(edge.target) || edge.source === edge.target) {
+      continue
+    }
+
+    outgoing.get(edge.source)?.push(edge.target)
+    incomingParents.get(edge.target)?.push(edge.source)
+    indegree.set(edge.target, (indegree.get(edge.target) ?? 0) + 1)
+  }
+
+  const nodeById = new Map(nodes.map((node) => [node.id, node]))
+  const queue = nodes
+    .filter((node) => (indegree.get(node.id) ?? 0) === 0)
+    .sort(compareNodes)
+    .map((node) => node.id)
+
+  const visited = new Set<string>()
+
+  while (queue.length > 0) {
+    const currentId = queue.shift()
+    if (!currentId || visited.has(currentId)) {
+      continue
+    }
+    visited.add(currentId)
+
+    const currentLevel = levelById.get(currentId) ?? 0
+    for (const targetId of outgoing.get(currentId) ?? []) {
+      levelById.set(targetId, Math.max(levelById.get(targetId) ?? 0, currentLevel + 1))
+      indegree.set(targetId, (indegree.get(targetId) ?? 0) - 1)
+      if ((indegree.get(targetId) ?? 0) <= 0) {
+        queue.push(targetId)
+        queue.sort((leftId, rightId) =>
+          compareNodes(nodeById.get(leftId) as Node, nodeById.get(rightId) as Node)
+        )
+      }
+    }
+  }
+
+  if (visited.size !== nodes.length) {
+    let fallbackLevel = Math.max(0, ...Array.from(levelById.values()))
+    for (const node of [...nodes].sort(compareNodes)) {
+      if (visited.has(node.id)) {
+        continue
+      }
+      fallbackLevel += 1
+      levelById.set(node.id, fallbackLevel)
+    }
+  }
+
+  const levels = new Map<number, string[]>()
+  for (const node of nodes) {
+    const level = levelById.get(node.id) ?? 0
+    const bucket = levels.get(level)
+    if (bucket) {
+      bucket.push(node.id)
+    } else {
+      levels.set(level, [node.id])
+    }
+  }
+
+  const sortedLevels = [...levels.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([, ids], levelIndex, entries) => {
+      if (levelIndex === 0) {
+        return ids.sort((leftId, rightId) =>
+          compareNodes(nodeById.get(leftId) as Node, nodeById.get(rightId) as Node)
+        )
+      }
+
+      const previousIds = entries[levelIndex - 1]?.[1] ?? []
+      const previousIndex = new Map(previousIds.map((id, index) => [id, index]))
+      return ids.sort((leftId, rightId) => {
+        const leftParents = incomingParents.get(leftId) ?? []
+        const rightParents = incomingParents.get(rightId) ?? []
+
+        const leftScore =
+          leftParents.length > 0
+            ? leftParents.reduce((sum, id) => sum + (previousIndex.get(id) ?? 0), 0) /
+              leftParents.length
+            : Number.MAX_SAFE_INTEGER
+        const rightScore =
+          rightParents.length > 0
+            ? rightParents.reduce((sum, id) => sum + (previousIndex.get(id) ?? 0), 0) /
+              rightParents.length
+            : Number.MAX_SAFE_INTEGER
+
+        if (leftScore !== rightScore) {
+          return leftScore - rightScore
+        }
+
+        return compareNodes(nodeById.get(leftId) as Node, nodeById.get(rightId) as Node)
+      })
+    })
+
+  return sortedLevels
+}
+
+function layoutGroup(nodes: Node[], edges: Edge[], groupKey: GroupKey): Node[] {
+  if (nodes.length === 0) {
+    return nodes
+  }
+
+  const levels = buildLevels(nodes, edges)
+  const nodeById = new Map(nodes.map((node) => [node.id, node]))
+  const nextPositionById = new Map<string, { x: number; y: number }>()
+
+  let x = groupKey === ROOT_GROUP ? ROOT_MARGIN_X : CHILD_MARGIN_X
+
+  for (const level of levels) {
+    let y = groupKey === ROOT_GROUP ? ROOT_MARGIN_Y : CHILD_MARGIN_Y
+    let columnWidth = 0
+
+    for (const nodeId of level) {
+      const node = nodeById.get(nodeId)
+      if (!node) continue
+
+      nextPositionById.set(nodeId, { x, y })
+      columnWidth = Math.max(columnWidth, getNodeWidth(node))
+      y += getNodeHeight(node) + ROW_GAP
+    }
+
+    x += columnWidth + COLUMN_GAP
+  }
+
+  return nodes.map((node) => {
+    const nextPosition = nextPositionById.get(node.id)
+    return nextPosition ? { ...node, position: nextPosition } : node
+  })
+}
+
+export function applyAutoLayout(nodes: Node[], edges: Edge[]): Node[] {
+  const groups = new Map<GroupKey, Node[]>()
+
+  for (const node of nodes) {
+    const groupKey = node.parentNode ?? ROOT_GROUP
+    const bucket = groups.get(groupKey)
+    if (bucket) {
+      bucket.push(node)
+    } else {
+      groups.set(groupKey, [node])
+    }
+  }
+
+  const laidOutById = new Map<string, Node>()
+
+  for (const [groupKey, groupNodes] of groups.entries()) {
+    const groupNodeIds = new Set(groupNodes.map((node) => node.id))
+    const groupEdges = edges.filter(
+      (edge) => groupNodeIds.has(edge.source) && groupNodeIds.has(edge.target)
+    )
+
+    for (const node of layoutGroup(groupNodes, groupEdges, groupKey)) {
+      laidOutById.set(node.id, node)
+    }
+  }
+
+  return nodes.map((node) => laidOutById.get(node.id) ?? node)
+}


### PR DESCRIPTION
## What changed

This PR adds a basic auto-layout action for the canvas.

- adds an `Auto Layout` button in the header
- computes a left-to-right layered layout for topology nodes
- refits the viewport after layout
- adds focused tests for the layout utility

## Why

Building topologies manually quickly turns messy, especially while exploring different designs. This gives authors and learners a fast cleanup action without changing any simulation behavior.

## Impact

- improves canvas usability
- keeps the change isolated to renderer-side layout behavior
- does not change simulation or grading logic

## Validation

- `npm run typecheck`
- `npx vitest run src/renderer/src/utils/autoLayout.test.ts`
