### PR TITLE
feat(engine): implement justification grading, budget evaluation, and authoring validation

### DIFF
--- a/src/engine/analysis/authoringValidator.test.ts
+++ b/src/engine/analysis/authoringValidator.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import type { ComponentType } from '../core/types'
+import type { QuestionPackage } from './question'
+import { isAuthoredValid, validateAuthoredQuestion } from './authoringValidator'
+
+function base(): QuestionPackage {
+  return {
+    version: '1.0',
+    id: 'q',
+    title: 'q',
+    difficulty: 'intermediate',
+    type: 'open-build',
+    prompt: {
+      text: 't',
+      functionalRequirements: [],
+      nonFunctionalRequirements: [
+        { metric: 'latency_p99', operator: '<', value: 100, unit: 'ms', description: 'p99 < 100ms' }
+      ],
+      scale: { peakRps: 2000, readWriteRatio: 99 }
+    },
+    scaffold: { type: 'empty' },
+    constraints: { canModifyScaffold: true, canRemoveScaffoldNodes: true },
+    suite: {
+      name: 's',
+      visibleToStudent: false,
+      cases: [
+        {
+          id: 'peak',
+          workload: {
+            baseRps: 2000,
+            requestDistribution: [
+              { type: 'read', weight: 0.99, sizeBytes: 256 },
+              { type: 'write', weight: 0.01, sizeBytes: 512 }
+            ]
+          }
+        }
+      ]
+    },
+    rubric: {
+      checks: [
+        {
+          id: 'p99',
+          kind: 'simulation',
+          description: 'p99',
+          metric: 'summary.latency.p99',
+          op: '<',
+          value: 100,
+          points: 3
+        }
+      ]
+    }
+  }
+}
+
+const codes = (pkg: QuestionPackage) => validateAuthoredQuestion(pkg).map((d) => d.code)
+
+describe('validateAuthoredQuestion', () => {
+  it('passes a correctly authored question with no diagnostics', () => {
+    const d = validateAuthoredQuestion(base())
+    expect(d).toEqual([])
+    expect(isAuthoredValid(d)).toBe(true)
+  })
+
+  it('errors on the classic bad latency metric key', () => {
+    const pkg = base()
+    pkg.rubric.checks[0].metric = 'summary.latencyP99Ms'
+    const d = validateAuthoredQuestion(pkg)
+    expect(d.some((x) => x.code === 'metric.badLatencyKey' && x.level === 'error')).toBe(true)
+    expect(isAuthoredValid(d)).toBe(false)
+  })
+
+  it('warns when readWriteRatio is set but not injected as typed traffic', () => {
+    const pkg = base()
+    pkg.suite.cases[0].workload = { baseRps: 2000 } // no requestDistribution
+    expect(codes(pkg)).toContain('scale.mixNotInjected')
+  })
+
+  it('warns when peakRps is set but no case injects baseRps', () => {
+    const pkg = base()
+    pkg.suite.cases[0].workload = {
+      requestDistribution: [
+        { type: 'read', weight: 0.99, sizeBytes: 1 },
+        { type: 'write', weight: 0.01, sizeBytes: 1 }
+      ]
+    }
+    expect(codes(pkg)).toContain('scale.rpsNotInjected')
+  })
+
+  it('warns on a requestDistribution entry missing sizeBytes', () => {
+    const pkg = base()
+    pkg.suite.cases[0].workload!.requestDistribution = [
+      { type: 'read', weight: 1 } as unknown as { type: string; weight: number; sizeBytes: number }
+    ]
+    expect(codes(pkg)).toContain('workload.missingSizeBytes')
+  })
+
+  it('warns on an orphan NFR with no matching rubric check', () => {
+    const pkg = base()
+    pkg.prompt.nonFunctionalRequirements = [
+      {
+        metric: 'throughput',
+        operator: '>=',
+        value: 1000,
+        unit: 'req_per_sec',
+        description: 'thru'
+      }
+    ]
+    // rubric only checks latency → throughput NFR is orphaned
+    expect(codes(pkg)).toContain('nfr.orphan')
+  })
+
+  it('flags a correctness-heavy question that leans on a simulation perf check', () => {
+    const pkg = base()
+    pkg.workloadCategory = 'correctness-heavy'
+    expect(codes(pkg)).toContain('correctness.simulationCheck')
+  })
+
+  it('errors on a dangling forbidUnjustified.justifyId', () => {
+    const pkg = base()
+    pkg.semanticCriteria = [
+      {
+        id: 'no-cdn',
+        kind: 'forbidUnjustified',
+        componentType: 'cdn' as ComponentType,
+        justifyId: 'missing',
+        points: 2
+      }
+    ]
+    const d = validateAuthoredQuestion(pkg)
+    expect(d.some((x) => x.code === 'justify.dangling' && x.level === 'error')).toBe(true)
+  })
+
+  it('warns on a guardedPath with a destination under a read/write mix', () => {
+    const pkg = base()
+    pkg.semanticCriteria = [
+      {
+        id: 'g',
+        kind: 'guardedPath',
+        from: 'microservice' as ComponentType,
+        guard: 'in-memory-cache' as ComponentType,
+        to: 'kv-store' as ComponentType,
+        points: 3
+      }
+    ]
+    expect(codes(pkg)).toContain('guardedPath.readWriteMix')
+  })
+
+  it('errors when the grading suite is empty', () => {
+    const pkg = base()
+    pkg.suite.cases = []
+    const d = validateAuthoredQuestion(pkg)
+    expect(d.some((x) => x.code === 'suite.empty' && x.level === 'error')).toBe(true)
+  })
+})

--- a/src/engine/analysis/authoringValidator.ts
+++ b/src/engine/analysis/authoringValidator.ts
@@ -1,0 +1,293 @@
+/**
+ * Authoring validator (Phase 1) — the "is this question authored correctly?" gate.
+ *
+ * `parseQuestionPackage` checks the *schema*; this checks the *authoring
+ * contract* (question-simulation-alignment.md §10): does the question actually
+ * grade what its prompt claims? It is a pure function of the `QuestionPackage`,
+ * run at author time (Django admin `clean()` / CI), NOT at grade time. It catches
+ * the exact mistakes the bank validation surfaced — wrong metric keys, scale
+ * numbers that are printed but never injected, orphan NFRs, correctness questions
+ * leaning on the simulation, dangling justify bindings, and missing `sizeBytes`.
+ *
+ * `error` diagnostics should block a save; `warning`s are advisory.
+ */
+import type { QuestionPackage } from './question'
+import { inferRubricCheckKind } from './rubric'
+
+export type AuthoringLevel = 'error' | 'warning'
+
+export interface AuthoringDiagnostic {
+  level: AuthoringLevel
+  code: string
+  message: string
+  path?: string
+}
+
+/** Known-good verdict metric leaves for `simulation` checks. */
+const SIMULATION_METRICS = new Set<string>([
+  'summary.latency.p50',
+  'summary.latency.p90',
+  'summary.latency.p95',
+  'summary.latency.p99',
+  'summary.latency.min',
+  'summary.latency.max',
+  'summary.latency.mean',
+  'summary.errorRate',
+  'summary.throughput',
+  'summary.totalRequests',
+  'summary.successfulRequests',
+  'summary.failedRequests',
+  'perNode.maxUtilization',
+  'perNode.maxErrorRate',
+  'perNode.maxLatencyP99'
+])
+
+/** Known-good invariant metric keys. */
+const INVARIANT_METRICS = new Set<string>([
+  'invariantViolations.count',
+  'sloBreaches.count',
+  'conservation.unbalanced',
+  'littlesLaw.violations'
+])
+
+/** NFR `metric` enum → the verdict metric a rubric check should use. */
+const NFR_TO_VERDICT: Record<string, string> = {
+  latency_p99: 'summary.latency.p99',
+  latency_p50: 'summary.latency.p50',
+  error_rate: 'summary.errorRate',
+  throughput: 'summary.throughput'
+  // `availability` has no direct verdict metric (≈ 1 - errorRate) — handled below.
+}
+
+function err(code: string, message: string, path?: string): AuthoringDiagnostic {
+  return { level: 'error', code, message, ...(path ? { path } : {}) }
+}
+function warn(code: string, message: string, path?: string): AuthoringDiagnostic {
+  return { level: 'warning', code, message, ...(path ? { path } : {}) }
+}
+
+function validateMetric(
+  metric: string,
+  kind: ReturnType<typeof inferRubricCheckKind>,
+  path: string,
+  out: AuthoringDiagnostic[]
+): void {
+  // The single most common mistake (bank finding): a made-up latency key.
+  if (metric !== 'summary.latency.p99' && /latencyp99ms|latency_p99|p99ms/i.test(metric)) {
+    out.push(
+      err('metric.badLatencyKey', `"${metric}" does not resolve — use "summary.latency.p99".`, path)
+    )
+    return
+  }
+
+  if (kind === 'topology') {
+    if (!metric.startsWith('topology.')) {
+      out.push(
+        err(
+          'metric.kindMismatch',
+          `topology check must use a "topology.*" metric, got "${metric}".`,
+          path
+        )
+      )
+    }
+    return
+  }
+  if (kind === 'invariant') {
+    if (
+      !INVARIANT_METRICS.has(metric) &&
+      !/^(invariantViolations|conservation|littlesLaw)\./.test(metric)
+    ) {
+      out.push(
+        warn('metric.unknownInvariant', `"${metric}" is not a recognized invariant metric.`, path)
+      )
+    }
+    return
+  }
+  // simulation
+  if (metric.startsWith('topology.')) {
+    out.push(
+      err(
+        'metric.kindMismatch',
+        `simulation check uses a topology metric "${metric}" — set kind:"topology" or use a verdict metric.`,
+        path
+      )
+    )
+    return
+  }
+  if (SIMULATION_METRICS.has(metric)) {
+    return
+  }
+  if (metric.startsWith('summary.') || metric.startsWith('perNode.')) {
+    out.push(
+      warn(
+        'metric.uncommon',
+        `"${metric}" is an uncommon verdict path — verify it resolves (see the known metric list).`,
+        path
+      )
+    )
+    return
+  }
+  out.push(
+    warn(
+      'metric.unrecognized',
+      `"${metric}" is not a recognized metric key — verify it resolves against the verdict.`,
+      path
+    )
+  )
+}
+
+/**
+ * Validates a QuestionPackage against the authoring contract. Returns diagnostics
+ * (empty ⇒ clean). Errors should block a save; warnings are advisory.
+ */
+export function validateAuthoredQuestion(pkg: QuestionPackage): AuthoringDiagnostic[] {
+  const out: AuthoringDiagnostic[] = []
+
+  // ── suite / rubric presence ────────────────────────────────────────────────
+  if (!pkg.suite || pkg.suite.cases.length === 0) {
+    out.push(err('suite.empty', 'The grading suite has no cases — nothing is run.', 'suite.cases'))
+  }
+  if (!pkg.rubric || pkg.rubric.checks.length === 0) {
+    out.push(
+      warn(
+        'rubric.empty',
+        'The rubric has no checks — the design is never scored on metrics.',
+        'rubric.checks'
+      )
+    )
+  }
+
+  // ── metric keys ────────────────────────────────────────────────────────────
+  const rubricMetrics = new Set<string>()
+  ;(pkg.rubric?.checks ?? []).forEach((check, i) => {
+    rubricMetrics.add(check.metric)
+    validateMetric(check.metric, inferRubricCheckKind(check), `rubric.checks[${i}].metric`, out)
+  })
+
+  // ── scale numbers must be injected, not just displayed ─────────────────────
+  const scale = pkg.prompt.scale ?? {}
+  const cases = pkg.suite?.cases ?? []
+  const anyBaseRps = cases.some((c) => typeof c.workload?.baseRps === 'number')
+  const typedDist = cases.find(
+    (c) =>
+      Array.isArray(c.workload?.requestDistribution) && c.workload!.requestDistribution!.length >= 1
+  )?.workload?.requestDistribution
+
+  if (typeof scale.peakRps === 'number' && !anyBaseRps) {
+    out.push(
+      warn(
+        'scale.rpsNotInjected',
+        'prompt.scale.peakRps is set but no suite case injects workload.baseRps — the load is display-only.',
+        'suite.cases'
+      )
+    )
+  }
+  if (typeof scale.readWriteRatio === 'number') {
+    const hasReadWrite =
+      Array.isArray(typedDist) &&
+      typedDist.some((d) => /read/i.test(d.type)) &&
+      typedDist.some((d) => /write/i.test(d.type))
+    if (!hasReadWrite) {
+      out.push(
+        warn(
+          'scale.mixNotInjected',
+          'prompt.scale.readWriteRatio is set but no suite case injects a typed read/write requestDistribution — the ratio is display-only and does not stress the design (alignment §3/§9).',
+          'suite.cases'
+        )
+      )
+    }
+  }
+
+  // ── requestDistribution entries need sizeBytes (bank finding #1) ────────────
+  cases.forEach((c, ci) => {
+    ;(c.workload?.requestDistribution ?? []).forEach((d, di) => {
+      if (typeof (d as { sizeBytes?: number }).sizeBytes !== 'number') {
+        out.push(
+          warn(
+            'workload.missingSizeBytes',
+            `requestDistribution entry "${d.type}" is missing sizeBytes — a merged topology requires it.`,
+            `suite.cases[${ci}].workload.requestDistribution[${di}]`
+          )
+        )
+      }
+    })
+  })
+
+  // ── orphan NFRs: each NFR should map to a rubric check ─────────────────────
+  ;(pkg.prompt.nonFunctionalRequirements ?? []).forEach((nfr, i) => {
+    if (nfr.metric === 'availability') {
+      if (!rubricMetrics.has('summary.errorRate')) {
+        out.push(
+          warn(
+            'nfr.orphan',
+            'availability NFR has no rubric check — availability ≈ 1 - errorRate; add a summary.errorRate check.',
+            `prompt.nonFunctionalRequirements[${i}]`
+          )
+        )
+      }
+      return
+    }
+    const expected = NFR_TO_VERDICT[nfr.metric]
+    if (expected && !rubricMetrics.has(expected)) {
+      out.push(
+        warn(
+          'nfr.orphan',
+          `NFR "${nfr.metric}" has no corresponding rubric check (expected a check on "${expected}").`,
+          `prompt.nonFunctionalRequirements[${i}]`
+        )
+      )
+    }
+  })
+
+  // ── performance-vs-correctness boundary (alignment §1) ─────────────────────
+  if (pkg.workloadCategory === 'correctness-heavy') {
+    const perfCheck = (pkg.rubric?.checks ?? []).find(
+      (c) => inferRubricCheckKind(c) === 'simulation' && /latency|throughput/i.test(c.metric)
+    )
+    if (perfCheck) {
+      out.push(
+        warn(
+          'correctness.simulationCheck',
+          `A correctness-heavy question has a simulation performance check ("${perfCheck.metric}") — the sim cannot measure correctness; grade it via structural/semantic + justification instead.`,
+          'rubric.checks'
+        )
+      )
+    }
+  }
+
+  // ── dangling justify bindings ──────────────────────────────────────────────
+  const justifyIds = new Set((pkg.justify ?? []).map((j) => j.id))
+  ;(pkg.semanticCriteria ?? []).forEach((c, i) => {
+    if (c.kind === 'forbidUnjustified' && c.justifyId && !justifyIds.has(c.justifyId)) {
+      out.push(
+        err(
+          'justify.dangling',
+          `forbidUnjustified references justifyId "${c.justifyId}" which is not defined in justify[].`,
+          `semanticCriteria[${i}].justifyId`
+        )
+      )
+    }
+  })
+
+  // ── guardedPath under a read/write mix (alignment §9) ──────────────────────
+  if (typeof scale.readWriteRatio === 'number') {
+    ;(pkg.semanticCriteria ?? []).forEach((c, i) => {
+      if (c.kind === 'guardedPath' && c.to) {
+        out.push(
+          warn(
+            'guardedPath.readWriteMix',
+            `guardedPath (${c.from}→${c.guard}→${c.to}) on a read/write-mix question can wrongly fail a correct design if writes legitimately bypass the guard — confirm this is an all-traffic guard, not a "reads-through-cache" rule (use the p99 simulation check for that).`,
+            `semanticCriteria[${i}]`
+          )
+        )
+      }
+    })
+  }
+
+  return out
+}
+
+/** Convenience: true when there are no `error`-level diagnostics. */
+export function isAuthoredValid(diagnostics: readonly AuthoringDiagnostic[]): boolean {
+  return !diagnostics.some((d) => d.level === 'error')
+}

--- a/src/engine/analysis/budget.test.ts
+++ b/src/engine/analysis/budget.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import type { ComponentNode, TopologyJSON } from '../core/types'
+import { estimateNodeCost, evaluateBudget } from './budget'
+
+function node(id: string, extra: Partial<ComponentNode> = {}): ComponentNode {
+  return {
+    id,
+    type: 'microservice',
+    category: 'compute',
+    label: id,
+    position: { x: 0, y: 0 },
+    ...extra
+  } as unknown as ComponentNode
+}
+
+function topo(nodes: ComponentNode[], edgeCount: number): TopologyJSON {
+  return {
+    id: 't',
+    name: 't',
+    version: '2.0.0',
+    nodes,
+    edges: Array.from({ length: edgeCount }, (_, i) => ({ id: `e${i}`, source: 'a', target: 'b' }))
+  } as unknown as TopologyJSON
+}
+
+describe('evaluateBudget', () => {
+  it('nodes unit: counts nodes vs cap', () => {
+    const t = topo([node('a'), node('b'), node('c')], 2)
+    expect(evaluateBudget(t, { unit: 'nodes', cap: 5 })).toMatchObject({
+      actual: 3,
+      withinBudget: true
+    })
+    const over = evaluateBudget(t, { unit: 'nodes', cap: 2 })
+    expect(over.withinBudget).toBe(false)
+    expect(over.detail).toMatch(/nodes budget exceeded: 3 > cap 2/)
+  })
+
+  it('edges unit: counts edges vs cap', () => {
+    const t = topo([node('a')], 4)
+    expect(evaluateBudget(t, { unit: 'edges', cap: 4 })).toMatchObject({
+      actual: 4,
+      withinBudget: true
+    })
+    expect(evaluateBudget(t, { unit: 'edges', cap: 3 }).withinBudget).toBe(false)
+  })
+
+  it('cost unit: penalizes over-provisioned capacity (replicas + workers)', () => {
+    const lean = estimateNodeCost(node('a')) // 1 base + 1 replica default + 0 workers = 2
+    const heavy = estimateNodeCost(
+      node('b', {
+        resources: { replicas: 10 },
+        queue: { workers: 500, capacity: 1, discipline: 'fifo' }
+      } as Partial<ComponentNode>)
+    )
+    expect(lean).toBe(2)
+    expect(heavy).toBeGreaterThan(lean) // 1 + 10 + ceil(500/50)=10 = 21
+    // a big over-provisioned design blows the cost cap; a lean one fits
+    const heavyTopo = topo(
+      [
+        node('b', {
+          resources: { replicas: 10 },
+          queue: { workers: 500, capacity: 1, discipline: 'fifo' }
+        } as Partial<ComponentNode>)
+      ],
+      0
+    )
+    expect(evaluateBudget(heavyTopo, { unit: 'cost', cap: 10 }).withinBudget).toBe(false)
+    expect(evaluateBudget(topo([node('a')], 0), { unit: 'cost', cap: 10 }).withinBudget).toBe(true)
+  })
+})

--- a/src/engine/analysis/budget.ts
+++ b/src/engine/analysis/budget.ts
@@ -1,0 +1,67 @@
+/**
+ * Budget evaluation — the anti-kitchen-sink `$` axis.
+ *
+ * Grades a topology against an authored `Budget` cap. Three units:
+ *   - `nodes` / `edges`: pure counts (the primary anti-kitchen-sink lever).
+ *   - `cost`: a **v1 heuristic** capacity cost — there is no real pricing model
+ *     yet, so cost is derived from provisioned capacity (a node's replicas +
+ *     workers) so that over-provisioning genuinely costs more. Documented as a
+ *     heuristic; swap in a real cost model later without changing the DSL.
+ *
+ * Pure and deterministic — mirrors `structural.ts` / `semanticCriteria.ts`.
+ */
+import type { ComponentNode, TopologyJSON } from '../core/types'
+import type { Budget } from './gradingCriteria'
+
+export const BUDGET_VERSION = '1.0' as const
+
+export interface BudgetEvaluation {
+  version: typeof BUDGET_VERSION
+  unit: Budget['unit']
+  cap: number
+  /** The topology's measured value in the budget's unit. */
+  actual: number
+  /** Whether `actual <= cap`. */
+  withinBudget: boolean
+  detail?: string
+}
+
+/** Per-edge cost weight in the `cost` heuristic. */
+const EDGE_COST = 1
+
+/**
+ * v1 capacity-cost heuristic for a single node: a base charge plus its
+ * provisioned replicas and a coarse charge per pool of workers. Penalizes
+ * over-provisioning (the anti-kitchen-sink intent) without a real price sheet.
+ */
+export function estimateNodeCost(node: ComponentNode): number {
+  const replicas = node.resources?.replicas ?? 1
+  const workers = node.queue?.workers ?? 0
+  return 1 + replicas + Math.ceil(workers / 50)
+}
+
+export function evaluateBudget(topology: TopologyJSON, budget: Budget): BudgetEvaluation {
+  const actual =
+    budget.unit === 'nodes'
+      ? topology.nodes.length
+      : budget.unit === 'edges'
+        ? topology.edges.length
+        : topology.nodes.reduce((sum, node) => sum + estimateNodeCost(node), 0) +
+          topology.edges.length * EDGE_COST
+
+  const withinBudget = actual <= budget.cap
+  return {
+    version: BUDGET_VERSION,
+    unit: budget.unit,
+    cap: budget.cap,
+    actual,
+    withinBudget,
+    ...(withinBudget
+      ? {}
+      : {
+          detail: `${budget.unit} budget exceeded: ${actual} > cap ${budget.cap}${
+            budget.unit === 'cost' ? ' (v1 capacity-cost heuristic)' : ''
+          }. Trim over-provisioned components.`
+        })
+  }
+}

--- a/src/engine/analysis/index.ts
+++ b/src/engine/analysis/index.ts
@@ -1,3 +1,5 @@
+export * from './authoringValidator'
+export * from './budget'
 export * from './evaluate'
 export * from './environmentProfile'
 export * from './evaluationContract'

--- a/src/engine/analysis/justification.test.ts
+++ b/src/engine/analysis/justification.test.ts
@@ -1,12 +1,44 @@
 import { describe, expect, it } from 'vitest'
-import type { ComponentType } from '../core/types'
+import type { ComponentType, TopologyJSON } from '../core/types'
 import type { JustifyPrompt } from './gradingCriteria'
 import {
+  buildJustificationContext,
   extractNumbers,
   gradeJustification,
   gradeJustifications,
   type JustificationContext
 } from './justification'
+
+describe('buildJustificationContext', () => {
+  const topology = {
+    nodes: [
+      { id: 'store-1', type: 'kv-store', label: 'Cassandra' },
+      { id: 'svc-1', type: 'microservice', label: 'API' }
+    ],
+    edges: []
+  } as unknown as TopologyJSON
+
+  it('resolves a bound type only when a node of that type exists', () => {
+    const ctx = buildJustificationContext(topology, [200000])
+    expect(ctx.resolveBoundType({ componentType: 'kv-store' as ComponentType })).toBe('kv-store')
+    expect(
+      ctx.resolveBoundType({ componentType: 'relational-db' as ComponentType })
+    ).toBeUndefined()
+    expect(ctx.resolveBoundType({ nodeId: 'svc-1' })).toBe('microservice')
+  })
+
+  it('derives aliases from the type token and the node label', () => {
+    const ctx = buildJustificationContext(topology, [])
+    const aliases = ctx.aliasesOf('kv-store' as ComponentType)
+    expect(aliases).toEqual(
+      expect.arrayContaining(['kv-store', 'kv store', 'kv', 'store', 'cassandra'])
+    )
+  })
+
+  it('carries the injected scale numbers through', () => {
+    expect(buildJustificationContext(topology, [200000, 99]).scaleNumbers).toEqual([200000, 99])
+  })
+})
 
 const prompt: JustifyPrompt = {
   id: 'why-db',

--- a/src/engine/analysis/justification.ts
+++ b/src/engine/analysis/justification.ts
@@ -17,7 +17,7 @@
  * `JustificationContext`, so this module is fully unit-testable with no DOM,
  * store, or catalog dependency.
  */
-import type { ComponentType } from '../core/types'
+import type { ComponentType, TopologyJSON } from '../core/types'
 import type { JustifyPrompt } from './gradingCriteria'
 
 export interface JustificationAnswer {
@@ -36,6 +36,41 @@ export interface JustificationContext {
   aliasesOf: (type: ComponentType) => readonly string[]
   /** The numbers this question defines (scale + NFR targets), for number-citation. */
   scaleNumbers: readonly number[]
+}
+
+/**
+ * Builds a `JustificationContext` from the student's topology + the question's
+ * scale numbers. Pure and dependency-light (no catalog import): aliases are
+ * derived from the component-type token plus any labels the student gave nodes of
+ * that type. Reused by the renderer (live feedback) and, later, by `gradeAttempt`.
+ */
+export function buildJustificationContext(
+  topology: TopologyJSON,
+  scaleNumbers: readonly number[]
+): JustificationContext {
+  return {
+    resolveBoundType: (boundTo) => {
+      if (boundTo?.nodeId) {
+        return topology.nodes.find((node) => node.id === boundTo.nodeId)?.type
+      }
+      if (boundTo?.componentType) {
+        return topology.nodes.some((node) => node.type === boundTo.componentType)
+          ? boundTo.componentType
+          : undefined
+      }
+      return undefined
+    },
+    aliasesOf: (type) => {
+      const aliases = new Set<string>([type, type.replace(/-/g, ' '), ...type.split('-')])
+      for (const node of topology.nodes) {
+        if (node.type === type && typeof node.label === 'string' && node.label.length > 0) {
+          aliases.add(node.label.toLowerCase())
+        }
+      }
+      return [...aliases].filter((a) => a.length > 0)
+    },
+    scaleNumbers
+  }
 }
 
 export type JustificationOutcome = 'passed' | 'partial' | 'failed' | 'missing'

--- a/src/engine/analysis/newtonGamePlayground.ts
+++ b/src/engine/analysis/newtonGamePlayground.ts
@@ -69,6 +69,8 @@ export interface NewtonSaveBlob {
   attemptState: AttemptState
   /** Advisory per-check detail for UI restore — never re-graded by the backend. */
   rubric_results: HostTest[]
+  /** The student's free-text justification answers, by prompt id (persisted for grading/audit). */
+  justification_answers?: Record<string, string>
   saved_at: string
 }
 
@@ -156,8 +158,10 @@ export function buildNewtonSaveBlob(
   questionPackage: QuestionPackage,
   attemptState: AttemptState,
   result: GamePlaygroundResult,
-  savedAt: string
+  savedAt: string,
+  justificationAnswers?: Record<string, string>
 ): NewtonSaveBlob {
+  const hasAnswers = justificationAnswers && Object.keys(justificationAnswers).length > 0
   return {
     version: NEWTON_SAVE_BLOB_VERSION,
     ...mapResultToNewtonScores(result),
@@ -165,6 +169,7 @@ export function buildNewtonSaveBlob(
     questionPackage,
     attemptState,
     rubric_results: result.tests.map((test) => ({ ...test })),
+    ...(hasAnswers ? { justification_answers: { ...justificationAnswers } } : {}),
     saved_at: savedAt
   }
 }

--- a/src/engine/analysis/question.test.ts
+++ b/src/engine/analysis/question.test.ts
@@ -527,3 +527,124 @@ describe('gradeAttempt — semantic criteria wiring', () => {
     expect(grade.semantic).toBeUndefined()
   })
 })
+
+describe('gradeAttempt — justification feeds forbidUnjustified', () => {
+  function cdnTopology(): TopologyJSON {
+    return {
+      id: 't',
+      name: 't',
+      version: '2.0.0',
+      global: { seed: 'base', simulationDuration: 1000, warmupDuration: 0 },
+      nodes: [
+        {
+          id: 'cdn',
+          type: 'cdn',
+          category: 'network-and-edge',
+          label: 'CDN',
+          position: { x: 0, y: 0 }
+        },
+        {
+          id: 'svc',
+          type: 'microservice',
+          category: 'compute',
+          label: 's',
+          position: { x: 0, y: 0 }
+        }
+      ],
+      edges: [{ id: 'e', source: 'cdn', target: 'svc' }]
+    } as unknown as TopologyJSON
+  }
+
+  const cdnPkg: QuestionPackage = {
+    ...pkg,
+    id: 'q-cdn',
+    prompt: { ...pkg.prompt, scale: { peakRps: 8000 } },
+    semanticCriteria: [
+      {
+        id: 'cdn-justified',
+        kind: 'forbidUnjustified',
+        componentType: 'cdn' as ComponentType,
+        justifyId: 'why-cdn',
+        points: 4
+      }
+    ],
+    justify: [
+      {
+        id: 'why-cdn',
+        decision: 'Why a CDN?',
+        boundTo: { componentType: 'cdn' as ComponentType },
+        requires: { choice: true, tradeoff: true }
+      }
+    ]
+  }
+
+  it('fails a present-but-undefended component (no justification answer)', () => {
+    const grade = gradeAttempt(cdnPkg, cdnTopology(), () => fakeOutput(0.02))
+    expect(grade.semantic?.results[0].outcome).toBe('failed')
+    expect(grade.justification?.[0].outcome).toBe('missing')
+  })
+
+  it('passes forbidUnjustified when a valid justification defends the component', () => {
+    const grade = gradeAttempt(cdnPkg, cdnTopology(), () => fakeOutput(0.02), [
+      {
+        promptId: 'why-cdn',
+        text: 'A CDN caches static assets at the edge, but we accept staleness.'
+      }
+    ])
+    expect(grade.justification?.[0].outcome).toBe('passed')
+    expect(grade.semantic?.results[0].outcome).toBe('passed')
+  })
+})
+
+describe('gradeAttempt — budget', () => {
+  function threeNodeTopo(): TopologyJSON {
+    return {
+      id: 't',
+      name: 't',
+      version: '2.0.0',
+      global: { seed: 'base', simulationDuration: 1000, warmupDuration: 0 },
+      nodes: [
+        {
+          id: 'a',
+          type: 'microservice',
+          category: 'compute',
+          label: 'a',
+          position: { x: 0, y: 0 }
+        },
+        {
+          id: 'b',
+          type: 'kv-store',
+          category: 'storage-and-data',
+          label: 'b',
+          position: { x: 0, y: 0 }
+        },
+        {
+          id: 'c',
+          type: 'load-balancer',
+          category: 'network-and-edge',
+          label: 'c',
+          position: { x: 0, y: 0 }
+        }
+      ],
+      edges: []
+    } as unknown as TopologyJSON
+  }
+
+  it('fails the budget row when node count exceeds the cap', () => {
+    const grade = gradeAttempt({ ...pkg, budget: { unit: 'nodes', cap: 2 } }, threeNodeTopo(), () =>
+      fakeOutput(0.02)
+    )
+    expect(grade.budget).toMatchObject({ unit: 'nodes', actual: 3, withinBudget: false })
+    const row = grade.contract.tests.find((t) => t.id === 'topology.budget')
+    expect(row?.passed).toBe(false)
+    expect(grade.contract.allPassed).toBe(false)
+  })
+
+  it('passes the budget row when within cap', () => {
+    const grade = gradeAttempt({ ...pkg, budget: { unit: 'nodes', cap: 5 } }, threeNodeTopo(), () =>
+      fakeOutput(0.02)
+    )
+    expect(grade.budget?.withinBudget).toBe(true)
+    expect(grade.contract.tests.find((t) => t.id === 'topology.budget')?.passed).toBe(true)
+  })
+})

--- a/src/engine/analysis/question.ts
+++ b/src/engine/analysis/question.ts
@@ -35,6 +35,13 @@ import {
   type SemanticContext,
   type SemanticEvaluation
 } from './semanticCriteria'
+import {
+  buildJustificationContext,
+  gradeJustification,
+  type JustificationAnswer,
+  type JustificationResult
+} from './justification'
+import { evaluateBudget, type BudgetEvaluation } from './budget'
 import { SIMULATION_VERDICT_VERSION, type SimulationVerdict } from './verdict'
 import {
   BudgetSchema,
@@ -220,6 +227,10 @@ export interface AttemptGrade {
   structural: StructuralEvaluation
   /** Semantic criteria — the topology-meaning axis (absent when none authored). */
   semantic?: SemanticEvaluation
+  /** Graph-consistent justification results (absent when no justify prompts). */
+  justification?: JustificationResult[]
+  /** Budget/cost evaluation — the anti-kitchen-sink axis (absent when no budget authored). */
+  budget?: BudgetEvaluation
   /** The full graded batch (rich data — stays inside the simulator). */
   graded: GradedEvaluationBatch
   /** The collapsed boolean contract sent across the iframe seam to the host. */
@@ -258,6 +269,28 @@ export function topologyRubricTestId(checkId: string): string {
 
 export function semanticTestId(criterionId: string): string {
   return `topology.semantic.${hostSafeToken(criterionId)}`
+}
+
+export function justifyTestId(promptId: string): string {
+  return `topology.justify.${hostSafeToken(promptId)}`
+}
+
+export function budgetTestId(): string {
+  return 'topology.budget'
+}
+
+/** Scale + NFR numbers a question defines, for justification number-citation. */
+function collectScaleNumbers(pkg: QuestionPackage): number[] {
+  const numbers: number[] = []
+  for (const value of Object.values(pkg.prompt.scale)) {
+    if (typeof value === 'number') {
+      numbers.push(value)
+    }
+  }
+  for (const nfr of pkg.prompt.nonFunctionalRequirements) {
+    numbers.push(nfr.value)
+  }
+  return numbers
 }
 
 export function caseRubricTestId(caseId: string, kind: CheckResultKind, checkId: string): string {
@@ -1172,10 +1205,51 @@ function flattenSemanticRows(semantic: SemanticEvaluation | undefined): AttemptC
   }))
 }
 
+function flattenJustificationRows(
+  justification: JustificationResult[] | undefined
+): AttemptCheckRow[] {
+  if (!justification) {
+    return []
+  }
+  return justification.map((result) => ({
+    id: justifyTestId(result.promptId),
+    name: `Justification: ${result.promptId}`,
+    scope: 'topology',
+    kind: 'topology',
+    // A missing/partial/failed justification is not a full pass in the collapse.
+    status: result.outcome === 'passed' ? 'passed' : 'failed',
+    passed: result.outcome === 'passed',
+    pointsEarned: 0,
+    pointsPossible: 0,
+    ...(result.detail ? { detail: result.detail } : {})
+  }))
+}
+
+function flattenBudgetRows(budget: BudgetEvaluation | undefined): AttemptCheckRow[] {
+  if (!budget) {
+    return []
+  }
+  return [
+    {
+      id: budgetTestId(),
+      name: `Budget: ${budget.actual} / ${budget.cap} ${budget.unit}`,
+      scope: 'budget',
+      kind: 'topology',
+      status: budget.withinBudget ? 'passed' : 'failed',
+      passed: budget.withinBudget,
+      pointsEarned: 0,
+      pointsPossible: 0,
+      ...(budget.detail ? { detail: budget.detail } : {})
+    }
+  ]
+}
+
 export function flattenAttemptCheckRows(grade: AttemptGrade): AttemptCheckRow[] {
   return [
     ...flattenStructuralRows(grade.structural),
     ...flattenSemanticRows(grade.semantic),
+    ...flattenJustificationRows(grade.justification),
+    ...flattenBudgetRows(grade.budget),
     ...flattenQuestionRubricRows(grade.graded.question),
     ...grade.graded.cases.flatMap((entry) => flattenCaseRubricRows(entry))
   ]
@@ -1189,11 +1263,15 @@ export function flattenAttemptCheckRows(grade: AttemptGrade): AttemptCheckRow[] 
 export function toHostContract(
   structural: StructuralEvaluation,
   graded: GradedEvaluationBatch,
-  semantic?: SemanticEvaluation
+  semantic?: SemanticEvaluation,
+  justification?: JustificationResult[],
+  budget?: BudgetEvaluation
 ): HostContract {
   const tests: HostTest[] = flattenAttemptCheckRows({
     structural,
     semantic,
+    ...(justification ? { justification } : {}),
+    ...(budget ? { budget } : {}),
     graded,
     contract: { tests: [], totalTests: 0, passedTests: 0, allPassed: false }
   }).map((row) => ({
@@ -1228,6 +1306,28 @@ export function buildQuestionTestRows(
       scope: 'topology',
       status: 'pending' as const
     })),
+    ...(pkg.semanticCriteria ?? []).map((criterion) => ({
+      id: semanticTestId(criterion.id),
+      name: criterion.description ?? criterion.id,
+      scope: 'design',
+      status: 'pending' as const
+    })),
+    ...(pkg.justify ?? []).map((prompt) => ({
+      id: justifyTestId(prompt.id),
+      name: `Justify: ${prompt.decision}`,
+      scope: 'justification',
+      status: 'pending' as const
+    })),
+    ...(pkg.budget
+      ? [
+          {
+            id: budgetTestId(),
+            name: `Budget: within ${pkg.budget.cap} ${pkg.budget.unit}`,
+            scope: 'budget',
+            status: 'pending' as const
+          }
+        ]
+      : []),
     ...pkg.rubric.checks
       .filter((check) => inferRubricCheckKind(check) === 'topology')
       .map((check) => ({
@@ -1262,8 +1362,9 @@ export function buildQuestionTestRows(
 
     return {
       id: gradedRow.id,
-      name: gradedRow.name,
-      scope: gradedRow.scope,
+      // Keep the authored label (more descriptive than the flattened graded name).
+      name: row.name,
+      scope: row.scope,
       status: normalizeQuestionRowStatus(gradedRow.status),
       ...(gradedRow.detail ? { detail: gradedRow.detail } : {})
     }
@@ -1368,10 +1469,28 @@ function evaluateSemanticCriteriaForPackage(
   return evaluateSemanticCriteria(studentTopology, pkg.semanticCriteria, ctx)
 }
 
+/**
+ * Grades the package's justify prompts against the student's answers, graph-
+ * consistently, or `undefined` when none are authored. Deterministic, no LLM.
+ */
+function gradeJustificationsForPackage(
+  pkg: QuestionPackage,
+  studentTopology: TopologyJSON,
+  answers: readonly JustificationAnswer[]
+): JustificationResult[] | undefined {
+  if (!pkg.justify || pkg.justify.length === 0) {
+    return undefined
+  }
+  const ctx = buildJustificationContext(studentTopology, collectScaleNumbers(pkg))
+  const answerById = new Map(answers.map((answer) => [answer.promptId, answer]))
+  return pkg.justify.map((prompt) => gradeJustification(prompt, answerById.get(prompt.id), ctx))
+}
+
 export function gradeAttemptWithArtifacts(
   pkg: QuestionPackage,
   studentTopology: TopologyJSON,
-  runTopology: (topology: TopologyJSON) => SimulationOutput
+  runTopology: (topology: TopologyJSON) => SimulationOutput,
+  justificationAnswers: readonly JustificationAnswer[] = []
 ): GradedAttempt {
   const structural =
     pkg.structuralRules && pkg.structuralRules.length > 0
@@ -1414,12 +1533,24 @@ export function gradeAttemptWithArtifacts(
 
   const batch = evaluateSuite(preparedCases, capturingRun, pkg.suite.name)
   const graded = gradeQuestionBatch(pkg.rubric, studentTopology, batch)
-  const semantic = evaluateSemanticCriteriaForPackage(pkg, studentTopology)
+  // Grade justifications first; a passed justification defends a `forbidUnjustified`
+  // component via the injected SemanticContext (the anti-cargo-cult unblock).
+  const justification = gradeJustificationsForPackage(pkg, studentTopology, justificationAnswers)
+  const passedByJustifyId = new Map(
+    (justification ?? []).map((result) => [result.promptId, result.outcome === 'passed'])
+  )
+  const semanticCtx: SemanticContext = justification
+    ? { justificationPassed: (id) => passedByJustifyId.get(id) }
+    : {}
+  const semantic = evaluateSemanticCriteriaForPackage(pkg, studentTopology, semanticCtx)
+  const budget = pkg.budget ? evaluateBudget(studentTopology, pkg.budget) : undefined
   const grade: AttemptGrade = {
     structural,
     ...(semantic ? { semantic } : {}),
+    ...(justification ? { justification } : {}),
+    ...(budget ? { budget } : {}),
     graded,
-    contract: toHostContract(structural, graded, semantic)
+    contract: toHostContract(structural, graded, semantic, justification, budget)
   }
 
   const verdictByCaseId = new Map<string, SimulationVerdict>()
@@ -1454,7 +1585,8 @@ export function gradeAttemptWithArtifacts(
 export function gradeAttempt(
   pkg: QuestionPackage,
   studentTopology: TopologyJSON,
-  runTopology: (topology: TopologyJSON) => SimulationOutput
+  runTopology: (topology: TopologyJSON) => SimulationOutput,
+  justificationAnswers: readonly JustificationAnswer[] = []
 ): AttemptGrade {
-  return gradeAttemptWithArtifacts(pkg, studentTopology, runTopology).grade
+  return gradeAttemptWithArtifacts(pkg, studentTopology, runTopology, justificationAnswers).grade
 }

--- a/src/engine/worker/protocols.ts
+++ b/src/engine/worker/protocols.ts
@@ -2,6 +2,7 @@ import type { TopologyJSON } from '../core/types'
 import type { EdgeFlowEvent } from '../core/events'
 import type { SimulationOutput, TimeSeriesSnapshot } from '../analysis/output'
 import type { AttemptCaseRun, AttemptGrade, QuestionPackage } from '../analysis/question'
+import type { JustificationAnswer } from '../analysis/justification'
 
 // ─── Inbound (main thread → worker) ──────────────────────────────────────────
 
@@ -13,7 +14,11 @@ export interface RunMessage {
 /** Grade a student topology against a question package (runs the whole suite). */
 export interface GradeMessage {
   type: 'grade'
-  payload: { question: QuestionPackage; topology: TopologyJSON }
+  payload: {
+    question: QuestionPackage
+    topology: TopologyJSON
+    justificationAnswers?: JustificationAnswer[]
+  }
 }
 
 export interface PauseMessage {

--- a/src/engine/worker/simulation.worker.ts
+++ b/src/engine/worker/simulation.worker.ts
@@ -211,7 +211,8 @@ self.onmessage = (event: MessageEvent<WorkerInboundMessage>) => {
         const { grade, cases } = gradeAttemptWithArtifacts(
           msg.payload.question,
           msg.payload.topology,
-          (topology) => new SimulationEngine(topology).run()
+          (topology) => new SimulationEngine(topology).run(),
+          msg.payload.justificationAnswers ?? []
         )
         post({ type: 'grade-complete', payload: { grade, cases } })
       } catch (err) {

--- a/src/renderer/src/components/layout/WorkspaceLayout.tsx
+++ b/src/renderer/src/components/layout/WorkspaceLayout.tsx
@@ -336,6 +336,9 @@ export const WorkspaceLayout = () => {
   const attemptState = useStore((s) => s.attemptState)
   const environmentProfile = useStore((s) => s.environmentProfile)
   const setActiveQuestion = useStore((s) => s.setActiveQuestion)
+  const clearJustificationAnswers = useStore((s) => s.clearJustificationAnswers)
+  const questionLoadRequest = useStore((s) => s.questionLoadRequest)
+  const clearQuestionLoadRequest = useStore((s) => s.clearQuestionLoadRequest)
   const setAttemptState = useStore((s) => s.setAttemptState)
   const setEnvironmentProfile = useStore((s) => s.setEnvironmentProfile)
   const setResultsRevealed = useStore((s) => s.setResultsRevealed)
@@ -501,8 +504,10 @@ export const WorkspaceLayout = () => {
           ? createAttemptState({ questionId: questionPackage.id, topology: topologyToLoad })
           : null)
       setAttemptState(options.readOnly && baseAttempt ? lockAttempt(baseAttempt) : baseAttempt)
+      clearJustificationAnswers()
     },
     [
+      clearJustificationAnswers,
       clearSimulationMetrics,
       loadFromData,
       selectGraphElements,
@@ -514,6 +519,16 @@ export const WorkspaceLayout = () => {
       setIsLeftOpen
     ]
   )
+
+  // Local/dev question load (no iframe host): consume a requested package through
+  // the same loader the host launch uses.
+  useEffect(() => {
+    if (!questionLoadRequest) {
+      return
+    }
+    void loadQuestionIntoWorkspace(questionLoadRequest, undefined)
+    clearQuestionLoadRequest()
+  }, [questionLoadRequest, loadQuestionIntoWorkspace, clearQuestionLoadRequest])
 
   useEffect(() => {
     const onMessage = (event: MessageEvent<unknown>) => {
@@ -632,7 +647,8 @@ export const WorkspaceLayout = () => {
           activeQuestion,
           { ...attemptState, topology, lastSavedAt: now },
           result,
-          now
+          now,
+          useStore.getState().justificationAnswers
         )
       )
     }, 4000)

--- a/src/renderer/src/components/question/QuestionPanel.tsx
+++ b/src/renderer/src/components/question/QuestionPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import useStore from '@renderer/store/useStore'
 import { useTopologySerializer } from '@renderer/hooks/useTopologySerializer'
 import { useQuestionGrader } from '@renderer/hooks/useQuestionGrader'
@@ -11,6 +11,11 @@ import {
   buildGamePlaygroundSubmitPayload
 } from '../../../../engine/analysis/gamePlayground'
 import { buildNewtonSaveBlob } from '../../../../engine/analysis/newtonGamePlayground'
+import {
+  buildJustificationContext,
+  gradeJustification,
+  type JustificationResult
+} from '../../../../engine/analysis/justification'
 import { buildQuestionEvaluationContract } from '../../../../engine/analysis/evaluationContract'
 import { buildEvaluationEnvelope } from '../../../../engine/analysis/evaluationEnvelope'
 import {
@@ -23,6 +28,7 @@ import {
   createAttemptState,
   isAttemptCurrentForTopology,
   markAttemptGrading,
+  parseQuestionPackage,
   recordDryRunGrade,
   recordSubmittedGrade,
   resolveVisibleAttemptGrade,
@@ -91,6 +97,12 @@ export const QuestionPanel = () => {
   const setActiveQuestion = useStore((s) => s.setActiveQuestion)
   const attemptState = useStore((s) => s.attemptState)
   const setAttemptState = useStore((s) => s.setAttemptState)
+  const justificationAnswers = useStore((s) => s.justificationAnswers)
+  const setJustificationAnswer = useStore((s) => s.setJustificationAnswer)
+  const requestQuestionLoad = useStore((s) => s.requestQuestionLoad)
+  const [questionLoadError, setQuestionLoadError] = useState<string | null>(null)
+  const nodes = useStore((s) => s.nodes)
+  const edges = useStore((s) => s.edges)
   const environmentProfile = useStore((s) => s.environmentProfile)
   const resultsRevealed = useStore((s) => s.resultsRevealed)
   const { serialize } = useTopologySerializer()
@@ -204,7 +216,15 @@ export const QuestionPanel = () => {
           // Newton Game Playground host: post a verbatim-persisted JSON blob with
           // the two score keys + carried-forward package (client-computed; the
           // backend does not re-grade).
-          postNewtonSave(buildNewtonSaveBlob(activeQuestion, completedAttempt, gameResult, now))
+          postNewtonSave(
+            buildNewtonSaveBlob(
+              activeQuestion,
+              completedAttempt,
+              gameResult,
+              now,
+              useStore.getState().justificationAnswers
+            )
+          )
         } else {
           postQuestionHostMessage({
             type: 'ns-simulator:submit',
@@ -232,9 +252,40 @@ export const QuestionPanel = () => {
     setAttemptState
   ])
 
+  // Live, deterministic feedback on justification prompts — graded against the
+  // current graph (graph-consistency), no LLM. Re-derives when the graph or an
+  // answer changes. Declared before the early return to satisfy rules-of-hooks.
+  const justifyGrades = useMemo<Record<string, JustificationResult>>(() => {
+    const prompts = activeQuestion?.justify ?? []
+    if (prompts.length === 0) {
+      return {}
+    }
+    const { topology } = serialize()
+    if (!topology) {
+      return {}
+    }
+    const scaleNumbers: number[] = [
+      ...Object.values(activeQuestion!.prompt.scale).filter(
+        (v): v is number => typeof v === 'number'
+      ),
+      ...activeQuestion!.prompt.nonFunctionalRequirements.map((nfr) => nfr.value)
+    ]
+    const ctx = buildJustificationContext(topology, scaleNumbers)
+    const out: Record<string, JustificationResult> = {}
+    for (const prompt of prompts) {
+      out[prompt.id] = gradeJustification(
+        prompt,
+        { promptId: prompt.id, text: justificationAnswers[prompt.id] ?? '' },
+        ctx
+      )
+    }
+    return out
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeQuestion, justificationAnswers, nodes, edges])
+
   if (!activeQuestion) {
     return (
-      <section className="flex h-full min-h-0 flex-col">
+      <section className="flex min-h-0 flex-col">
         <div className="border-b border-nss-border p-4 pb-3">
           <h2 className="text-xs font-bold uppercase tracking-widest text-nss-muted">
             Question Text
@@ -246,8 +297,8 @@ export const QuestionPanel = () => {
           </p>
         </div>
 
-        <div className="flex flex-1 items-center p-3">
-          <div className="w-full rounded-lg border border-dashed border-nss-border bg-nss-surface p-4">
+        <div className="flex flex-1 items-center">
+          <div className="w-full rounded-lg p-4">
             <p className="text-xs font-semibold text-nss-text">No question loaded</p>
             <p className="mt-1 text-[11px] leading-relaxed text-nss-muted">
               {isEmbedded
@@ -255,16 +306,48 @@ export const QuestionPanel = () => {
                 : 'This tab now hosts the question brief, rubric checks, and Test/Submit flow.'}
             </p>
             {!isEmbedded && (
-              <button
-                type="button"
-                onClick={() => {
-                  setAttemptState(null)
-                  setActiveQuestion(SAMPLE_QUESTION)
-                }}
-                className="mt-4 w-full rounded-md bg-nss-primary px-3 py-2 text-xs font-semibold text-white hover:bg-nss-primary-hover"
-              >
-                Load sample question
-              </button>
+              <div className="mt-4 space-y-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setAttemptState(null)
+                    setActiveQuestion(SAMPLE_QUESTION)
+                  }}
+                  className="w-full rounded-md bg-nss-primary px-3 py-2 text-xs font-semibold text-white hover:bg-nss-primary-hover"
+                >
+                  Load sample question
+                </button>
+                <label className="block w-full cursor-pointer rounded-md border border-nss-border bg-nss-surface px-3 py-2 text-center text-xs font-semibold text-nss-text hover:border-nss-primary">
+                  Load question (.json)…
+                  <input
+                    type="file"
+                    accept="application/json,.json"
+                    className="hidden"
+                    onChange={(event) => {
+                      const file = event.target.files?.[0]
+                      event.target.value = ''
+                      if (!file) return
+                      const reader = new FileReader()
+                      reader.onload = () => {
+                        try {
+                          const pkg = parseQuestionPackage(JSON.parse(String(reader.result)))
+                          setQuestionLoadError(null)
+                          requestQuestionLoad(pkg)
+                        } catch (error) {
+                          setQuestionLoadError((error as Error).message.split('\n')[0])
+                        }
+                      }
+                      reader.readAsText(file)
+                    }}
+                  />
+                </label>
+                <p className="text-center text-[10px] text-nss-muted">
+                  Paste any bank QuestionPackage JSON into a file and load it — no host needed.
+                </p>
+                {questionLoadError && (
+                  <p className="text-[10px] leading-snug text-red-500">{questionLoadError}</p>
+                )}
+              </div>
             )}
           </div>
         </div>
@@ -293,7 +376,11 @@ export const QuestionPanel = () => {
       })
     )
     setPendingRun({ kind, topology })
-    gradeQuestion(question, topology)
+    gradeQuestion(
+      question,
+      topology,
+      Object.entries(justificationAnswers).map(([promptId, text]) => ({ promptId, text }))
+    )
   }
 
   const onSubmit = () => runGrade(activeQuestion, 'submit')
@@ -429,6 +516,13 @@ export const QuestionPanel = () => {
 
         {effectivePanelView === 'brief' ? (
           <>
+            <div className="rounded-md border border-nss-primary/20 bg-nss-primary/5 px-3 py-2 text-[11px] leading-relaxed text-nss-muted">
+              <span className="font-semibold text-nss-primary">Design the architecture.</span> Place
+              and connect components and size them — you are not writing application code. The
+              simulator grades the <em>shape</em> and <em>performance</em> of your system under the
+              question&rsquo;s load.
+            </div>
+
             <p className="text-xs leading-relaxed text-nss-text/90">{activeQuestion.prompt.text}</p>
 
             {activeQuestion.prompt.functionalRequirements.length > 0 && (
@@ -484,6 +578,62 @@ export const QuestionPanel = () => {
                 )}
               </div>
             </section>
+
+            {activeQuestion.justify && activeQuestion.justify.length > 0 && (
+              <section className="space-y-2">
+                <h3 className={SECTION_TITLE}>Justify your design</h3>
+                <p className="text-[11px] leading-relaxed text-nss-muted">
+                  Reference the component you actually placed, cite a number from the question, and
+                  state a tradeoff. Graded deterministically against your graph.
+                </p>
+                <div className="space-y-3">
+                  {activeQuestion.justify.map((prompt) => {
+                    const grade = justifyGrades[prompt.id]
+                    const badge =
+                      grade?.outcome === 'passed'
+                        ? { label: 'consistent', cls: 'text-green-500 border-green-500/30' }
+                        : grade?.outcome === 'partial'
+                          ? { label: 'partial', cls: 'text-yellow-500 border-yellow-500/30' }
+                          : grade?.outcome === 'failed'
+                            ? { label: 'not consistent', cls: 'text-red-500 border-red-500/30' }
+                            : null
+                    return (
+                      <div key={prompt.id} className="space-y-1">
+                        <div className="flex items-start justify-between gap-2">
+                          <label
+                            htmlFor={`justify-${prompt.id}`}
+                            className="text-[11px] font-medium text-nss-text"
+                          >
+                            {prompt.decision}
+                          </label>
+                          {showRubricResults && badge && (
+                            <span
+                              className={`shrink-0 rounded border px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide ${badge.cls}`}
+                            >
+                              {badge.label}
+                            </span>
+                          )}
+                        </div>
+                        <textarea
+                          id={`justify-${prompt.id}`}
+                          value={justificationAnswers[prompt.id] ?? ''}
+                          onChange={(event) =>
+                            setJustificationAnswer(prompt.id, event.target.value)
+                          }
+                          disabled={isAttemptLocked}
+                          rows={2}
+                          placeholder="e.g. I used a KV store — it handles 200K reads/sec, but we lose ad-hoc joins."
+                          className="w-full resize-y rounded-md border border-nss-border bg-nss-input-bg px-2 py-1.5 text-[11px] text-nss-text placeholder:text-nss-muted/70 outline-none focus:border-nss-primary transition-colors disabled:opacity-60"
+                        />
+                        {showRubricResults && grade?.detail && grade.outcome !== 'passed' && (
+                          <p className="text-[10px] leading-snug text-nss-muted">{grade.detail}</p>
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
+              </section>
+            )}
 
             {showSuiteDetails && (
               <section className="space-y-2">

--- a/src/renderer/src/hooks/useQuestionGrader.ts
+++ b/src/renderer/src/hooks/useQuestionGrader.ts
@@ -5,6 +5,7 @@ import type {
   AttemptGrade,
   QuestionPackage
 } from '../../../engine/analysis/question'
+import type { JustificationAnswer } from '../../../engine/analysis/justification'
 import type { WorkerInboundMessage, WorkerOutboundMessage } from '../../../engine/worker/protocols'
 
 export type GraderStatus = 'idle' | 'grading' | 'graded' | 'error'
@@ -16,7 +17,11 @@ export interface QuestionGraderState {
   runs: AttemptCaseRun[] | null
   error: string | null
   /** Grade a student topology against a question package (runs the suite off-thread). */
-  grade_: (question: QuestionPackage, topology: TopologyJSON) => void
+  grade_: (
+    question: QuestionPackage,
+    topology: TopologyJSON,
+    justificationAnswers?: JustificationAnswer[]
+  ) => void
   reset: () => void
 }
 
@@ -38,45 +43,52 @@ export function useQuestionGrader(): QuestionGraderState {
     }
   }, [])
 
-  const gradeAttempt = useCallback((question: QuestionPackage, topology: TopologyJSON) => {
-    workerRef.current?.terminate()
-    const worker = new Worker(
-      new URL('../../../engine/worker/simulation.worker.ts', import.meta.url),
-      { type: 'module' }
-    )
-    workerRef.current = worker
+  const gradeAttempt = useCallback(
+    (
+      question: QuestionPackage,
+      topology: TopologyJSON,
+      justificationAnswers: JustificationAnswer[] = []
+    ) => {
+      workerRef.current?.terminate()
+      const worker = new Worker(
+        new URL('../../../engine/worker/simulation.worker.ts', import.meta.url),
+        { type: 'module' }
+      )
+      workerRef.current = worker
 
-    worker.onmessage = (event: MessageEvent<WorkerOutboundMessage>) => {
-      const msg = event.data
-      if (msg.type === 'grade-complete') {
-        setGrade(msg.payload.grade)
-        setRuns(msg.payload.cases)
-        setStatus('graded')
-        worker.terminate()
-        workerRef.current = null
-      } else if (msg.type === 'error') {
-        setError(msg.payload.message)
+      worker.onmessage = (event: MessageEvent<WorkerOutboundMessage>) => {
+        const msg = event.data
+        if (msg.type === 'grade-complete') {
+          setGrade(msg.payload.grade)
+          setRuns(msg.payload.cases)
+          setStatus('graded')
+          worker.terminate()
+          workerRef.current = null
+        } else if (msg.type === 'error') {
+          setError(msg.payload.message)
+          setStatus('error')
+          worker.terminate()
+          workerRef.current = null
+        }
+      }
+      worker.onerror = (err) => {
+        setError(err.message ?? 'Unknown grader error')
         setStatus('error')
         worker.terminate()
         workerRef.current = null
       }
-    }
-    worker.onerror = (err) => {
-      setError(err.message ?? 'Unknown grader error')
-      setStatus('error')
-      worker.terminate()
-      workerRef.current = null
-    }
 
-    setStatus('grading')
-    setGrade(null)
-    setRuns(null)
-    setError(null)
-    worker.postMessage({
-      type: 'grade',
-      payload: { question, topology }
-    } satisfies WorkerInboundMessage)
-  }, [])
+      setStatus('grading')
+      setGrade(null)
+      setRuns(null)
+      setError(null)
+      worker.postMessage({
+        type: 'grade',
+        payload: { question, topology, justificationAnswers }
+      } satisfies WorkerInboundMessage)
+    },
+    []
+  )
 
   const reset = useCallback(() => {
     workerRef.current?.terminate()

--- a/src/renderer/src/store/useStore.ts
+++ b/src/renderer/src/store/useStore.ts
@@ -292,6 +292,15 @@ type RFState = {
   scaffoldNodeIds: string[]
   attemptState: AttemptState | null
   setAttemptState: (attempt: AttemptState | null) => void
+  /** The student's free-text answers to the active question's justify prompts, by prompt id. */
+  justificationAnswers: Record<string, string>
+  setJustificationAnswer: (promptId: string, text: string) => void
+  clearJustificationAnswers: () => void
+  /** Local/dev question load: a package to load through the full workspace loader (canvas reset +
+   * scaffold), consumed by WorkspaceLayout. Lets authors load questions without an iframe host. */
+  questionLoadRequest: QuestionPackage | null
+  requestQuestionLoad: (question: QuestionPackage) => void
+  clearQuestionLoadRequest: () => void
   /** The resolved presentation profile (visibility + capabilities) for question mode. */
   environmentProfile: EnvironmentProfile
   setEnvironmentProfile: (profile: EnvironmentProfile) => void
@@ -354,6 +363,8 @@ const useStore = create<RFState>((set, get) => ({
   activeQuestion: null,
   scaffoldNodeIds: [],
   attemptState: null,
+  justificationAnswers: {},
+  questionLoadRequest: null,
   environmentProfile: DEFAULT_ENVIRONMENT_PROFILE,
   resultsRevealed: false,
   viewportFitVersion: 0,
@@ -644,6 +655,13 @@ const useStore = create<RFState>((set, get) => ({
           : []
     }),
   setAttemptState: (attemptState) => set({ attemptState }),
+  setJustificationAnswer: (promptId, text) =>
+    set((state) => ({
+      justificationAnswers: { ...state.justificationAnswers, [promptId]: text }
+    })),
+  clearJustificationAnswers: () => set({ justificationAnswers: {} }),
+  requestQuestionLoad: (questionLoadRequest) => set({ questionLoadRequest }),
+  clearQuestionLoadRequest: () => set({ questionLoadRequest: null }),
   setEnvironmentProfile: (environmentProfile) => set({ environmentProfile }),
   setResultsRevealed: (resultsRevealed) => set({ resultsRevealed }),
   requestViewportFit: () =>


### PR DESCRIPTION
## Overview
This PR introduces three core features to the grading and analysis engine:
1. **Deterministic Justification Evaluation:** Student rationale answers are graded graph-consistently to enforce architectural decisions without requiring an LLM.
2. **Budget Evaluation Axis:** Enforces node count, edge count, and capacity cost caps on topologies to prevent over-provisioned / "kitchen-sink" architectures.
3. **Phase-1 Authoring Validator:** Pre-flight validation for question packages to catch configuration mistakes (e.g., bad metric keys, orphan NFRs, display-only scale numbers) during question authoring.

---

## Key Changes

### Engine & Analysis
* **Authoring Validator (`src/engine/analysis/authoringValidator.ts`)**: Added a validation pipeline to detect metric key typos (e.g., `summary.latencyP99Ms` vs `summary.latency.p99`), un-injected scale numbers, dangling `justifyId` references, and orphan NFR checks.
* **Budget Engine (`src/engine/analysis/budget.ts`)**: Implemented `evaluateBudget()` supporting `nodes`, `edges`, and a capacity `cost` heuristic (`1 + replicas + Math.ceil(workers / 50)`) to penalize over-provisioning.
* **Justification Pipeline (`src/engine/analysis/justification.ts` & `question.ts`)**: Integrated student justification answers into the full grading pipeline. Linked passed justifications to defend components constrained by `forbidUnjustified` rules.
* **Worker & Save State (`protocols.ts`, `simulation.worker.ts`, `newtonGamePlayground.ts`)**: Updated worker protocols to pass `justificationAnswers` through the background grader and persist answers inside `NewtonSaveBlob`.

### Renderer & UI
* **Question Panel (`QuestionPanel.tsx`)**: 
  * Added free-text decision justification inputs with live graph-consistency status badges (`consistent`, `partial`, `not consistent`).
  * Added a local file picker (`.json`) allowing authors to test question packages directly in local/dev mode without requiring an iframe host.
* **State Management (`useStore.ts` & `WorkspaceLayout.tsx`)**: Managed `justificationAnswers` and `questionLoadRequest` lifecycle across canvas resets and attempt state updates.

---

## Testing

Added comprehensive unit test suites in `vitest`:
- [x] `authoringValidator.test.ts`: Verifies diagnostics for invalid metric keys, orphan NFRs, missing `sizeBytes`, and dangling justification bindings.
- [x] `budget.test.ts`: Tests node/edge counts and capacity cost heuristic over-provisioning penalties.
- [x] `justification.test.ts` & `question.test.ts`: Verifies graph-bound alias resolution and justification pass/fail flow against `forbidUnjustified`.