### PR TITLE
feat: add minimum question mode loop

### DIFF
--- a/src/engine/worker/protocols.ts
+++ b/src/engine/worker/protocols.ts
@@ -1,12 +1,18 @@
 import type { TopologyJSON } from '../core/types'
 import type { EdgeFlowEvent } from '../core/events'
 import type { SimulationOutput, TimeSeriesSnapshot } from '../analysis/output'
+import type { AttemptGrade, QuestionPackage } from '../analysis/question'
 
 // ─── Inbound (main thread → worker) ──────────────────────────────────────────
 
 export interface RunMessage {
   type: 'run'
   payload: { topology: TopologyJSON }
+}
+
+export interface GradeMessage {
+  type: 'grade'
+  payload: { question: QuestionPackage; topology: TopologyJSON }
 }
 
 export interface PauseMessage {
@@ -28,6 +34,7 @@ export interface StepMessage {
 
 export type WorkerInboundMessage =
   | RunMessage
+  | GradeMessage
   | PauseMessage
   | ResumeMessage
   | StopMessage
@@ -60,9 +67,15 @@ export interface ErrorMessage {
   payload: { message: string; stack?: string }
 }
 
+export interface GradeCompleteMessage {
+  type: 'grade-complete'
+  payload: { grade: AttemptGrade }
+}
+
 export type WorkerOutboundMessage =
   | ProgressMessage
   | SnapshotMessage
   | EdgeFlowBatchMessage
   | CompleteMessage
+  | GradeCompleteMessage
   | ErrorMessage

--- a/src/engine/worker/simulation.worker.ts
+++ b/src/engine/worker/simulation.worker.ts
@@ -1,4 +1,5 @@
 import { SimulationEngine } from '../engine'
+import { gradeAttempt } from '../analysis/question'
 import type { EdgeFlowEvent } from '../core/events'
 import type { SimulationOutput, TimeSeriesSnapshot } from '../analysis/output'
 import type { RequestOutcomeRecord } from '../core/event-stream'
@@ -196,6 +197,26 @@ self.onmessage = (event: MessageEvent<WorkerInboundMessage>) => {
 
       // Kick off the chunked execution loop (async, doesn't block the thread)
       runChunked()
+      break
+    }
+
+    case 'grade': {
+      if (running) {
+        post({ type: 'error', payload: { message: 'Simulation already running.' } })
+        return
+      }
+
+      try {
+        const grade = gradeAttempt(
+          msg.payload.question,
+          msg.payload.topology,
+          (topology) => new SimulationEngine(topology).run()
+        )
+        post({ type: 'grade-complete', payload: { grade } })
+      } catch (err) {
+        const e = err as Error
+        post({ type: 'error', payload: { message: e.message, stack: e.stack } })
+      }
       break
     }
 

--- a/src/renderer/src/components/layout/WorkspaceLayout.tsx
+++ b/src/renderer/src/components/layout/WorkspaceLayout.tsx
@@ -9,14 +9,16 @@ import { useFlowPersistence } from '@renderer/hooks/useFlowPersistence'
 import { useConfirmDialog } from '@renderer/hooks/useConfirmDialog'
 import { useSimulation } from '@renderer/hooks/useSimulation'
 import { useTopologySerializer } from '@renderer/hooks/useTopologySerializer'
+import {
+  isQuestionLaunchContextMessage,
+  postQuestionHostMessage
+} from '@renderer/utils/questionHostMessaging'
 import { validateTopology } from '../../../../engine/validation/validator'
 import type { LatencyPercentiles } from '../../../../engine/metrics'
 import type { TimeSeriesSnapshot } from '../../../../engine/analysis/output'
+import type { AttemptState } from '../../../../engine/analysis/question'
 import type { ValidationError } from '../../../../engine/validation/validator'
-import {
-  hasWorkloadSourceConfig,
-  isSourceComponentData
-} from '../../../../engine/catalog/sourceNodeSemantics'
+import { hasWorkloadSourceConfig, isSourceComponentData } from '../../../../engine/catalog/sourceNodeSemantics'
 
 // Organisms
 import {
@@ -28,6 +30,7 @@ import { FlowCanvas } from '../canvas/FlowCanvas'
 import { Header } from './Header'
 import { SampleScenarioPicker } from '../samples/SampleScenarioPicker'
 import { SAMPLE_SCENARIOS, type SampleScenario } from '@renderer/config/sampleScenarios'
+import { DEFAULT_SCENARIO_STATE } from '@renderer/types/ui'
 
 // Atoms
 import { ResizeHandle } from '../ui/ResizeHandle'
@@ -127,6 +130,20 @@ function PanelFallback({ label }: { label: string }) {
       {label}
     </div>
   )
+}
+
+function buildDraftAttempt(questionId: string, topology: AttemptState['topology']): AttemptState {
+  const now = new Date().toISOString()
+
+  return {
+    attemptId: globalThis.crypto?.randomUUID?.() ?? `attempt-${Date.now()}`,
+    questionId,
+    topology,
+    status: 'DRAFT',
+    startedAt: now,
+    lastSavedAt: now,
+    testRunCount: 0
+  }
 }
 
 function roundNullable(value: number | null): number | null {
@@ -299,6 +316,8 @@ export const WorkspaceLayout = () => {
   const setSimulationMetrics = useStore((s) => s.setSimulationMetrics)
   const clearSimulationMetrics = useStore((s) => s.clearSimulationMetrics)
   const selectGraphElements = useStore((s) => s.selectGraphElements)
+  const setActiveQuestion = useStore((s) => s.setActiveQuestion)
+  const setAttemptState = useStore((s) => s.setAttemptState)
   const runInspectorPinned = useStore((s) => s.runInspectorPinned)
   const setRunInspectorPinned = useStore((s) => s.setRunInspectorPinned)
   const routingVisualization = useStore((s) => s.routingStrategyVisualization)
@@ -386,6 +405,67 @@ export const WorkspaceLayout = () => {
   // Simulation
   const sim = useSimulation()
   const { serialize } = useTopologySerializer()
+
+  useEffect(() => {
+    postQuestionHostMessage({ type: 'ns-simulator:ready' })
+  }, [])
+
+  useEffect(() => {
+    const onMessage = (event: MessageEvent<unknown>) => {
+      if (!isQuestionLaunchContextMessage(event.data)) {
+        return
+      }
+
+      const { questionPackage, priorAttempt } = event.data.payload
+
+      void (async () => {
+        const topologyToLoad = priorAttempt?.topology ?? questionPackage.scaffold.topology
+        const launchData =
+          topologyToLoad ??
+          ({
+            version: '2.0.0',
+            nodes: [],
+            edges: [],
+            scenario: DEFAULT_SCENARIO_STATE
+          } as const)
+
+        const loaded = await loadFromData(launchData, `${questionPackage.id}.json`)
+        if (!loaded) {
+          postQuestionHostMessage({
+            type: 'ns-simulator:error',
+            message: 'Could not load the question launch context into the simulator.'
+          })
+          return
+        }
+
+        sim.reset()
+        clearSimulationMetrics()
+        setShowResults(false)
+        setLastRunContext(null)
+        setRunIssues({ messages: [], tone: 'warning' })
+        setRoutingVisualization(null)
+        selectGraphElements({})
+        setIsRightOpen(false)
+        setLeftSidebarTab('question')
+        setIsLeftOpen(true)
+        setActiveQuestion(questionPackage)
+        setAttemptState(
+          priorAttempt ?? (topologyToLoad ? buildDraftAttempt(questionPackage.id, topologyToLoad) : null)
+        )
+      })()
+    }
+
+    window.addEventListener('message', onMessage)
+    return () => window.removeEventListener('message', onMessage)
+  }, [
+    clearSimulationMetrics,
+    loadFromData,
+    selectGraphElements,
+    setActiveQuestion,
+    setAttemptState,
+    setRoutingVisualization,
+    sim
+  ])
   const handleLoadScenario = useCallback(
     async (scenarioId: string) => {
       const sampleId = scenarioId.startsWith('sample:') ? scenarioId.slice('sample:'.length) : ''

--- a/src/renderer/src/components/library/LibrarySidebar.tsx
+++ b/src/renderer/src/components/library/LibrarySidebar.tsx
@@ -8,8 +8,7 @@ import {
 } from 'lucide-react'
 import { CATALOG_CONFIG } from '../../config/catalogConfig'
 import { SAMPLE_SCENARIOS } from '../../config/sampleScenarios'
-import { EmbeddedIframeQuestionPreview } from './EmbeddedIframeQuestion'
-import { parseEmbeddedIframeQuestion } from './embeddedIframeQuestionSchema'
+import { QuestionPanel } from '../question/QuestionPanel'
 import { LibraryItem } from './LibraryItem'
 
 type Filter = 'all' | 'common'
@@ -73,11 +72,6 @@ interface LibrarySidebarContentProps {
   onLoadScenario: (scenarioId: string) => Promise<void>
 }
 
-interface QuestionTextPanelProps {
-  questionText: string
-  onQuestionTextChange: (value: string) => void
-}
-
 interface ComponentLibraryPanelProps {
   query: string
   filter: Filter
@@ -139,39 +133,6 @@ export const LibraryActivityRail = memo(function LibraryActivityRail({
     </nav>
   )
 })
-
-function QuestionTextPanel({ questionText, onQuestionTextChange }: QuestionTextPanelProps) {
-  const embeddedQuestion = parseEmbeddedIframeQuestion(questionText)
-
-  return (
-    <>
-      <div className="p-4 pb-3 border-b border-nss-border shrink-0 space-y-1">
-        <h2 className="text-xs font-bold text-nss-muted uppercase tracking-widest">
-          Question Text
-        </h2>
-      </div>
-
-      <div className="flex-1 min-h-0 p-3">
-        <div className="h-full overflow-y-auto space-y-3">
-          <textarea
-            value={questionText}
-            onChange={(event) => onQuestionTextChange(event.target.value)}
-            placeholder="Paste or type the system design question here..."
-            className="min-h-[220px] w-full resize-y rounded-md border border-nss-border bg-nss-input-bg p-3 text-xs leading-relaxed text-nss-text placeholder:text-nss-muted outline-none focus:border-nss-primary"
-          />
-          {embeddedQuestion.error && (
-            <div className="rounded-md border border-nss-danger/30 bg-nss-danger/10 px-3 py-2 text-[11px] leading-relaxed text-nss-danger">
-              {embeddedQuestion.error}
-            </div>
-          )}
-          {embeddedQuestion.question && (
-            <EmbeddedIframeQuestionPreview question={embeddedQuestion.question} />
-          )}
-        </div>
-      </div>
-    </>
-  )
-}
 
 function ComponentLibraryPanel({
   query,
@@ -364,27 +325,30 @@ function ScenarioPanel({
 export function LibrarySidebarContent({ activeTab, onLoadScenario }: LibrarySidebarContentProps) {
   const [query, setQuery] = useState('')
   const [filter, setFilter] = useState<Filter>('all')
-  const [questionText, setQuestionText] = useState('')
   const [selectedScenarioId, setSelectedScenarioId] = useState('')
 
   return (
     <aside className="h-full w-full min-w-0 bg-nss-panel border-r border-nss-border flex flex-col transition-colors duration-200">
-      {activeTab === 'question' ? (
-        <QuestionTextPanel questionText={questionText} onQuestionTextChange={setQuestionText} />
-      ) : activeTab === 'scenarios' ? (
+      <div className={activeTab === 'question' ? 'flex h-full min-h-0 flex-col' : 'hidden'}>
+        <QuestionPanel />
+      </div>
+
+      <div className={activeTab === 'scenarios' ? 'flex h-full min-h-0 flex-col' : 'hidden'}>
         <ScenarioPanel
           selectedScenarioId={selectedScenarioId}
           onSelectScenario={setSelectedScenarioId}
           onLoadScenario={onLoadScenario}
         />
-      ) : (
+      </div>
+
+      <div className={activeTab === 'library' ? 'flex h-full min-h-0 flex-col' : 'hidden'}>
         <ComponentLibraryPanel
           query={query}
           filter={filter}
           onQueryChange={setQuery}
           onFilterChange={setFilter}
         />
-      )}
+      </div>
     </aside>
   )
 }

--- a/src/renderer/src/components/question/QuestionPanel.tsx
+++ b/src/renderer/src/components/question/QuestionPanel.tsx
@@ -1,0 +1,407 @@
+import { useEffect, useState } from 'react'
+import useStore from '@renderer/store/useStore'
+import { useTopologySerializer } from '@renderer/hooks/useTopologySerializer'
+import { useQuestionGrader } from '@renderer/hooks/useQuestionGrader'
+import { SAMPLE_QUESTION } from '@renderer/config/sampleQuestion'
+import { postQuestionHostMessage } from '@renderer/utils/questionHostMessaging'
+import type {
+  AttemptGrade,
+  AttemptState,
+  AttemptStatus,
+  QuestionPackage
+} from '../../../../engine/analysis/question'
+import type { TopologyJSON } from '../../../../engine/core/types'
+
+const SECTION_TITLE = 'text-[10px] font-bold uppercase tracking-widest text-nss-muted'
+
+type PendingRun = {
+  kind: 'dry-run' | 'submit'
+  topology: TopologyJSON
+}
+
+function buildAttemptId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `attempt-${Date.now()}`
+}
+
+function buildAttemptState({
+  current,
+  questionId,
+  topology,
+  status,
+  now
+}: {
+  current: AttemptState | null
+  questionId: string
+  topology: TopologyJSON
+  status: AttemptStatus
+  now: string
+}): AttemptState {
+  return {
+    attemptId: current?.attemptId ?? buildAttemptId(),
+    questionId,
+    topology,
+    status,
+    startedAt: current?.startedAt ?? now,
+    lastSavedAt: now,
+    submittedAt: current?.submittedAt,
+    testRunCount: current?.testRunCount ?? 0,
+    lastDryRun: current?.lastDryRun,
+    grade: current?.grade
+  }
+}
+
+function formatAttemptStatus(status: AttemptStatus | 'DRAFT'): string {
+  switch (status) {
+    case 'AUTOSAVED':
+      return 'Autosaved'
+    case 'SUBMITTED':
+      return 'Submitted'
+    case 'GRADING':
+      return 'Grading'
+    case 'GRADED':
+      return 'Graded'
+    case 'LOCKED':
+      return 'Locked'
+    default:
+      return 'Draft'
+  }
+}
+
+function attemptStatusClasses(status: AttemptStatus | 'DRAFT'): string {
+  switch (status) {
+    case 'GRADED':
+      return 'border-nss-success/25 bg-nss-success/10 text-nss-success'
+    case 'GRADING':
+      return 'border-nss-warning/25 bg-nss-warning/10 text-nss-warning'
+    case 'SUBMITTED':
+      return 'border-nss-primary/25 bg-nss-primary/10 text-nss-primary'
+    case 'LOCKED':
+      return 'border-nss-border bg-nss-surface text-nss-muted'
+    default:
+      return 'border-nss-border bg-nss-surface text-nss-text'
+  }
+}
+
+export const QuestionPanel = () => {
+  const activeQuestion = useStore((s) => s.activeQuestion)
+  const setActiveQuestion = useStore((s) => s.setActiveQuestion)
+  const attemptState = useStore((s) => s.attemptState)
+  const setAttemptState = useStore((s) => s.setAttemptState)
+  const { serialize } = useTopologySerializer()
+  const grader = useQuestionGrader()
+  const {
+    status: graderStatus,
+    grade: graderGrade,
+    error: graderError,
+    grade_: gradeQuestion,
+    reset: resetGrader
+  } = grader
+  const [serializeError, setSerializeError] = useState<string | null>(null)
+  const [pendingRun, setPendingRun] = useState<PendingRun | null>(null)
+
+  useEffect(() => {
+    resetGrader()
+    setSerializeError(null)
+    setPendingRun(null)
+  }, [activeQuestion?.id, resetGrader])
+
+  useEffect(() => {
+    if (!activeQuestion || !pendingRun) {
+      return
+    }
+
+    if (graderStatus === 'graded' && graderGrade) {
+      const now = new Date().toISOString()
+      const baseAttempt = buildAttemptState({
+        current: attemptState,
+        questionId: activeQuestion.id,
+        topology: pendingRun.topology,
+        status: 'GRADING',
+        now
+      })
+
+      if (pendingRun.kind === 'dry-run') {
+        setAttemptState({
+          ...baseAttempt,
+          status: 'DRAFT',
+          lastSavedAt: now,
+          testRunCount: baseAttempt.testRunCount + 1,
+          lastDryRun: {
+            timestamp: now,
+            grade: graderGrade
+          }
+        })
+      } else {
+        const completedAttempt: AttemptState = {
+          ...baseAttempt,
+          status: 'GRADED',
+          submittedAt: baseAttempt.submittedAt ?? now,
+          grade: {
+            gradedAt: now,
+            result: graderGrade
+          }
+        }
+
+        setAttemptState(completedAttempt)
+        postQuestionHostMessage({
+          type: 'ns-simulator:submit',
+          payload: {
+            contract: graderGrade.contract,
+            attemptState: completedAttempt
+          }
+        })
+      }
+
+      setPendingRun(null)
+      return
+    }
+
+    if (graderStatus === 'error') {
+      const now = new Date().toISOString()
+      if (attemptState) {
+        setAttemptState({
+          ...attemptState,
+          status: attemptState.grade ? 'GRADED' : 'DRAFT',
+          lastSavedAt: now
+        })
+      }
+      setPendingRun(null)
+    }
+  }, [activeQuestion, attemptState, graderGrade, graderStatus, pendingRun, setAttemptState])
+
+  if (!activeQuestion) {
+    return (
+      <section className="flex h-full min-h-0 flex-col">
+        <div className="border-b border-nss-border p-4 pb-3">
+          <h2 className="text-xs font-bold uppercase tracking-widest text-nss-muted">
+            Question Text
+          </h2>
+          <p className="mt-1 text-[11px] leading-relaxed text-nss-muted">
+            Load a question package to show the brief, run the minimum grading loop, and submit
+            from this sidebar.
+          </p>
+        </div>
+
+        <div className="flex flex-1 items-center p-3">
+          <div className="w-full rounded-lg border border-dashed border-nss-border bg-nss-surface p-4">
+            <p className="text-xs font-semibold text-nss-text">No question loaded</p>
+            <p className="mt-1 text-[11px] leading-relaxed text-nss-muted">
+              This tab now hosts the question brief, rubric checks, and Test/Submit flow.
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                setAttemptState(null)
+                setActiveQuestion(SAMPLE_QUESTION)
+              }}
+              className="mt-4 w-full rounded-md bg-nss-primary px-3 py-2 text-xs font-semibold text-white hover:bg-nss-primary-hover"
+            >
+              Load sample question
+            </button>
+          </div>
+        </div>
+      </section>
+    )
+  }
+
+  const runGrade = (question: QuestionPackage, kind: PendingRun['kind']) => {
+    const { topology, errors } = serialize()
+    if (!topology) {
+      setSerializeError(errors[0] ?? 'Could not serialize the current topology.')
+      return
+    }
+
+    const now = new Date().toISOString()
+    setSerializeError(null)
+    setAttemptState(
+      buildAttemptState({
+        current: attemptState,
+        questionId: activeQuestion.id,
+        topology,
+        status: 'GRADING',
+        now
+      })
+    )
+    setPendingRun({ kind, topology })
+    gradeQuestion(question, topology)
+  }
+
+  const onSubmit = () => runGrade(activeQuestion, 'submit')
+  const onTest = () =>
+    runGrade(
+      activeQuestion.suite.dryRunCase
+        ? {
+            ...activeQuestion,
+            suite: { ...activeQuestion.suite, cases: [activeQuestion.suite.dryRunCase] }
+          }
+        : activeQuestion,
+      'dry-run'
+    )
+
+  const currentStatus =
+    pendingRun?.kind || graderStatus === 'grading'
+      ? 'GRADING'
+      : (attemptState?.status ?? 'DRAFT')
+  const latestGrade: AttemptGrade | null =
+    graderGrade ?? attemptState?.grade?.result ?? attemptState?.lastDryRun?.grade ?? null
+  const contract = latestGrade?.contract
+  const hasDryRunCase = Boolean(activeQuestion.suite.dryRunCase)
+  const testRunCount = attemptState?.testRunCount ?? 0
+
+  return (
+    <section className="flex h-full min-h-0 flex-col text-nss-text">
+      <header className="border-b border-nss-border p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <h2 className="text-xs font-bold uppercase tracking-widest text-nss-muted">
+              Question Text
+            </h2>
+            <p className="mt-1 text-[10px] uppercase tracking-wide text-nss-primary">
+              {activeQuestion.type} · {activeQuestion.difficulty}
+            </p>
+            <h3 className="truncate text-sm font-semibold">{activeQuestion.title}</h3>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              resetGrader()
+              setPendingRun(null)
+              setAttemptState(null)
+              setActiveQuestion(null)
+            }}
+            className="shrink-0 text-nss-muted hover:text-nss-text"
+            aria-label="Close question"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <span
+            className={`rounded-full border px-2 py-0.5 text-[10px] font-bold uppercase ${attemptStatusClasses(
+              currentStatus
+            )}`}
+          >
+            {formatAttemptStatus(currentStatus)}
+          </span>
+          <span className="text-[10px] uppercase tracking-wide text-nss-muted">
+            Test runs: {testRunCount}
+          </span>
+          {attemptState?.submittedAt && (
+            <span className="text-[10px] uppercase tracking-wide text-nss-muted">
+              Submitted {new Date(attemptState.submittedAt).toLocaleDateString()}
+            </span>
+          )}
+        </div>
+      </header>
+
+      <div className="flex-1 space-y-5 overflow-y-auto custom-scrollbar p-4">
+        <p className="text-xs leading-relaxed text-nss-text/90">{activeQuestion.prompt.text}</p>
+
+        {activeQuestion.prompt.functionalRequirements.length > 0 && (
+          <section className="space-y-2">
+            <h3 className={SECTION_TITLE}>Functional Requirements</h3>
+            <ul className="list-disc space-y-1 pl-4 text-xs text-nss-muted">
+              {activeQuestion.prompt.functionalRequirements.map((fr) => (
+                <li key={fr}>{fr}</li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {activeQuestion.prompt.nonFunctionalRequirements.length > 0 && (
+          <section className="space-y-2">
+            <h3 className={SECTION_TITLE}>Non-Functional Targets</h3>
+            <div className="space-y-1">
+              {activeQuestion.prompt.nonFunctionalRequirements.map((nfr) => (
+                <div key={nfr.metric} className="flex items-center justify-between gap-3 text-xs">
+                  <span className="text-nss-muted">{nfr.description}</span>
+                  <span className="shrink-0 font-semibold tabular-nums">
+                    {nfr.operator} {nfr.value}
+                    {nfr.unit === 'percent' ? '%' : nfr.unit === 'ms' ? 'ms' : ''}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        <section className="space-y-2">
+          <h3 className={SECTION_TITLE}>Scale</h3>
+          <div className="grid grid-cols-2 gap-2 text-xs">
+            {activeQuestion.prompt.scale.peakRps !== undefined && (
+              <div className="rounded border border-nss-border bg-nss-surface px-2 py-1.5">
+                <div className="text-nss-muted">Peak RPS</div>
+                <div className="font-semibold tabular-nums">
+                  {activeQuestion.prompt.scale.peakRps}
+                </div>
+              </div>
+            )}
+            {activeQuestion.prompt.scale.readWriteRatio !== undefined && (
+              <div className="rounded border border-nss-border bg-nss-surface px-2 py-1.5">
+                <div className="text-nss-muted">Read / Write</div>
+                <div className="font-semibold tabular-nums">
+                  {activeQuestion.prompt.scale.readWriteRatio}:
+                  {100 - activeQuestion.prompt.scale.readWriteRatio}
+                </div>
+              </div>
+            )}
+          </div>
+        </section>
+
+        {serializeError && <p className="text-xs text-nss-danger">{serializeError}</p>}
+        {graderError && <p className="text-xs text-nss-danger">Grading error: {graderError}</p>}
+
+        {contract && (
+          <section className="space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <h3 className={SECTION_TITLE}>Result</h3>
+              <span
+                className={`rounded px-2 py-0.5 text-[10px] font-bold uppercase ${
+                  contract.allPassed
+                    ? 'bg-nss-success/15 text-nss-success'
+                    : 'bg-nss-danger/15 text-nss-danger'
+                }`}
+              >
+                {contract.allPassed ? 'Passed' : 'Failed'} · {contract.passedTests}/
+                {contract.totalTests}
+              </span>
+            </div>
+            <div className="space-y-1">
+              {contract.tests.map((test) => (
+                <div key={test.id} className="flex items-center gap-2 text-xs">
+                  <span className={test.passed ? 'text-nss-success' : 'text-nss-danger'}>
+                    {test.passed ? '✓' : '✗'}
+                  </span>
+                  <span className="text-nss-muted">{test.name}</span>
+                  <span className="ml-auto text-[10px] text-nss-muted/70">
+                    {test.id.split(':')[0]}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+
+      <footer className="flex gap-2 border-t border-nss-border p-4">
+        <button
+          type="button"
+          onClick={onTest}
+          disabled={graderStatus === 'grading'}
+          className="flex-1 rounded-md border border-nss-border bg-nss-surface px-3 py-2 text-xs font-semibold text-nss-text hover:bg-nss-bg disabled:opacity-50"
+        >
+          {graderStatus === 'grading' ? 'Grading…' : hasDryRunCase ? 'Test (dry run)' : 'Test'}
+        </button>
+        <button
+          type="button"
+          onClick={onSubmit}
+          disabled={graderStatus === 'grading'}
+          className="flex-1 rounded-md bg-nss-primary px-3 py-2 text-xs font-semibold text-white hover:bg-nss-primary-hover disabled:opacity-50"
+        >
+          {graderStatus === 'grading' ? 'Grading…' : 'Submit'}
+        </button>
+      </footer>
+    </section>
+  )
+}

--- a/src/renderer/src/config/sampleQuestion.ts
+++ b/src/renderer/src/config/sampleQuestion.ts
@@ -1,0 +1,85 @@
+import type { QuestionPackage } from '../../../engine/analysis/question'
+
+export const SAMPLE_QUESTION: QuestionPackage = {
+  version: '1.0',
+  id: 'order-platform-open-build',
+  title: 'Design an order-processing platform',
+  difficulty: 'intermediate',
+  type: 'open-build',
+  prompt: {
+    text: 'Design the backend for an e-commerce order platform. It must stay responsive and low-error under both steady and peak load. Build your topology on the canvas, then Submit.',
+    functionalRequirements: [
+      'Accept order-create requests',
+      'Look up catalog and inventory',
+      'Persist orders durably'
+    ],
+    nonFunctionalRequirements: [
+      {
+        metric: 'error_rate',
+        operator: '<',
+        value: 10,
+        unit: 'percent',
+        description: 'Error rate under 10%'
+      },
+      {
+        metric: 'throughput',
+        operator: '>=',
+        value: 100,
+        unit: 'req_per_sec',
+        description: 'Sustains at least 100 req/s'
+      }
+    ],
+    scale: { peakRps: 1000, readWriteRatio: 80 }
+  },
+  scaffold: { type: 'empty' },
+  constraints: { canModifyScaffold: true, canRemoveScaffoldNodes: true },
+  suite: {
+    name: 'order-platform-grading',
+    visibleToStudent: false,
+    cases: [
+      { id: 'baseline', description: 'Steady-state load.' },
+      {
+        id: 'peak-load',
+        description: 'Peak surge on a fresh seed.',
+        global: { seed: 'order-platform-peak-1' },
+        workload: { baseRps: 1000 }
+      }
+    ],
+    dryRunCase: { id: 'dry-run', description: 'Quick learner-side dry run.', workload: { baseRps: 200 } }
+  },
+  rubric: {
+    id: 'order-platform-slo',
+    passThreshold: 1,
+    checks: [
+      {
+        id: 'error-rate',
+        description: 'Error rate under 10%',
+        metric: 'summary.errorRate',
+        op: '<',
+        value: 0.1,
+        points: 2
+      },
+      {
+        id: 'throughput',
+        description: 'Sustains at least 100 req/s',
+        metric: 'summary.throughput',
+        op: '>=',
+        value: 100
+      },
+      {
+        id: 'no-invariant-violations',
+        description: 'No invariant violations',
+        metric: 'invariantViolations.count',
+        op: '==',
+        value: 0
+      },
+      {
+        id: 'node-saturation',
+        description: 'No node pinned at full saturation',
+        metric: 'perNode.maxUtilization',
+        op: '<',
+        value: 1
+      }
+    ]
+  }
+}

--- a/src/renderer/src/hooks/useQuestionGrader.ts
+++ b/src/renderer/src/hooks/useQuestionGrader.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { TopologyJSON } from '../../../engine/core/types'
+import type { AttemptGrade, QuestionPackage } from '../../../engine/analysis/question'
+import type { WorkerInboundMessage, WorkerOutboundMessage } from '../../../engine/worker/protocols'
+
+export type GraderStatus = 'idle' | 'grading' | 'graded' | 'error'
+
+export interface QuestionGraderState {
+  status: GraderStatus
+  grade: AttemptGrade | null
+  error: string | null
+  grade_: (question: QuestionPackage, topology: TopologyJSON) => void
+  reset: () => void
+}
+
+export function useQuestionGrader(): QuestionGraderState {
+  const [status, setStatus] = useState<GraderStatus>('idle')
+  const [grade, setGrade] = useState<AttemptGrade | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const workerRef = useRef<Worker | null>(null)
+
+  useEffect(() => {
+    return () => {
+      workerRef.current?.terminate()
+    }
+  }, [])
+
+  const gradeAttempt = useCallback((question: QuestionPackage, topology: TopologyJSON) => {
+    workerRef.current?.terminate()
+    const worker = new Worker(
+      new URL('../../../engine/worker/simulation.worker.ts', import.meta.url),
+      { type: 'module' }
+    )
+    workerRef.current = worker
+
+    worker.onmessage = (event: MessageEvent<WorkerOutboundMessage>) => {
+      const msg = event.data
+      if (msg.type === 'grade-complete') {
+        setGrade(msg.payload.grade)
+        setStatus('graded')
+        worker.terminate()
+        workerRef.current = null
+      } else if (msg.type === 'error') {
+        setError(msg.payload.message)
+        setStatus('error')
+        worker.terminate()
+        workerRef.current = null
+      }
+    }
+
+    worker.onerror = (err) => {
+      setError(err.message ?? 'Unknown grader error')
+      setStatus('error')
+      worker.terminate()
+      workerRef.current = null
+    }
+
+    setStatus('grading')
+    setGrade(null)
+    setError(null)
+    worker.postMessage({
+      type: 'grade',
+      payload: { question, topology }
+    } satisfies WorkerInboundMessage)
+  }, [])
+
+  const reset = useCallback(() => {
+    workerRef.current?.terminate()
+    workerRef.current = null
+    setStatus('idle')
+    setGrade(null)
+    setError(null)
+  }, [])
+
+  return { status, grade, error, grade_: gradeAttempt, reset }
+}

--- a/src/renderer/src/store/useStore.ts
+++ b/src/renderer/src/store/useStore.ts
@@ -22,6 +22,7 @@ import type {
 import { DEFAULT_SCENARIO_STATE } from '@renderer/types/ui'
 import type { EdgeFailureCause, EdgeFlowEvent } from '../../../engine/core/events'
 import type { WorkloadProfile } from '../../../engine/core/types'
+import type { AttemptState, QuestionPackage } from '../../../engine/analysis/question'
 import type { RoutingStrategy } from '../../../engine/catalog/nodeSpecTypes'
 
 type FailureCountsByCause = Partial<Record<EdgeFailureCause, number>>
@@ -261,6 +262,12 @@ type RFState = {
   isUnsaved: boolean
   scenario: ScenarioState
 
+  // --- Question mode ---
+  activeQuestion: QuestionPackage | null
+  setActiveQuestion: (question: QuestionPackage | null) => void
+  attemptState: AttemptState | null
+  setAttemptState: (attempt: AttemptState | null) => void
+
   // --- Actions ---
   onNodesChange: OnNodesChange
   onEdgesChange: OnEdgesChange
@@ -311,6 +318,8 @@ const useStore = create<RFState>((set, get) => ({
   fileName: 'Untitled',
   isUnsaved: false,
   scenario: DEFAULT_SCENARIO_STATE,
+  activeQuestion: null,
+  attemptState: null,
 
   onNodesChange: (changes: NodeChange[]) => {
     set({
@@ -569,6 +578,8 @@ const useStore = create<RFState>((set, get) => ({
   setFileName: (fileName) => set({ fileName }),
   setUnsaved: (isUnsaved) => set({ isUnsaved }),
   setScenario: (scenario) => set({ scenario }),
+  setActiveQuestion: (activeQuestion) => set({ activeQuestion }),
+  setAttemptState: (attemptState) => set({ attemptState }),
   updateScenario: (updater) => set((state) => ({ scenario: updater(state.scenario) }))
 }))
 

--- a/src/renderer/src/utils/questionHostMessaging.ts
+++ b/src/renderer/src/utils/questionHostMessaging.ts
@@ -1,0 +1,83 @@
+import type {
+  AttemptState,
+  HostContract,
+  QuestionPackage
+} from '../../../engine/analysis/question'
+
+export interface QuestionLaunchContextPayload {
+  questionPackage: QuestionPackage
+  priorAttempt?: AttemptState
+  environmentProfile?: unknown
+}
+
+export interface QuestionLaunchContextMessage {
+  type: 'ns-simulator:launch-context'
+  payload: QuestionLaunchContextPayload
+}
+
+export interface QuestionReadyMessage {
+  type: 'ns-simulator:ready'
+}
+
+export interface QuestionSubmitMessage {
+  type: 'ns-simulator:submit'
+  payload: {
+    contract: HostContract
+    attemptState: AttemptState
+  }
+}
+
+export interface QuestionErrorMessage {
+  type: 'ns-simulator:error'
+  message: string
+}
+
+export type QuestionHostInboundMessage = QuestionLaunchContextMessage
+export type QuestionHostOutboundMessage =
+  | QuestionReadyMessage
+  | QuestionSubmitMessage
+  | QuestionErrorMessage
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isQuestionPackage(value: unknown): value is QuestionPackage {
+  return (
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    typeof value.title === 'string' &&
+    typeof value.type === 'string' &&
+    isRecord(value.prompt) &&
+    isRecord(value.scaffold) &&
+    isRecord(value.constraints) &&
+    isRecord(value.suite) &&
+    isRecord(value.rubric)
+  )
+}
+
+function getHostTargetOrigin(): string {
+  try {
+    return document.referrer ? new URL(document.referrer).origin : '*'
+  } catch {
+    return '*'
+  }
+}
+
+export function isQuestionLaunchContextMessage(
+  value: unknown
+): value is QuestionLaunchContextMessage {
+  if (!isRecord(value) || value.type !== 'ns-simulator:launch-context' || !isRecord(value.payload)) {
+    return false
+  }
+
+  return isQuestionPackage(value.payload.questionPackage)
+}
+
+export function postQuestionHostMessage(message: QuestionHostOutboundMessage): void {
+  if (window.parent === window) {
+    return
+  }
+
+  window.parent.postMessage(message, getHostTargetOrigin())
+}


### PR DESCRIPTION
## What changed

This PR adds the minimum question-mode loop in the simulator UI.

- moves the question experience into the left sidebar `Question Text` tab
- adds host messaging for `launch-context`, `ready`, and `submit`
- adds worker support for off-thread question grading
- adds renderer question state for active question and attempt state
- adds a sample question and a local question panel flow for `Test` and `Submit`

## Why

The current engine branch already introduces the question-analysis foundation. This stacked PR adds the first UI loop on top of that foundation so the simulator can be embedded in a host and used as a question runtime.

## Review notes

- this PR is intentionally based on `feat/add-workload-source-configuration-and-verdict-handling-in-simulation-engine`
- it is still the minimum loop only
- environment gating, scaffold locks, palette allowlists, autosave, and curated results are follow-up work

## Validation

- `npm run typecheck`
